### PR TITLE
Add tolerations-file validation, kube-operator patching, and cleanup fix

### DIFF
--- a/otel-collector/otel-operator/README.md
+++ b/otel-collector/otel-operator/README.md
@@ -122,14 +122,37 @@ nodeExporterTolerations:
   - operator: "Exists"
 ```
 
+**Components that receive tolerations and nodeSelector:**
+- OpenTelemetry Operator
+- OpenTelemetry Collector (DaemonSet)
+- Prometheus Agent
+- Kube-State-Metrics
+- Prometheus Operator
+- Kube-Operator
+
+**Note:** node-exporter DaemonSet only receives `nodeExporterTolerations` (no nodeSelector) to ensure it runs on ALL nodes for complete metrics collection.
+
 **Usage:**
 ```bash
-
-# Run installation (same command as above)
+# IMPORTANT: tolerations-file must be an absolute path
 ./last9-otel-setup.sh \
-  tolerations-file=tolerations.yaml \
+  tolerations-file=/absolute/path/to/tolerations.yaml \
+  token="your-token" \
+  endpoint="your-endpoint" \
+  monitoring-endpoint="your-metrics-endpoint" \
+  username="your-username" \
+  password="your-password"
+
+# Example with full path
+./last9-otel-setup.sh \
+  tolerations-file=/home/user/k8s/tolerations.yaml \
   token="your-token" ...
 ```
+
+**Path Requirements:**
+- ✅ Must be an absolute path (starts with `/`)
+- ✅ File must exist and be readable
+- ❌ Relative paths (e.g., `./tolerations.yaml`) are not supported
 
 ---
 

--- a/otel-collector/otel-operator/examples/tolerations-monitoring-nodes.yaml
+++ b/otel-collector/otel-operator/examples/tolerations-monitoring-nodes.yaml
@@ -7,7 +7,7 @@
 #   ./last9-otel-setup.sh tolerations-file=examples/tolerations-monitoring-nodes.yaml \
 #     token="xxx" endpoint="xxx" monitoring-endpoint="xxx" username="xxx" password="xxx"
 
-# Applied to: Operator, Collector, Prometheus, Kube-State-Metrics, Prometheus Operator
+# Applied to: Operator, Collector, Prometheus, Kube-State-Metrics, Prometheus Operator, Kube-Operator
 tolerations:
   - key: "monitoring"
     operator: "Equal"


### PR DESCRIPTION
- Add comprehensive validation for tolerations-file parameter
  * Verify path is not empty
  * Check path is absolute (starts with /)
  * Validate file exists and is readable
  * Provide helpful error messages and examples
- Add tolerations/nodeSelector patching for last9-k8s-monitoring-kube-operator deployment
  * Previously missing from patching logic
  * Now receives same treatment as other monitoring components
- Fix cleanup function to properly remove otel-setup-* directories
  * Save original directory at script start (ORIGINAL_DIR)
  * Return to correct directory during cleanup
  * Add existence check before attempting deletion
- Update README.md Advanced Configuration section
  * Document all components that receive tolerations/nodeSelector
  * Add path requirements for tolerations-file parameter
  * Include clear usage examples with absolute paths
  * Explain node-exporter behavior (tolerations only, no nodeSelector)
- Update example files to include kube-operator in component list

