### PR TITLE
Add cluster name override support and fix tolerations handling

### DIFF
--- a/otel-collector/otel-operator/README.md
+++ b/otel-collector/otel-operator/README.md
@@ -65,7 +65,45 @@ chmod +x last9-otel-setup.sh
 
 ---
 
-## 🎯 Advanced (Optional): Kubernetes Tolerations and NodeSelector
+## 🎯 Advanced Configuration (Optional)
+
+### Cluster Name Override
+
+By default, the cluster name is auto-detected from your kubectl current context. You can override it using the `cluster=` parameter:
+
+```bash
+# Set custom cluster name
+./last9-otel-setup.sh \
+  token="your-token" \
+  endpoint="your-endpoint" \
+  cluster=prod-us-east-1
+
+# Combined with environment
+./last9-otel-setup.sh \
+  token="your-token" \
+  endpoint="your-endpoint" \
+  env=production \
+  cluster=prod-us-east-1
+
+# Full setup with cluster name
+./last9-otel-setup.sh \
+  token="your-token" \
+  endpoint="your-endpoint" \
+  monitoring-endpoint="your-metrics-endpoint" \
+  username="your-username" \
+  password="your-password" \
+  env=production \
+  cluster=my-k8s-cluster
+```
+
+**Why override cluster name?**
+- When kubectl context name doesn't match your preferred cluster identifier
+- For consistent naming across multiple environments
+- When auto-detection doesn't provide meaningful names
+
+---
+
+### Kubernetes Tolerations and NodeSelector
 
 If your nodes **ARE tainted**, you need both tolerations and nodeSelector:
 


### PR DESCRIPTION
- Add cluster= parameter support for custom cluster name override
- Auto-detect cluster name from kubectl context if not provided
- Document cluster name override in README Advanced Configuration section
- Fix yq lexer error by removing apply_tolerations_to_monitoring_values for monitoring stack
- Use kubectl patch method for applying tolerations (more reliable than Helm values)
- Add nodeSelector support for monitoring components
- Add special nodeExporterTolerations field for DaemonSet tolerations
- Patch Prometheus Operator Deployment with tolerations and nodeSelector
- Update help documentation with cluster parameter examples

🤖 Generated with [Claude Code]