### PR TITLE
feat: Add AWS ECS Fargate large logs example with Last9 integration

### DIFF
--- a/aws/ecs-fargate/nodejs-express-large-logs/.env.example
+++ b/aws/ecs-fargate/nodejs-express-large-logs/.env.example
@@ -1,0 +1,14 @@
+# Application Configuration
+PORT=3000
+NODE_ENV=production
+
+# AWS Configuration (for ECS deployment)
+AWS_REGION=us-east-1
+AWS_ACCOUNT_ID=<your-aws-account-id>
+ECR_REPOSITORY=<your-ecr-repository-name>
+
+# ECS Configuration
+ECS_CLUSTER=<your-ecs-cluster-name>
+ECS_SERVICE=<your-ecs-service-name>
+EXECUTION_ROLE_ARN=<your-execution-role-arn>
+TASK_ROLE_ARN=<your-task-role-arn>

--- a/aws/ecs-fargate/nodejs-express-large-logs/.gitignore
+++ b/aws/ecs-fargate/nodejs-express-large-logs/.gitignore
@@ -1,0 +1,29 @@
+# Environment/secrets
+.env
+.env.local
+.env.*.local
+
+# Dependencies
+/node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+logs/
+
+# Build artifacts
+/dist/
+/build/

--- a/aws/ecs-fargate/nodejs-express-large-logs/Dockerfile
+++ b/aws/ecs-fargate/nodejs-express-large-logs/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci --only=production
+
+# Copy application code
+COPY index.js ./
+
+# Expose port
+EXPOSE 3000
+
+# Run the application
+CMD ["node", "index.js"]

--- a/aws/ecs-fargate/nodejs-express-large-logs/Dockerfile.fluentbit
+++ b/aws/ecs-fargate/nodejs-express-large-logs/Dockerfile.fluentbit
@@ -1,0 +1,4 @@
+FROM amazon/aws-for-fluent-bit:latest
+
+# Copy custom Fluent Bit configuration
+COPY extra.conf /fluent-bit/etc/extra.conf

--- a/aws/ecs-fargate/nodejs-express-large-logs/README.md
+++ b/aws/ecs-fargate/nodejs-express-large-logs/README.md
@@ -1,0 +1,366 @@
+# Handling Large Logs in AWS ECS Fargate with Last9
+
+This example demonstrates how to handle large logs (>100KB) in AWS ECS Fargate and forward them to Last9 using OpenTelemetry, solving the AWS Fargate 16KB log buffer limitation.
+
+## Table of Contents
+
+- [The Problem](#the-problem)
+- [The Solution](#the-solution)
+- [Architecture](#architecture)
+- [Prerequisites](#prerequisites)
+- [Integration Steps](#integration-steps)
+- [Configuration Reference](#configuration-reference)
+- [Verification](#verification)
+- [Troubleshooting](#troubleshooting)
+
+## The Problem
+
+AWS Fargate has a **fixed 16KB runtime buffer limit** for container stdout/stderr. When your application writes logs larger than 16KB:
+
+1. Docker runtime **splits the log** into multiple chunks (16KB each)
+2. Each chunk gets metadata: `partial_message`, `partial_id`, `partial_ordinal`, `partial_last`
+3. Without reassembly, these appear as **separate incomplete log entries** in your observability platform
+4. JSON parsing fails on partial chunks, breaking log analysis
+
+**The 16KB limit cannot be increased** - it's a hard AWS Fargate limitation.
+
+## The Solution
+
+Use **AWS FireLens (Fluent Bit)** with a multiline filter to reassemble split logs before forwarding to OpenTelemetry Collector:
+
+1. Fluent Bit captures log chunks with Docker metadata
+2. Multiline filter detects `partial_message=true` and groups chunks by `partial_id`
+3. Chunks are concatenated in order until `partial_last=true`
+4. Complete log is forwarded to OTEL Collector
+5. OTEL Collector exports to Last9 with full log intact
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    ECS Fargate Task                     │
+│                                                         │
+│  ┌──────────┐    ┌──────────────┐    ┌──────────────┐ │
+│  │   Your   │───▶│ log-router   │───▶│    otel-     │ │
+│  │   App    │    │ (Fluent Bit) │    │  collector   │ │
+│  │          │    │   Multiline  │    │              │ │
+│  │  Writes  │    │    Filter    │    │  Metrics +   │ │
+│  │ >100KB   │    │  Reassembles │    │    Logs      │ │
+│  │  logs    │    │  split logs  │    │              │ │
+│  └──────────┘    └──────────────┘    └──────────────┘ │
+│                                              │          │
+└──────────────────────────────────────────────┼──────────┘
+                                               │
+                                               │ OTLP/HTTPS
+                                               ▼
+                                       ┌──────────────┐
+                                       │    Last9     │
+                                       └──────────────┘
+```
+
+**Data Flow:**
+1. **Your App** → Writes large JSON logs to stdout
+2. **log-router** → Fluent Bit reassembles split logs using multiline filter
+3. **otel-collector** → Receives complete logs + collects ECS metrics
+4. **Last9** → Receives complete, parseable logs and metrics
+
+## Prerequisites
+
+- Existing ECS Fargate cluster with running application
+- AWS CLI configured
+- Docker installed locally
+- Last9 account with OTLP credentials
+- Basic knowledge of ECS task definitions
+
+## Integration Steps
+
+### Step 1: Create Custom Fluent Bit Image
+
+Create a file named `extra.conf`:
+
+```ini
+[FILTER]
+    Name                multiline
+    Match               *-firelens-*
+    multiline.key_content log
+    mode                partial_message
+```
+
+Create `Dockerfile.fluentbit`:
+
+```dockerfile
+FROM amazon/aws-for-fluent-bit:latest
+
+# Copy custom Fluent Bit configuration
+COPY extra.conf /fluent-bit/etc/extra.conf
+```
+
+Build and push to ECR:
+
+```bash
+# Set variables
+export AWS_REGION=<your-region>
+export AWS_ACCOUNT_ID=<your-account-id>
+export ECR_REPO_FLUENTBIT=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/your-app-fluentbit
+
+# Authenticate to ECR
+aws ecr get-login-password --region $AWS_REGION | \
+  docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
+
+# Create repository
+aws ecr create-repository --repository-name your-app-fluentbit --region $AWS_REGION
+
+# Build and push
+docker build --platform linux/amd64 -f Dockerfile.fluentbit -t ${ECR_REPO_FLUENTBIT}:latest .
+docker push ${ECR_REPO_FLUENTBIT}:latest
+```
+
+### Step 2: Get Last9 Credentials
+
+1. Log into your Last9 dashboard
+2. Navigate to Settings → Integrations → OTLP
+3. Copy your OTLP endpoint (e.g., `YOUR_OTLP_ENDPOINT`)
+4. Copy your credentials (username and password)
+5. Encode credentials:
+
+```bash
+echo -n "your-username:your-password" | base64
+# Output: <base64-encoded-credentials>
+```
+
+### Step 3: Create OTEL Collector Configuration
+
+Create `otel-config.yaml`:
+
+```yaml
+receivers:
+  # Collect ECS container metrics
+  awsecscontainermetrics:
+    collection_interval: 60s
+
+  # Receive logs from Fluent Bit
+  fluentforward:
+    endpoint: 0.0.0.0:8006
+
+  # Accept OTLP (optional, for traces)
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  # Transform ECS metrics to add resource attributes
+  transform/ecsmetrics:
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(attributes["aws.ecs.cluster.name"], resource.attributes["aws.ecs.cluster.name"])
+          - set(attributes["aws.ecs.task.family"], resource.attributes["aws.ecs.task.family"])
+          - set(attributes["aws.ecs.task.arn"], resource.attributes["aws.ecs.task.arn"])
+          - set(attributes["cloud.region"], resource.attributes["cloud.region"])
+          - set(attributes["container.name"], resource.attributes["container.name"])
+
+  # Transform logs from Fluent Bit
+  transform/firelens:
+    error_mode: ignore
+    log_statements:
+      - context: log
+        statements:
+          # Set resource attributes from Fluent Bit metadata
+          - set(resource.attributes["container_name"], attributes["container_name"]) where attributes["container_name"] != nil
+          - set(resource.attributes["container_id"], attributes["container_id"]) where attributes["container_id"] != nil
+          - set(resource.attributes["service.name"], attributes["container_name"]) where attributes["container_name"] != nil
+
+          # Clean up metadata
+          - delete_key(attributes, "container_id")
+          - delete_key(attributes, "container_name")
+
+  # Batch for efficient export
+  batch:
+    send_batch_max_size: 1000
+    send_batch_size: 1000
+    timeout: 10s
+
+  # Detect ECS resource attributes
+  resourcedetection:
+    detectors: [ecs]
+
+exporters:
+  otlp/last9:
+    endpoint: "<YOUR_LAST9_OTLP_ENDPOINT>"
+    headers:
+      "Authorization": "Basic <YOUR_BASE64_CREDENTIALS>"
+    sending_queue:
+      enabled: true
+      num_consumers: 10
+      queue_size: 5000
+
+service:
+  pipelines:
+    metrics:
+      receivers: [awsecscontainermetrics]
+      processors: [batch, resourcedetection, transform/ecsmetrics]
+      exporters: [otlp/last9]
+
+    logs:
+      receivers: [fluentforward]
+      processors: [transform/firelens, batch, resourcedetection]
+      exporters: [otlp/last9]
+```
+
+**Replace placeholders:**
+- `<YOUR_LAST9_OTLP_ENDPOINT>` - Your Last9 OTLP endpoint
+- `<YOUR_BASE64_CREDENTIALS>` - Your base64-encoded credentials from Step 2
+
+### (Optional) Step 4: Create CloudWatch Log Groups
+
+```bash
+aws logs create-log-group --log-group-name /ecs/log-router --region $AWS_REGION
+aws logs create-log-group --log-group-name /ecs/otel-collector --region $AWS_REGION
+```
+
+### Step 5: Update Task Definition
+
+Update your existing task definition JSON to add two new containers and modify your app container's logging configuration.
+
+**Add to `containerDefinitions` array:**
+
+```json
+{
+  "containerDefinitions": [
+    {
+      "name": "your-app",
+      "image": "<your-app-image>",
+      "essential": true,
+      "logConfiguration": {
+        "logDriver": "awsfirelens",
+        "options": {
+          "Name": "forward",
+          "Host": "127.0.0.1",
+          "Port": "8006"
+        }
+      },
+      "dependsOn": [
+        {
+          "containerName": "log-router",
+          "condition": "START"
+        },
+        {
+          "containerName": "otel-collector",
+          "condition": "START"
+        }
+      ]
+    },
+    {
+      "name": "log-router",
+      "image": "<your-account-id>.dkr.ecr.<region>.amazonaws.com/your-app-fluentbit:latest",
+      "essential": false,
+      "firelensConfiguration": {
+        "type": "fluentbit",
+        "options": {
+          "enable-ecs-log-metadata": "true",
+          "config-file-type": "file",
+          "config-file-value": "/fluent-bit/etc/extra.conf"
+        }
+      },
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/log-router",
+          "awslogs-region": "<your-region>",
+          "awslogs-stream-prefix": "firelens"
+        }
+      }
+    },
+    {
+      "name": "otel-collector",
+      "image": "otel/opentelemetry-collector-contrib:latest",
+      "essential": false,
+      "command": ["--config", "env:OTEL_CONFIG"],
+      "portMappings": [
+        {
+          "containerPort": 4317,
+          "protocol": "tcp",
+          "name": "otel-collector-4317-grpc"
+        },
+        {
+          "containerPort": 4318,
+          "protocol": "tcp",
+          "name": "otel-collector-4318-http"
+        }
+      ],
+      "environment": [
+        {
+          "name": "OTEL_CONFIG",
+          "value": "<paste-entire-otel-config.yaml-contents-here-as-string>"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/otel-collector",
+          "awslogs-region": "<your-region>",
+          "awslogs-stream-prefix": "otel"
+        }
+      }
+    }
+  ]
+}
+```
+
+**Key changes to your app container:**
+1. Change `logDriver` from `awslogs` to `awsfirelens`
+2. Configure forward output to port `8006`
+3. Add `dependsOn` to ensure log-router and otel-collector start first
+
+**To convert YAML to inline string for OTEL_CONFIG:**
+```bash
+# Read the file and create properly escaped JSON string
+cat otel-config.yaml | sed ':a;N;$!ba;s/\n/\\n/g' | sed 's/"/\\"/g'
+```
+
+Or copy the YAML content directly as shown in the example file `task-definition-with-otel.json`.
+
+### Step 6: Register and Deploy
+
+```bash
+# Register new task definition
+aws ecs register-task-definition --cli-input-json file://task-definition.json --region $AWS_REGION
+
+# Update your service to use new task definition
+aws ecs update-service \
+  --cluster <your-cluster-name> \
+  --service <your-service-name> \
+  --task-definition <your-task-family>:<new-revision> \
+  --force-new-deployment \
+  --region $AWS_REGION
+```
+
+## Configuration Reference
+
+### extra.conf - Fluent Bit Multiline Filter
+
+```ini
+[FILTER]
+    Name                multiline          # Use multiline filter plugin
+    Match               *-firelens-*       # Apply to all FireLens logs
+    multiline.key_content log              # Field containing log content
+    mode                partial_message    # Detect Docker partial markers
+```
+
+### Verify in Last9
+
+1. Log into Last9 dashboard
+2. Go to **Logs** section
+3. Filter by `service.name = "your-app"`
+4. Verify you see **complete logs**, not split chunks
+5. Check that large logs (>100KB) appear as single entries
+
+### Verify Metrics
+
+In Last9, navigate to **Metrics** and check for:
+- `container.cpu.usage`
+- `container.memory.usage`
+- Filter by `aws.ecs.cluster.name = "<your-cluster>"`

--- a/aws/ecs-fargate/nodejs-express-large-logs/extra.conf
+++ b/aws/ecs-fargate/nodejs-express-large-logs/extra.conf
@@ -1,0 +1,5 @@
+[FILTER]
+    Name                multiline
+    Match               *-firelens-*
+    multiline.key_content log
+    mode                partial_message

--- a/aws/ecs-fargate/nodejs-express-large-logs/index.js
+++ b/aws/ecs-fargate/nodejs-express-large-logs/index.js
@@ -1,0 +1,212 @@
+const express = require('express');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Helper function to generate a large nested context object (>30KB)
+function generateLargeContext() {
+  const largeContext = {
+    requestId: `req-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+    timestamp: new Date().toISOString(),
+    user: {
+      id: Math.floor(Math.random() * 100000),
+      name: `user_${Math.random().toString(36).substr(2, 9)}`,
+      email: `user${Math.random().toString(36).substr(2, 9)}@example.com`,
+      roles: ['admin', 'user', 'developer', 'tester'],
+      metadata: {
+        loginCount: Math.floor(Math.random() * 1000),
+        lastLogin: new Date().toISOString(),
+        preferences: {}
+      }
+    },
+    session: {
+      id: `session-${Math.random().toString(36).substr(2, 20)}`,
+      createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 3600000).toISOString()
+    },
+    // Generate a large array of data to exceed 30KB
+    dataRecords: [],
+    nestedStructure: {
+      level1: {
+        level2: {
+          level3: {
+            level4: {
+              level5: {
+                data: []
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+
+  // Add large amount of data to exceed 30KB
+  // Each record is approximately 200-300 bytes, so we need ~150-200 records to exceed 30KB
+  for (let i = 0; i < 200; i++) {
+    largeContext.dataRecords.push({
+      id: i,
+      uuid: `${Math.random().toString(36).substr(2, 9)}-${Math.random().toString(36).substr(2, 9)}-${Math.random().toString(36).substr(2, 9)}`,
+      timestamp: new Date(Date.now() - Math.random() * 86400000).toISOString(),
+      status: ['success', 'pending', 'failed', 'processing'][Math.floor(Math.random() * 4)],
+      message: `This is a sample message for record ${i} with some additional text to increase size. Lorem ipsum dolor sit amet, consectetur adipiscing elit.`,
+      payload: {
+        key1: Math.random().toString(36).substr(2, 20),
+        key2: Math.random().toString(36).substr(2, 20),
+        key3: Math.random().toString(36).substr(2, 20),
+        nestedData: {
+          field1: `value-${Math.random().toString(36).substr(2, 15)}`,
+          field2: `value-${Math.random().toString(36).substr(2, 15)}`,
+          field3: `value-${Math.random().toString(36).substr(2, 15)}`
+        }
+      },
+      metadata: {
+        source: 'api',
+        version: '1.0.0',
+        tags: ['tag1', 'tag2', 'tag3', 'tag4']
+      }
+    });
+  }
+
+  // Add more nested data
+  for (let i = 0; i < 50; i++) {
+    largeContext.nestedStructure.level1.level2.level3.level4.level5.data.push({
+      index: i,
+      value: Math.random().toString(36).substr(2, 50),
+      description: `Nested data entry ${i} with additional information to increase the overall size of the context object.`
+    });
+  }
+
+  return largeContext;
+}
+
+// Helper function to generate a small context object
+function generateSmallContext() {
+  return {
+    requestId: `req-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+    timestamp: new Date().toISOString(),
+    user: {
+      id: Math.floor(Math.random() * 100000),
+      name: `user_${Math.random().toString(36).substr(2, 9)}`
+    }
+  };
+}
+
+// Helper function to log JSON with context (30% small, 70% large)
+function logWithContext(level, message, additionalFields = {}) {
+  const isSmallLog = Math.random() < 0.3; // 30% chance of small log
+  const context = isSmallLog ? generateSmallContext() : generateLargeContext();
+
+  const logEntry = {
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+    context,
+    ...additionalFields
+  };
+
+  console.log(JSON.stringify(logEntry));
+
+  // Also log the size for monitoring
+  const logSize = JSON.stringify(logEntry).length;
+  if (!isSmallLog && logSize > 30000) {
+    console.log(JSON.stringify({
+      level: 'info',
+      message: `Generated large log: ${logSize} bytes`,
+      timestamp: new Date().toISOString()
+    }));
+  }
+}
+
+// Middleware
+app.use(express.json());
+
+// Routes
+app.get('/', (req, res) => {
+  logWithContext('info', 'Received request to root endpoint', {
+    path: req.path,
+    method: req.method,
+    ip: req.ip
+  });
+
+  res.json({
+    status: 'ok',
+    message: 'ECS Fargate Large Logs Example',
+    timestamp: new Date().toISOString()
+  });
+});
+
+app.get('/health', (req, res) => {
+  logWithContext('info', 'Health check', {
+    path: req.path,
+    healthy: true
+  });
+
+  res.json({ status: 'healthy' });
+});
+
+app.post('/api/data', (req, res) => {
+  logWithContext('info', 'Processing data request', {
+    path: req.path,
+    method: req.method,
+    bodySize: JSON.stringify(req.body).length
+  });
+
+  res.json({
+    status: 'processed',
+    timestamp: new Date().toISOString()
+  });
+});
+
+app.get('/api/generate-logs/:count', (req, res) => {
+  const count = parseInt(req.params.count) || 10;
+
+  logWithContext('info', `Generating ${count} log entries`, {
+    path: req.path,
+    count
+  });
+
+  for (let i = 0; i < count; i++) {
+    logWithContext('info', `Generated log entry ${i + 1}/${count}`, {
+      iteration: i + 1,
+      total: count
+    });
+  }
+
+  res.json({
+    status: 'completed',
+    logsGenerated: count,
+    timestamp: new Date().toISOString()
+  });
+});
+
+// Error handling
+app.use((err, req, res, next) => {
+  logWithContext('error', 'Unhandled error', {
+    error: err.message,
+    stack: err.stack,
+    path: req.path
+  });
+
+  res.status(500).json({
+    status: 'error',
+    message: err.message
+  });
+});
+
+// Generate logs periodically (every 5 seconds)
+setInterval(() => {
+  logWithContext('info', 'Periodic log generation', {
+    type: 'automated',
+    interval: '5s'
+  });
+}, 5000);
+
+app.listen(PORT, () => {
+  console.log(JSON.stringify({
+    level: 'info',
+    message: `Server started on port ${PORT}`,
+    timestamp: new Date().toISOString(),
+    port: PORT
+  }));
+});

--- a/aws/ecs-fargate/nodejs-express-large-logs/otel-config-tcp.yaml
+++ b/aws/ecs-fargate/nodejs-express-large-logs/otel-config-tcp.yaml
@@ -1,0 +1,91 @@
+receivers:
+  awsecscontainermetrics:
+    collection_interval: 60s
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+        max_recv_msg_size_mib: 100
+      http:
+        endpoint: 0.0.0.0:4318
+        max_request_body_size: 104857600  # 100MB
+  fluentforward:
+    endpoint: 0.0.0.0:8006
+
+processors:
+  transform/ecsmetrics:
+    metric_statements:
+      - context: datapoint
+        statements:
+          # Task Level Resource Attributes
+          - set(attributes["aws.ecs.cluster.name"], resource.attributes["aws.ecs.cluster.name"])
+          - set(attributes["aws.ecs.task.family"], resource.attributes["aws.ecs.task.family"])
+          - set(attributes["aws.ecs.task.arn"], resource.attributes["aws.ecs.task.arn"])
+          - set(attributes["aws.ecs.task.id"], resource.attributes["aws.ecs.task.id"])
+          - set(attributes["aws.ecs.task.version"], resource.attributes["aws.ecs.task.version"])
+          - set(attributes["aws.ecs.service.name"], resource.attributes["aws.ecs.service.name"])
+          - set(attributes["cloud.zone"], resource.attributes["cloud.zone"])
+          - set(attributes["cloud.account.id"], resource.attributes["cloud.account.id"])
+          - set(attributes["cloud.region"], resource.attributes["cloud.region"])
+          - set(attributes["aws.ecs.task.pull_started_at"], resource.attributes["aws.ecs.task.pull_started_at"])
+          - set(attributes["aws.ecs.task.pull_stopped_at"], resource.attributes["aws.ecs.task.pull_stopped_at"])
+          - set(attributes["aws.ecs.task.known_status"], resource.attributes["aws.ecs.task.known_status"])
+          - set(attributes["aws.ecs.task.launch_type"], resource.attributes["aws.ecs.task.launch_type"])
+
+          # Container Level Resource Attributes (additional to task level)
+          - set(attributes["aws.ecs.container.created_at"], resource.attributes["aws.ecs.container.created_at"])
+          - set(attributes["aws.ecs.container.finished_at"], resource.attributes["aws.ecs.container.finished_at"])
+          - set(attributes["aws.ecs.container.know_status"], resource.attributes["aws.ecs.container.know_status"])
+          - set(attributes["container.name"], resource.attributes["container.name"])
+          - set(attributes["container.id"], resource.attributes["container.id"])
+          - set(attributes["aws.ecs.docker.name"], resource.attributes["aws.ecs.docker.name"])
+          - set(attributes["container.image.tag"], resource.attributes["container.image.tag"])
+          - set(attributes["aws.ecs.container.image.id"], resource.attributes["aws.ecs.container.image.id"])
+          - set(attributes["aws.ecs.container.exit_code"], resource.attributes["aws.ecs.container.exit_code"])
+
+          # Standard OpenTelemetry container attributes that may be present
+          - set(attributes["container.image.name"], resource.attributes["container.image.name"])
+          - set(attributes["container.runtime"], resource.attributes["container.runtime"])
+
+  transform/firelens:
+    error_mode: ignore
+    log_statements:
+      - context: log
+        statements:
+          # Set resource attributes from Fluent Bit metadata
+          - set(resource.attributes["container_name"], attributes["container_name"]) where attributes["container_name"] != nil
+          - set(resource.attributes["container_id"], attributes["container_id"]) where attributes["container_id"] != nil
+          - set(resource.attributes["service.name"], attributes["container_name"]) where attributes["container_name"] != nil
+
+          # Clean up Fluent Bit metadata
+          - delete_key(attributes, "container_id")
+          - delete_key(attributes, "container_name")
+
+  batch:
+    send_batch_max_size: 1000
+    send_batch_size: 1000
+    timeout: 10s
+
+  resourcedetection:
+    detectors: [ecs]
+
+exporters:
+  otlp/last9:
+    endpoint: "<YOUR_LAST9_OTLP_ENDPOINT>"
+    headers:
+      "Authorization": "Basic <YOUR_BASE64_CREDENTIALS>"
+    sending_queue:
+      enabled: true
+      num_consumers: 10
+      queue_size: 5000
+
+service:
+  pipelines:
+    metrics:
+      receivers: [awsecscontainermetrics]
+      processors: [batch, resourcedetection, transform/ecsmetrics]
+      exporters: [otlp/last9]
+    logs:
+      receivers: [fluentforward]
+      processors: [transform/firelens, batch, resourcedetection]
+      exporters: [otlp/last9]

--- a/aws/ecs-fargate/nodejs-express-large-logs/package.json
+++ b/aws/ecs-fargate/nodejs-express-large-logs/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "nodejs-express-large-logs",
+  "version": "1.0.0",
+  "description": "Node.js Express app generating large logs for ECS Fargate testing",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "nodemon index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.2"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/aws/ecs-fargate/nodejs-express-large-logs/task-definition-with-otel.json
+++ b/aws/ecs-fargate/nodejs-express-large-logs/task-definition-with-otel.json
@@ -1,0 +1,124 @@
+{
+  "family": "nodejs-express-large-logs",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "512",
+  "memory": "1024",
+  "executionRoleArn": "arn:aws:iam::<YOUR_AWS_ACCOUNT_ID>:role/ecsTaskExecutionRole",
+  "taskRoleArn": "arn:aws:iam::<YOUR_AWS_ACCOUNT_ID>:role/ecs_task_iam_role",
+  "containerDefinitions": [
+    {
+      "name": "nodejs-app",
+      "image": "<YOUR_AWS_ACCOUNT_ID>.dkr.ecr.<YOUR_REGION>.amazonaws.com/nodejs-express-large-logs:latest",
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 3000,
+          "protocol": "tcp"
+        }
+      ],
+      "environment": [
+        {
+          "name": "PORT",
+          "value": "3000"
+        },
+        {
+          "name": "NODE_ENV",
+          "value": "production"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awsfirelens",
+        "options": {
+          "Name": "forward",
+          "Host": "127.0.0.1",
+          "Port": "8006"
+        }
+      },
+      "healthCheck": {
+        "command": [
+          "CMD-SHELL",
+          "wget --no-verbose --tries=1 --spider http://localhost:3000/health || exit 1"
+        ],
+        "interval": 30,
+        "timeout": 5,
+        "retries": 3,
+        "startPeriod": 60
+      },
+      "dependsOn": [
+        {
+          "containerName": "log-router",
+          "condition": "START"
+        },
+        {
+          "containerName": "otel-collector",
+          "condition": "START"
+        }
+      ]
+    },
+    {
+      "name": "log-router",
+      "image": "<YOUR_AWS_ACCOUNT_ID>.dkr.ecr.<YOUR_REGION>.amazonaws.com/nodejs-express-large-logs-fluentbit:latest",
+      "essential": false,
+      "firelensConfiguration": {
+        "type": "fluentbit",
+        "options": {
+          "enable-ecs-log-metadata": "true",
+          "config-file-type": "file",
+          "config-file-value": "/fluent-bit/etc/extra.conf"
+        }
+      },
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/log-router",
+          "awslogs-region": "<YOUR_REGION>",
+          "awslogs-stream-prefix": "firelens"
+        }
+      }
+    },
+    {
+      "name": "otel-collector",
+      "image": "otel/opentelemetry-collector-contrib:latest",
+      "cpu": 0,
+      "portMappings": [
+        {
+          "name": "otel-collector-4317-grpc",
+          "containerPort": 4317,
+          "hostPort": 4317,
+          "protocol": "tcp",
+          "appProtocol": "grpc"
+        },
+        {
+          "name": "otel-collector-4318-http",
+          "containerPort": 4318,
+          "hostPort": 4318,
+          "protocol": "tcp",
+          "appProtocol": "http"
+        }
+      ],
+      "essential": false,
+      "command": [
+        "--config",
+        "env:OTEL_CONFIG"
+      ],
+      "environment": [
+        {
+          "name": "OTEL_CONFIG",
+          "value": "receivers:\n  awsecscontainermetrics:\n    collection_interval: 60s\n  otlp:\n    protocols:\n      grpc:\n        endpoint: 0.0.0.0:4317\n        max_recv_msg_size_mib: 100\n      http:\n        endpoint: 0.0.0.0:4318\n        max_request_body_size: 104857600  # 100MB\n  fluentforward:\n    endpoint: 0.0.0.0:8006\n\nprocessors:\n  transform/ecsmetrics:\n    metric_statements:\n      - context: datapoint\n        statements:\n          # Task Level Resource Attributes\n          - set(attributes[\"aws.ecs.cluster.name\"], resource.attributes[\"aws.ecs.cluster.name\"])\n          - set(attributes[\"aws.ecs.task.family\"], resource.attributes[\"aws.ecs.task.family\"])\n          - set(attributes[\"aws.ecs.task.arn\"], resource.attributes[\"aws.ecs.task.arn\"])\n          - set(attributes[\"aws.ecs.task.id\"], resource.attributes[\"aws.ecs.task.id\"])\n          - set(attributes[\"aws.ecs.task.version\"], resource.attributes[\"aws.ecs.task.version\"])\n          - set(attributes[\"aws.ecs.service.name\"], resource.attributes[\"aws.ecs.service.name\"])\n          - set(attributes[\"cloud.zone\"], resource.attributes[\"cloud.zone\"])\n          - set(attributes[\"cloud.account.id\"], resource.attributes[\"cloud.account.id\"])\n          - set(attributes[\"cloud.region\"], resource.attributes[\"cloud.region\"])\n          - set(attributes[\"aws.ecs.task.pull_started_at\"], resource.attributes[\"aws.ecs.task.pull_started_at\"])\n          - set(attributes[\"aws.ecs.task.pull_stopped_at\"], resource.attributes[\"aws.ecs.task.pull_stopped_at\"])\n          - set(attributes[\"aws.ecs.task.known_status\"], resource.attributes[\"aws.ecs.task.known_status\"])\n          - set(attributes[\"aws.ecs.task.launch_type\"], resource.attributes[\"aws.ecs.task.launch_type\"])\n\n          # Container Level Resource Attributes (additional to task level)\n          - set(attributes[\"aws.ecs.container.created_at\"], resource.attributes[\"aws.ecs.container.created_at\"])\n          - set(attributes[\"aws.ecs.container.finished_at\"], resource.attributes[\"aws.ecs.container.finished_at\"])\n          - set(attributes[\"aws.ecs.container.know_status\"], resource.attributes[\"aws.ecs.container.know_status\"])\n          - set(attributes[\"container.name\"], resource.attributes[\"container.name\"])\n          - set(attributes[\"container.id\"], resource.attributes[\"container.id\"])\n          - set(attributes[\"aws.ecs.docker.name\"], resource.attributes[\"aws.ecs.docker.name\"])\n          - set(attributes[\"container.image.tag\"], resource.attributes[\"container.image.tag\"])\n          - set(attributes[\"aws.ecs.container.image.id\"], resource.attributes[\"aws.ecs.container.image.id\"])\n          - set(attributes[\"aws.ecs.container.exit_code\"], resource.attributes[\"aws.ecs.container.exit_code\"])\n\n          # Standard OpenTelemetry container attributes that may be present\n          - set(attributes[\"container.image.name\"], resource.attributes[\"container.image.name\"])\n          - set(attributes[\"container.runtime\"], resource.attributes[\"container.runtime\"])\n\n  transform/firelens:\n    error_mode: ignore\n    log_statements:\n      - context: log\n        statements:\n          # Set resource attributes from Fluent Bit metadata\n          - set(resource.attributes[\"container_name\"], attributes[\"container_name\"]) where attributes[\"container_name\"] != nil\n          - set(resource.attributes[\"container_id\"], attributes[\"container_id\"]) where attributes[\"container_id\"] != nil\n          - set(resource.attributes[\"service.name\"], attributes[\"container_name\"]) where attributes[\"container_name\"] != nil\n\n          # Clean up Fluent Bit metadata\n          - delete_key(attributes, \"container_id\")\n          - delete_key(attributes, \"container_name\")\n\n  batch:\n    send_batch_max_size: 1000\n    send_batch_size: 1000\n    timeout: 10s\n\n  resourcedetection:\n    detectors: [ecs]\n\nexporters:\n  otlp/last9:\n    endpoint: \"<YOUR_LAST9_OTLP_ENDPOINT>\"\n    headers:\n      \"Authorization\": \"Basic <YOUR_BASE64_CREDENTIALS>\"\n    sending_queue:\n      enabled: true\n      num_consumers: 10\n      queue_size: 5000\n\nservice:\n  pipelines:\n    metrics:\n      receivers: [awsecscontainermetrics]\n      processors: [batch, resourcedetection, transform/ecsmetrics]\n      exporters: [otlp/last9]\n    logs:\n      receivers: [fluentforward]\n      processors: [transform/firelens, batch, resourcedetection]\n      exporters: [otlp/last9]\n"
+        }
+      ],
+      "user": "0",
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/otel-collector",
+          "awslogs-region": "<YOUR_REGION>",
+          "awslogs-stream-prefix": "otel"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds a comprehensive example for handling large logs (>100KB) in AWS ECS Fargate with Last9 integration using OpenTelemetry.

## Problem Solved

AWS Fargate has a fixed 16KB runtime buffer limit that causes logs larger than 16KB to be split into multiple partial chunks. This breaks JSON parsing and makes logs difficult to analyze in observability platforms.

## Solution

Uses AWS FireLens (Fluent Bit) with a multiline filter in `partial_message` mode to:
1. Detect Docker's partial message markers
2. Group chunks by `partial_id`
3. Reassemble chunks in order
4. Forward complete logs to OpenTelemetry Collector
5. Export to Last9 via OTLP

## Architecture

```
nodejs-app → log-router (Fluent Bit multiline) → otel-collector → Last9
```

## What's Included

- **Sample Application**: Node.js Express app generating large logs (30% <1KB, 70% >100KB)
- **Custom Fluent Bit Image**: With multiline filter configuration
- **OTEL Collector Config**: Collects ECS metrics + forwards logs
- **Complete Task Definition**: 3-container setup with proper dependencies
- **Comprehensive README**: Step-by-step integration guide for existing ECS deployments

## Files Added

- `aws/ecs-fargate/nodejs-express-large-logs/README.md` - Integration guide
- `aws/ecs-fargate/nodejs-express-large-logs/index.js` - Sample Node.js app
- `aws/ecs-fargate/nodejs-express-large-logs/Dockerfile` - App container
- `aws/ecs-fargate/nodejs-express-large-logs/Dockerfile.fluentbit` - Custom Fluent Bit
- `aws/ecs-fargate/nodejs-express-large-logs/extra.conf` - Multiline filter config
- `aws/ecs-fargate/nodejs-express-large-logs/otel-config-tcp.yaml` - OTEL config
- `aws/ecs-fargate/nodejs-express-large-logs/task-definition-with-otel.json` - Example task definition