### PR TITLE
feat: Add multi-namespace Rails API with rich OTel child spans

### DIFF
--- a/ruby/rails-api/Gemfile
+++ b/ruby/rails-api/Gemfile
@@ -53,3 +53,7 @@ gem 'opentelemetry-exporter-otlp'
 gem 'opentelemetry-instrumentation-all'
 
 gem 'dotenv-rails', groups: [:development, :test]
+
+# For rich traces with child spans
+gem 'redis', '~> 5.0'
+gem 'faraday', '~> 2.0'

--- a/ruby/rails-api/Gemfile.lock
+++ b/ruby/rails-api/Gemfile.lock
@@ -98,6 +98,12 @@ GEM
     drb (2.2.1)
     error_highlight (0.7.0)
     erubi (1.13.1)
+    faraday (2.14.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (4.30.2-arm64-darwin)
@@ -118,6 +124,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    json (2.18.0)
     logger (1.7.0)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -133,6 +140,8 @@ GEM
     minitest (5.25.5)
     msgpack (1.8.0)
     mutex_m (0.3.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.5.7)
       date
       net-protocol
@@ -402,6 +411,10 @@ GEM
     rake (13.2.1)
     rdoc (6.13.0)
       psych (>= 4.0.0)
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
+    redis-client (0.26.3)
+      connection_pool
     reline (0.6.0)
       io-console (~> 0.5)
     securerandom (0.4.1)
@@ -413,6 +426,7 @@ GEM
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uri (1.1.1)
     websocket-driver (0.7.7)
       base64
       websocket-extensions (>= 0.1.0)
@@ -429,11 +443,13 @@ DEPENDENCIES
   debug
   dotenv-rails
   error_highlight (>= 0.4.0)
+  faraday (~> 2.0)
   opentelemetry-exporter-otlp
   opentelemetry-instrumentation-all
   opentelemetry-sdk
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
+  redis (~> 5.0)
   sqlite3 (~> 1.4)
   tzinfo-data
 

--- a/ruby/rails-api/app/controllers/api/v1/auth_controller.rb
+++ b/ruby/rails-api/app/controllers/api/v1/auth_controller.rb
@@ -1,0 +1,223 @@
+module Api
+  module V1
+    class AuthController < ApplicationController
+      SERVICE_NAMESPACE = "auth".freeze
+
+      # POST /api/v1/auth/login
+      def login
+        email = params[:email] || "user#{rand(1000)}@example.com"
+        user_id = "usr_#{Digest::MD5.hexdigest(email)[0..15]}"
+
+        current_span.set_attribute("auth.method", "password")
+        current_span.set_attribute("auth.email_domain", email.split("@").last)
+
+        # 1. Check rate limit in cache
+        rate_key = "rate:login:#{user_id}"
+        attempts = CacheService.get(rate_key)&.to_i || 0
+
+        if attempts >= 5
+          current_span.set_attribute("auth.rate_limited", true)
+          render json: { success: false, error: "rate_limited" }, status: :too_many_requests
+          return
+        end
+
+        # 2. Verify user (external API call)
+        verify_result = ExternalApiService.verify_user(user_id: user_id)
+        current_span.set_attribute("auth.user_verified", verify_result[:success])
+
+        # Simulate authentication (15% failure rate)
+        if rand < 0.15
+          # Increment failed attempts
+          CacheService.increment(rate_key)
+          CacheService.set(rate_key, (attempts + 1).to_s, ex: 300) if attempts == 0
+
+          current_span.set_attribute("auth.success", false)
+          current_span.set_attribute("auth.failure_reason", "invalid_credentials")
+          current_span.add_event("authentication_failed", attributes: {
+            "auth.attempt_number" => attempts + 1
+          })
+
+          render json: {
+            success: false,
+            error: "invalid_credentials"
+          }, status: :unauthorized
+        else
+          session_id = "sess_#{SecureRandom.hex(16)}"
+          token = "tok_#{SecureRandom.hex(32)}"
+
+          # 3. Store session in cache
+          CacheService.set("session:#{session_id}", {
+            user_id: user_id,
+            email: email,
+            created_at: Time.now.iso8601
+          }.to_json, ex: 3600)
+
+          # 4. Clear rate limit on success
+          CacheService.delete(rate_key)
+
+          current_span.set_attribute("auth.success", true)
+          current_span.set_attribute("auth.session_id", session_id)
+          current_span.add_event("authentication_success")
+
+          render json: {
+            success: true,
+            token: token,
+            session_id: session_id,
+            user_id: user_id,
+            expires_in: 3600
+          }
+        end
+      end
+
+      # POST /api/v1/auth/logout
+      def logout
+        session_id = params[:session_id] || "sess_#{SecureRandom.hex(16)}"
+
+        current_span.set_attribute("auth.session_id", session_id)
+        current_span.set_attribute("auth.logout_type", params[:type] || "user_initiated")
+
+        # 1. Get session from cache
+        session_data = CacheService.get("session:#{session_id}")
+        current_span.set_attribute("auth.session_found", !session_data.nil?)
+
+        # 2. Delete session from cache
+        CacheService.delete("session:#{session_id}")
+
+        current_span.add_event("session_terminated")
+
+        render json: {
+          success: true,
+          message: "logged_out"
+        }
+      end
+
+      # POST /api/v1/auth/refresh
+      def refresh
+        session_id = params[:session_id] || request.headers["X-Session-ID"]
+
+        current_span.set_attribute("auth.token_type", "refresh")
+
+        # 1. Validate session in cache
+        session_data = CacheService.get("session:#{session_id}") if session_id
+        current_span.set_attribute("auth.session_valid", !session_data.nil?)
+
+        # Simulate token refresh (5% failure for expired tokens)
+        if rand < 0.05 || session_data.nil?
+          current_span.set_attribute("auth.refresh_success", false)
+          current_span.set_attribute("auth.refresh_error", "token_expired")
+
+          render json: {
+            success: false,
+            error: "refresh_token_expired"
+          }, status: :unauthorized
+        else
+          new_token = "tok_#{SecureRandom.hex(32)}"
+
+          # 2. Extend session TTL
+          CacheService.set("session:#{session_id}", session_data, ex: 3600)
+
+          current_span.set_attribute("auth.refresh_success", true)
+
+          render json: {
+            success: true,
+            token: new_token,
+            expires_in: 3600
+          }
+        end
+      end
+
+      # GET /api/v1/auth/verify
+      def verify
+        token = request.headers["Authorization"]&.gsub("Bearer ", "") || "tok_#{SecureRandom.hex(32)}"
+
+        current_span.set_attribute("auth.verification_type", "token")
+        current_span.set_attribute("auth.token_prefix", token[0..6])
+
+        # 1. Check token in cache
+        cached_verification = CacheService.get("token:#{token[0..15]}")
+        current_span.set_attribute("auth.cache_hit", !cached_verification.nil?)
+
+        # Simulate verification (8% invalid tokens)
+        if rand < 0.08
+          current_span.set_attribute("auth.token_valid", false)
+          current_span.set_attribute("auth.invalid_reason", "malformed_token")
+
+          render json: {
+            valid: false,
+            error: "invalid_token"
+          }, status: :unauthorized
+        else
+          user_id = "usr_#{SecureRandom.hex(8)}"
+
+          # 2. Cache the verification result
+          CacheService.set("token:#{token[0..15]}", {
+            user_id: user_id,
+            verified_at: Time.now.iso8601
+          }.to_json, ex: 300)
+
+          current_span.set_attribute("auth.token_valid", true)
+          current_span.set_attribute("auth.user_id", user_id)
+
+          render json: {
+            valid: true,
+            user_id: user_id,
+            scopes: ["read", "write"]
+          }
+        end
+      end
+
+      # POST /api/v1/auth/register
+      def register
+        email = params[:email] || "newuser#{rand(10000)}@example.com"
+        user_id = "usr_#{SecureRandom.hex(8)}"
+
+        current_span.set_attribute("auth.registration_type", "email")
+        current_span.set_attribute("auth.email_domain", email.split("@").last)
+
+        # 1. Check if email exists in cache (quick check)
+        email_key = "email:#{Digest::MD5.hexdigest(email)}"
+        existing = CacheService.get(email_key)
+
+        if existing || rand < 0.03
+          current_span.set_attribute("auth.registration_success", false)
+          current_span.set_attribute("auth.registration_error", "email_exists")
+
+          render json: {
+            success: false,
+            error: "email_already_registered"
+          }, status: :conflict
+          return
+        end
+
+        # 2. Verify email domain (external API call)
+        ExternalApiService.verify_user(user_id: email)
+
+        # 3. Store email in cache to prevent duplicates
+        CacheService.set(email_key, user_id, ex: 86400)
+
+        # 4. Send welcome notification
+        ExternalApiService.send_notification(
+          user_id: user_id,
+          type: 'welcome',
+          message: "Welcome to our platform!"
+        )
+
+        current_span.set_attribute("auth.registration_success", true)
+        current_span.set_attribute("auth.new_user_id", user_id)
+        current_span.add_event("user_registered")
+
+        render json: {
+          success: true,
+          user_id: user_id,
+          verification_required: true
+        }, status: :created
+      end
+
+      private
+
+      def current_span
+        OpenTelemetry::Trace.current_span
+      end
+    end
+  end
+end

--- a/ruby/rails-api/app/controllers/api/v1/internal_controller.rb
+++ b/ruby/rails-api/app/controllers/api/v1/internal_controller.rb
@@ -1,0 +1,185 @@
+module Api
+  module V1
+    class InternalController < ApplicationController
+      SERVICE_NAMESPACE = "internal".freeze
+
+      # GET /api/v1/internal/health
+      def health
+        simulate_work(5..20)
+
+        current_span.set_attribute("internal.check_type", "health")
+        current_span.set_attribute("internal.component", "api")
+
+        checks = {
+          database: check_database,
+          cache: check_cache,
+          queue: check_queue
+        }
+
+        all_healthy = checks.values.all? { |c| c[:status] == "healthy" }
+        current_span.set_attribute("internal.all_healthy", all_healthy)
+
+        status_code = all_healthy ? :ok : :service_unavailable
+
+        render json: {
+          status: all_healthy ? "healthy" : "degraded",
+          checks: checks,
+          timestamp: Time.now.iso8601
+        }, status: status_code
+      end
+
+      # GET /api/v1/internal/metrics
+      def metrics
+        simulate_work(30..100)
+
+        current_span.set_attribute("internal.check_type", "metrics")
+        current_span.set_attribute("internal.metrics_format", params[:format] || "json")
+
+        metrics = {
+          requests_per_second: rand(100..500),
+          average_latency_ms: rand(20..150),
+          error_rate: rand(0.01..0.05).round(4),
+          active_connections: rand(50..200),
+          memory_usage_mb: rand(256..1024),
+          cpu_usage_percent: rand(10..80)
+        }
+
+        current_span.set_attribute("internal.rps", metrics[:requests_per_second])
+        current_span.set_attribute("internal.error_rate", metrics[:error_rate])
+
+        render json: {
+          metrics: metrics,
+          collected_at: Time.now.iso8601
+        }
+      end
+
+      # POST /api/v1/internal/sync
+      def sync
+        sync_type = params[:type] || "full"
+        target = params[:target] || "all"
+
+        simulate_work(200..800)
+
+        current_span.set_attribute("internal.sync_type", sync_type)
+        current_span.set_attribute("internal.sync_target", target)
+
+        # Simulate sync operation
+        records_synced = rand(100..5000)
+        current_span.set_attribute("internal.records_synced", records_synced)
+        current_span.add_event("sync_completed", attributes: {
+          "sync.records" => records_synced,
+          "sync.duration_ms" => rand(200..800)
+        })
+
+        render json: {
+          success: true,
+          sync_type: sync_type,
+          target: target,
+          records_synced: records_synced,
+          completed_at: Time.now.iso8601
+        }
+      end
+
+      # POST /api/v1/internal/cache/invalidate
+      def cache_invalidate
+        cache_key = params[:key] || "*"
+        pattern = params[:pattern] || false
+
+        simulate_work(50..200)
+
+        current_span.set_attribute("internal.cache_operation", "invalidate")
+        current_span.set_attribute("internal.cache_key", cache_key)
+        current_span.set_attribute("internal.pattern_match", pattern)
+
+        keys_invalidated = pattern ? rand(10..100) : 1
+        current_span.set_attribute("internal.keys_invalidated", keys_invalidated)
+
+        render json: {
+          success: true,
+          keys_invalidated: keys_invalidated,
+          pattern_used: pattern
+        }
+      end
+
+      # GET /api/v1/internal/config
+      def get_config
+        simulate_work(10..50)
+
+        current_span.set_attribute("internal.check_type", "config")
+        current_span.set_attribute("internal.config_version", "v2.1.0")
+
+        # Return safe config values (never real secrets)
+        app_config = {
+          version: "2.1.0",
+          environment: Rails.env,
+          features: {
+            new_checkout: true,
+            beta_payments: false,
+            enhanced_auth: true
+          },
+          limits: {
+            rate_limit_per_minute: 1000,
+            max_payload_size_mb: 10,
+            session_timeout_seconds: 3600
+          }
+        }
+
+        render json: app_config
+      end
+
+      # POST /api/v1/internal/jobs/trigger
+      def trigger_job
+        job_type = params[:job_type] || ["cleanup", "report", "notification", "sync"].sample
+        priority = params[:priority] || "normal"
+
+        simulate_work(30..150)
+
+        job_id = "job_#{SecureRandom.hex(8)}"
+
+        current_span.set_attribute("internal.job_type", job_type)
+        current_span.set_attribute("internal.job_priority", priority)
+        current_span.set_attribute("internal.job_id", job_id)
+        current_span.add_event("job_enqueued", attributes: {
+          "job.id" => job_id,
+          "job.type" => job_type
+        })
+
+        render json: {
+          success: true,
+          job_id: job_id,
+          job_type: job_type,
+          priority: priority,
+          status: "enqueued"
+        }, status: :accepted
+      end
+
+      private
+
+      def current_span
+        OpenTelemetry::Trace.current_span
+      end
+
+      def simulate_work(range_ms)
+        sleep(rand(range_ms) / 1000.0)
+      end
+
+      def check_database
+        # Simulate database check
+        latency = rand(5..30)
+        { status: rand < 0.98 ? "healthy" : "degraded", latency_ms: latency }
+      end
+
+      def check_cache
+        # Simulate cache check
+        latency = rand(1..10)
+        { status: rand < 0.99 ? "healthy" : "degraded", latency_ms: latency }
+      end
+
+      def check_queue
+        # Simulate queue check
+        queue_depth = rand(0..100)
+        { status: queue_depth < 80 ? "healthy" : "degraded", queue_depth: queue_depth }
+      end
+    end
+  end
+end

--- a/ruby/rails-api/app/controllers/api/v1/payment_controller.rb
+++ b/ruby/rails-api/app/controllers/api/v1/payment_controller.rb
@@ -1,0 +1,226 @@
+module Api
+  module V1
+    class PaymentController < ApplicationController
+      SERVICE_NAMESPACE = "payment".freeze
+
+      # GET /api/v1/payment/status
+      def status
+        # Check cache for gateway status
+        cached_status = CacheService.get("gateway:status")
+
+        if cached_status
+          current_span.set_attribute("payment.cache_hit", true)
+          render json: JSON.parse(cached_status)
+          return
+        end
+
+        # Simulate checking payment gateway
+        simulate_work(50..150)
+
+        status_data = {
+          status: "operational",
+          gateway: "stripe",
+          latency_ms: rand(10..50),
+          timestamp: Time.now.iso8601
+        }
+
+        # Cache the status
+        CacheService.set("gateway:status", status_data.to_json, ex: 60)
+
+        current_span.set_attribute("payment.gateway", "stripe")
+        current_span.set_attribute("payment.gateway_status", "healthy")
+        current_span.set_attribute("payment.cache_hit", false)
+
+        render json: status_data
+      end
+
+      # POST /api/v1/payment/process
+      def process_payment
+        amount = params[:amount]&.to_f || rand(10.0..500.0).round(2)
+        currency = params[:currency] || "USD"
+        payment_method = params[:method] || "card"
+        user_id = params[:user_id] || "usr_#{SecureRandom.hex(8)}"
+
+        transaction_id = "txn_#{SecureRandom.hex(12)}"
+
+        current_span.set_attribute("payment.amount", amount)
+        current_span.set_attribute("payment.currency", currency)
+        current_span.set_attribute("payment.method", payment_method)
+        current_span.set_attribute("payment.transaction_id", transaction_id)
+
+        # 1. Check fraud (external API call)
+        fraud_result = ExternalApiService.fraud_check(
+          transaction_id: transaction_id,
+          amount: amount,
+          user_id: user_id
+        )
+        current_span.set_attribute("payment.fraud_check_passed", fraud_result[:success])
+
+        # 2. Create transaction in database
+        txn = DatabaseService.create_transaction(
+          transaction_id: transaction_id,
+          amount: amount,
+          currency: currency,
+          status: 'processing',
+          payment_method: payment_method,
+          user_id: user_id
+        )
+
+        # 3. Process with payment gateway (external API call)
+        gateway_result = ExternalApiService.process_with_gateway(
+          transaction_id: transaction_id,
+          amount: amount,
+          currency: currency,
+          method: payment_method
+        )
+
+        # 4. Update transaction status
+        final_status = (rand < 0.1) ? 'failed' : 'completed'
+        DatabaseService.update_transaction_status(transaction_id, final_status)
+
+        # 5. Cache the result
+        CacheService.set("txn:#{transaction_id}", { status: final_status, amount: amount }.to_json, ex: 300)
+
+        # 6. Increment counter
+        CacheService.increment("payments:count:#{Date.today}")
+
+        current_span.set_attribute("payment.status", final_status)
+
+        if final_status == 'failed'
+          current_span.set_attribute("payment.error_code", "insufficient_funds")
+          render json: {
+            success: false,
+            error: "insufficient_funds",
+            transaction_id: transaction_id
+          }, status: :payment_required
+        else
+          # Send notification (external API call)
+          ExternalApiService.send_notification(
+            user_id: user_id,
+            type: 'payment_success',
+            message: "Payment of #{amount} #{currency} completed"
+          )
+
+          render json: {
+            success: true,
+            transaction_id: transaction_id,
+            amount: amount,
+            currency: currency
+          }
+        end
+      end
+
+      # POST /api/v1/payment/refund
+      def refund
+        transaction_id = params[:transaction_id] || "txn_#{SecureRandom.hex(12)}"
+        amount = params[:amount]&.to_f || rand(10.0..100.0).round(2)
+
+        current_span.set_attribute("payment.original_transaction_id", transaction_id)
+        current_span.set_attribute("payment.refund_amount", amount)
+
+        # 1. Find original transaction
+        original_txn = DatabaseService.find_transaction(transaction_id)
+
+        # 2. Check cache for transaction details
+        cached_txn = CacheService.get("txn:#{transaction_id}")
+        current_span.set_attribute("payment.cache_hit", !cached_txn.nil?)
+
+        # 3. Create refund transaction
+        refund_id = "ref_#{SecureRandom.hex(8)}"
+        DatabaseService.create_transaction(
+          transaction_id: refund_id,
+          amount: -amount,
+          currency: original_txn&.currency || 'USD',
+          status: 'completed',
+          payment_method: 'refund',
+          user_id: original_txn&.user_id,
+          metadata: { original_transaction: transaction_id }.to_json
+        )
+
+        # 4. Process refund with gateway
+        ExternalApiService.process_with_gateway(
+          transaction_id: refund_id,
+          amount: -amount,
+          currency: 'USD',
+          method: 'refund'
+        )
+
+        # 5. Update original transaction status
+        DatabaseService.update_transaction_status(transaction_id, 'refunded') if original_txn
+
+        # 6. Invalidate cache
+        CacheService.delete("txn:#{transaction_id}")
+
+        current_span.set_attribute("payment.refund_id", refund_id)
+        current_span.set_attribute("payment.refund_status", "completed")
+
+        render json: {
+          success: true,
+          refund_id: refund_id,
+          original_transaction_id: transaction_id,
+          amount: amount
+        }
+      end
+
+      # GET /api/v1/payment/transactions
+      def transactions
+        limit = (params[:limit] || 10).to_i
+        user_id = params[:user_id]
+
+        current_span.set_attribute("payment.query_limit", limit)
+
+        # 1. Try cache first
+        cache_key = user_id ? "txns:user:#{user_id}" : "txns:recent"
+        cached = CacheService.get(cache_key)
+
+        if cached
+          current_span.set_attribute("payment.cache_hit", true)
+          render json: JSON.parse(cached)
+          return
+        end
+
+        # 2. Query database
+        transactions = if user_id
+          DatabaseService.transactions_by_user(user_id, limit: limit)
+        else
+          DatabaseService.recent_transactions(limit: limit)
+        end
+
+        # 3. Get stats
+        stats = DatabaseService.transaction_stats
+
+        result = {
+          transactions: transactions.map { |t|
+            {
+              id: t.transaction_id,
+              amount: t.amount.to_f,
+              currency: t.currency,
+              status: t.status,
+              created_at: t.created_at.iso8601
+            }
+          },
+          total: transactions.size,
+          stats: stats
+        }
+
+        # 4. Cache the result
+        CacheService.set(cache_key, result.to_json, ex: 60)
+
+        current_span.set_attribute("payment.transactions_returned", transactions.size)
+        current_span.set_attribute("payment.cache_hit", false)
+
+        render json: result
+      end
+
+      private
+
+      def current_span
+        OpenTelemetry::Trace.current_span
+      end
+
+      def simulate_work(range_ms)
+        sleep(rand(range_ms) / 1000.0)
+      end
+    end
+  end
+end

--- a/ruby/rails-api/app/controllers/api/v1/public_controller.rb
+++ b/ruby/rails-api/app/controllers/api/v1/public_controller.rb
@@ -1,0 +1,22 @@
+module Api
+  module V1
+    class PublicController < ApplicationController
+      # NO service.namespace attribute - intentionally omitted for comparison
+
+      # GET /api/v1/public/ping
+      def ping
+        render json: { pong: true, timestamp: Time.now.iso8601 }
+      end
+
+      # GET /api/v1/public/version
+      def version
+        render json: { version: "1.0.0", rails: Rails.version }
+      end
+
+      # GET /api/v1/public/echo
+      def echo
+        render json: { params: params.to_unsafe_h.except(:controller, :action) }
+      end
+    end
+  end
+end

--- a/ruby/rails-api/app/controllers/api/v1/users_controller.rb
+++ b/ruby/rails-api/app/controllers/api/v1/users_controller.rb
@@ -1,32 +1,46 @@
 module Api
   module V1
     class UsersController < ApplicationController
+      SERVICE_NAMESPACE = "users".freeze
+
       # GET /api/v1/users
       def index
+        current_span.set_attribute("users.operation", "list")
         render plain: "success"
       end
 
       # GET /api/v1/users/:id
       def show
+        current_span.set_attribute("users.operation", "get")
+        current_span.set_attribute("users.id", params[:id])
         render plain: "success"
       end
 
       # POST /api/v1/users
       def create
+        current_span.set_attribute("users.operation", "create")
         render plain: "success"
       end
 
       # PUT /api/v1/users/:id
       def update
+        current_span.set_attribute("users.operation", "update")
+        current_span.set_attribute("users.id", params[:id])
         render plain: "success"
       end
 
       # DELETE /api/v1/users/:id
       def destroy
+        current_span.set_attribute("users.operation", "delete")
+        current_span.set_attribute("users.id", params[:id])
         render plain: "success"
       end
 
       private
+
+      def current_span
+        OpenTelemetry::Trace.current_span
+      end
 
       def user_params
         params.require(:user).permit(:name, :email)

--- a/ruby/rails-api/app/controllers/application_controller.rb
+++ b/ruby/rails-api/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+  include NamespaceTraceable
 end

--- a/ruby/rails-api/app/controllers/concerns/namespace_traceable.rb
+++ b/ruby/rails-api/app/controllers/concerns/namespace_traceable.rb
@@ -1,0 +1,30 @@
+module NamespaceTraceable
+  extend ActiveSupport::Concern
+
+  included do
+    around_action :trace_with_namespace, if: -> { self.class.const_defined?(:SERVICE_NAMESPACE) }
+  end
+
+  private
+
+  def trace_with_namespace(&block)
+    namespace = self.class::SERVICE_NAMESPACE
+
+    # Store in request-scoped CurrentAttributes (auto-resets between requests)
+    CurrentRequest.service_namespace = namespace
+
+    # Set attribute on current span
+    current_span.set_attribute("service.namespace", namespace)
+
+    begin
+      block.call
+    ensure
+      # Explicitly clear to prevent any leakage
+      CurrentRequest.service_namespace = nil
+    end
+  end
+
+  def current_span
+    OpenTelemetry::Trace.current_span
+  end
+end

--- a/ruby/rails-api/app/models/application_record.rb
+++ b/ruby/rails-api/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  primary_abstract_class
+end

--- a/ruby/rails-api/app/models/current_request.rb
+++ b/ruby/rails-api/app/models/current_request.rb
@@ -1,0 +1,5 @@
+# Request-scoped storage for OpenTelemetry attributes
+# Automatically resets between requests - prevents namespace leakage
+class CurrentRequest < ActiveSupport::CurrentAttributes
+  attribute :service_namespace
+end

--- a/ruby/rails-api/app/models/transaction.rb
+++ b/ruby/rails-api/app/models/transaction.rb
@@ -1,0 +1,10 @@
+class Transaction < ApplicationRecord
+  validates :transaction_id, presence: true, uniqueness: true
+  validates :amount, presence: true, numericality: { greater_than: 0 }
+  validates :currency, presence: true
+  validates :status, inclusion: { in: %w[pending processing completed failed refunded] }
+
+  scope :recent, -> { order(created_at: :desc).limit(10) }
+  scope :by_status, ->(status) { where(status: status) }
+  scope :by_user, ->(user_id) { where(user_id: user_id) }
+end

--- a/ruby/rails-api/app/services/cache_service.rb
+++ b/ruby/rails-api/app/services/cache_service.rb
@@ -1,0 +1,74 @@
+# Service for Redis cache operations - creates child spans in traces
+class CacheService
+  class << self
+    def redis
+      @redis ||= Redis.new(
+        url: ENV.fetch('REDIS_URL', 'redis://localhost:6379/0'),
+        timeout: 1,
+        reconnect_attempts: 1
+      )
+    rescue Redis::CannotConnectError
+      nil
+    end
+
+    def get(key)
+      tracer.in_span("cache.get", attributes: { "cache.key" => key }) do |span|
+        begin
+          value = redis&.get(key)
+          span.set_attribute("cache.hit", !value.nil?)
+          value
+        rescue Redis::BaseError => e
+          span.set_attribute("cache.error", e.message)
+          span.status = OpenTelemetry::Trace::Status.error(e.message)
+          nil
+        end
+      end
+    end
+
+    def set(key, value, ex: 300)
+      tracer.in_span("cache.set", attributes: { "cache.key" => key, "cache.ttl" => ex }) do |span|
+        begin
+          redis&.set(key, value, ex: ex)
+          span.set_attribute("cache.success", true)
+          true
+        rescue Redis::BaseError => e
+          span.set_attribute("cache.error", e.message)
+          span.status = OpenTelemetry::Trace::Status.error(e.message)
+          false
+        end
+      end
+    end
+
+    def delete(key)
+      tracer.in_span("cache.delete", attributes: { "cache.key" => key }) do |span|
+        begin
+          result = redis&.del(key)
+          span.set_attribute("cache.keys_deleted", result || 0)
+          result
+        rescue Redis::BaseError => e
+          span.set_attribute("cache.error", e.message)
+          nil
+        end
+      end
+    end
+
+    def increment(key, by: 1)
+      tracer.in_span("cache.increment", attributes: { "cache.key" => key, "cache.increment_by" => by }) do |span|
+        begin
+          result = redis&.incrby(key, by)
+          span.set_attribute("cache.new_value", result) if result
+          result
+        rescue Redis::BaseError => e
+          span.set_attribute("cache.error", e.message)
+          nil
+        end
+      end
+    end
+
+    private
+
+    def tracer
+      OpenTelemetry.tracer_provider.tracer('cache-service')
+    end
+  end
+end

--- a/ruby/rails-api/app/services/database_service.rb
+++ b/ruby/rails-api/app/services/database_service.rb
@@ -1,0 +1,99 @@
+# Service for database operations - ActiveRecord already creates spans via instrumentation
+# This adds custom business-level spans wrapping DB operations
+class DatabaseService
+  class << self
+    def create_transaction(attrs)
+      tracer.in_span("db.create_transaction", attributes: {
+        "db.operation" => "insert",
+        "db.table" => "transactions"
+      }) do |span|
+        txn = Transaction.create!(attrs)
+        span.set_attribute("db.transaction_id", txn.transaction_id)
+        span.set_attribute("db.record_id", txn.id)
+        txn
+      rescue ActiveRecord::RecordInvalid => e
+        span.set_attribute("db.error", e.message)
+        span.status = OpenTelemetry::Trace::Status.error(e.message)
+        nil
+      end
+    end
+
+    def find_transaction(transaction_id)
+      tracer.in_span("db.find_transaction", attributes: {
+        "db.operation" => "select",
+        "db.table" => "transactions",
+        "db.transaction_id" => transaction_id
+      }) do |span|
+        txn = Transaction.find_by(transaction_id: transaction_id)
+        span.set_attribute("db.found", !txn.nil?)
+        txn
+      end
+    end
+
+    def update_transaction_status(transaction_id, status)
+      tracer.in_span("db.update_transaction_status", attributes: {
+        "db.operation" => "update",
+        "db.table" => "transactions",
+        "db.new_status" => status
+      }) do |span|
+        txn = Transaction.find_by(transaction_id: transaction_id)
+        if txn
+          txn.update!(status: status)
+          span.set_attribute("db.updated", true)
+          txn
+        else
+          span.set_attribute("db.updated", false)
+          span.set_attribute("db.error", "Transaction not found")
+          nil
+        end
+      end
+    end
+
+    def recent_transactions(limit: 10)
+      tracer.in_span("db.recent_transactions", attributes: {
+        "db.operation" => "select",
+        "db.table" => "transactions",
+        "db.limit" => limit
+      }) do |span|
+        transactions = Transaction.recent.limit(limit)
+        span.set_attribute("db.count", transactions.size)
+        transactions
+      end
+    end
+
+    def transactions_by_user(user_id, limit: 10)
+      tracer.in_span("db.transactions_by_user", attributes: {
+        "db.operation" => "select",
+        "db.table" => "transactions",
+        "db.user_id" => user_id
+      }) do |span|
+        transactions = Transaction.by_user(user_id).limit(limit)
+        span.set_attribute("db.count", transactions.size)
+        transactions
+      end
+    end
+
+    def transaction_stats
+      tracer.in_span("db.transaction_stats", attributes: {
+        "db.operation" => "aggregate",
+        "db.table" => "transactions"
+      }) do |span|
+        stats = {
+          total: Transaction.count,
+          completed: Transaction.by_status('completed').count,
+          pending: Transaction.by_status('pending').count,
+          failed: Transaction.by_status('failed').count,
+          total_amount: Transaction.sum(:amount)
+        }
+        span.set_attribute("db.total_records", stats[:total])
+        stats
+      end
+    end
+
+    private
+
+    def tracer
+      OpenTelemetry.tracer_provider.tracer('database-service')
+    end
+  end
+end

--- a/ruby/rails-api/app/services/external_api_service.rb
+++ b/ruby/rails-api/app/services/external_api_service.rb
@@ -1,0 +1,107 @@
+# Service for external HTTP calls - creates child spans in traces
+class ExternalApiService
+  ENDPOINTS = {
+    fraud_check: 'https://httpbin.org/post',
+    payment_gateway: 'https://httpbin.org/post',
+    notification: 'https://httpbin.org/post',
+    user_verification: 'https://httpbin.org/get',
+    exchange_rate: 'https://httpbin.org/get'
+  }.freeze
+
+  class << self
+    def fraud_check(transaction_id:, amount:, user_id:)
+      call_external(:fraud_check, {
+        transaction_id: transaction_id,
+        amount: amount,
+        user_id: user_id,
+        check_type: 'transaction'
+      })
+    end
+
+    def process_with_gateway(transaction_id:, amount:, currency:, method:)
+      call_external(:payment_gateway, {
+        transaction_id: transaction_id,
+        amount: amount,
+        currency: currency,
+        payment_method: method
+      })
+    end
+
+    def send_notification(user_id:, type:, message:)
+      call_external(:notification, {
+        user_id: user_id,
+        notification_type: type,
+        message: message
+      })
+    end
+
+    def verify_user(user_id:)
+      call_external(:user_verification, { user_id: user_id }, method: :get)
+    end
+
+    def get_exchange_rate(from:, to:)
+      call_external(:exchange_rate, { from: from, to: to }, method: :get)
+    end
+
+    private
+
+    def call_external(service, params, method: :post)
+      url = ENDPOINTS[service]
+      service_name = service.to_s.gsub('_', '-')
+
+      tracer.in_span("external.#{service_name}",
+        kind: :client,
+        attributes: {
+          "http.method" => method.to_s.upcase,
+          "http.url" => url,
+          "external.service" => service_name
+        }
+      ) do |span|
+        begin
+          # Simulate network latency
+          sleep(rand(50..200) / 1000.0)
+
+          response = if method == :get
+            connection.get(url, params)
+          else
+            connection.post(url, params.to_json, 'Content-Type' => 'application/json')
+          end
+
+          span.set_attribute("http.status_code", response.status)
+          span.set_attribute("external.success", response.success?)
+
+          if response.success?
+            { success: true, status: response.status, data: safe_parse(response.body) }
+          else
+            span.status = OpenTelemetry::Trace::Status.error("HTTP #{response.status}")
+            { success: false, status: response.status, error: response.body }
+          end
+        rescue Faraday::Error => e
+          span.set_attribute("external.error", e.class.name)
+          span.set_attribute("external.error_message", e.message)
+          span.status = OpenTelemetry::Trace::Status.error(e.message)
+          { success: false, error: e.message }
+        rescue StandardError => e
+          span.set_attribute("external.error", e.class.name)
+          { success: false, error: e.message }
+        end
+      end
+    end
+
+    def connection
+      @connection ||= Faraday.new do |f|
+        f.options.timeout = 5
+        f.options.open_timeout = 2
+        f.adapter Faraday.default_adapter
+      end
+    end
+
+    def safe_parse(body)
+      JSON.parse(body) rescue body
+    end
+
+    def tracer
+      OpenTelemetry.tracer_provider.tracer('external-api-service')
+    end
+  end
+end

--- a/ruby/rails-api/config/initializers/opentelemetry.rb
+++ b/ruby/rails-api/config/initializers/opentelemetry.rb
@@ -2,13 +2,25 @@ require 'opentelemetry/sdk'
 require 'opentelemetry/exporter/otlp'
 require 'opentelemetry/instrumentation/all'
 
+# Custom SpanProcessor that adds service.namespace from request-scoped storage
+class NamespaceSpanProcessor < OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor
+  def on_start(span, parent_context)
+    # Get namespace from request-scoped CurrentAttributes (not baggage)
+    # CurrentRequest resets automatically between requests - no leakage
+    namespace = CurrentRequest.service_namespace rescue nil
+    span.set_attribute("service.namespace", namespace) if namespace
+  end
+end
+
 # Exporter and Processor configuration
 otel_exporter = OpenTelemetry::Exporter::OTLP::Exporter.new
-processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(otel_exporter)
+batch_processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(otel_exporter)
+namespace_processor = NamespaceSpanProcessor.new(otel_exporter)
 
 OpenTelemetry::SDK.configure do |c|
-  # Exporter and Processor configuration
-  c.add_span_processor(processor) # Created above this SDK.configure block
+  # Add processors - namespace processor adds attributes, batch processor exports
+  c.add_span_processor(namespace_processor)
+  c.add_span_processor(batch_processor)
 
   # Resource configuration
   c.resource = OpenTelemetry::SDK::Resources::Resource.create({

--- a/ruby/rails-api/config/routes.rb
+++ b/ruby/rails-api/config/routes.rb
@@ -2,6 +2,40 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :users, only: [:index, :show, :create, :update, :destroy]
+
+      # Payment namespace
+      scope :payment do
+        get 'status', to: 'payment#status'
+        post 'process', to: 'payment#process_payment'
+        post 'refund', to: 'payment#refund'
+        get 'transactions', to: 'payment#transactions'
+      end
+
+      # Auth namespace
+      scope :auth do
+        post 'login', to: 'auth#login'
+        post 'logout', to: 'auth#logout'
+        post 'refresh', to: 'auth#refresh'
+        get 'verify', to: 'auth#verify'
+        post 'register', to: 'auth#register'
+      end
+
+      # Internal namespace
+      scope :internal do
+        get 'health', to: 'internal#health'
+        get 'metrics', to: 'internal#metrics'
+        post 'sync', to: 'internal#sync'
+        post 'cache/invalidate', to: 'internal#cache_invalidate'
+        get 'config', to: 'internal#get_config'
+        post 'jobs/trigger', to: 'internal#trigger_job'
+      end
+
+      # Public endpoints - NO service.namespace attribute
+      scope :public do
+        get 'ping', to: 'public#ping'
+        get 'version', to: 'public#version'
+        get 'echo', to: 'public#echo'
+      end
     end
   end
 

--- a/ruby/rails-api/db/migrate/20260108000001_create_transactions.rb
+++ b/ruby/rails-api/db/migrate/20260108000001_create_transactions.rb
@@ -1,0 +1,19 @@
+class CreateTransactions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :transactions do |t|
+      t.string :transaction_id, null: false
+      t.decimal :amount, precision: 10, scale: 2
+      t.string :currency, default: 'USD'
+      t.string :status, default: 'pending'
+      t.string :payment_method
+      t.string :user_id
+      t.text :metadata
+
+      t.timestamps
+    end
+
+    add_index :transactions, :transaction_id, unique: true
+    add_index :transactions, :user_id
+    add_index :transactions, :status
+  end
+end

--- a/ruby/rails-api/db/schema.rb
+++ b/ruby/rails-api/db/schema.rb
@@ -1,0 +1,29 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2026_01_08_000001) do
+  create_table "transactions", force: :cascade do |t|
+    t.string "transaction_id", null: false
+    t.decimal "amount", precision: 10, scale: 2
+    t.string "currency", default: "USD"
+    t.string "status", default: "pending"
+    t.string "payment_method"
+    t.string "user_id"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["status"], name: "index_transactions_on_status"
+    t.index ["transaction_id"], name: "index_transactions_on_transaction_id", unique: true
+    t.index ["user_id"], name: "index_transactions_on_user_id"
+  end
+
+end

--- a/ruby/rails-api/scripts/chaos_traffic.sh
+++ b/ruby/rails-api/scripts/chaos_traffic.sh
@@ -1,0 +1,382 @@
+#!/bin/bash
+
+# Chaos Traffic Generator for Rails API with OpenTelemetry
+# Generates realistic traffic across all namespaces (payment, auth, internal)
+
+set -e
+
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+DURATION="${DURATION:-300}"  # Default 5 minutes
+CONCURRENCY="${CONCURRENCY:-5}"
+REQUEST_DELAY="${REQUEST_DELAY:-0.1}"  # Delay between requests in seconds
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Counters
+TOTAL_REQUESTS=0
+SUCCESSFUL_REQUESTS=0
+FAILED_REQUESTS=0
+
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Payment namespace endpoints
+call_payment_status() {
+    curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/api/v1/payment/status"
+}
+
+call_payment_process() {
+    local amount=$(echo "scale=2; $RANDOM/100" | bc)
+    local currencies=("USD" "EUR" "GBP" "JPY")
+    local currency=${currencies[$RANDOM % ${#currencies[@]}]}
+    local methods=("card" "bank_transfer" "wallet")
+    local method=${methods[$RANDOM % ${#methods[@]}]}
+
+    curl -s -o /dev/null -w "%{http_code}" -X POST "${BASE_URL}/api/v1/payment/process" \
+        -H "Content-Type: application/json" \
+        -d "{\"amount\": ${amount}, \"currency\": \"${currency}\", \"method\": \"${method}\"}"
+}
+
+call_payment_refund() {
+    local amount=$(echo "scale=2; $RANDOM/100" | bc)
+    local txn_id="txn_$(openssl rand -hex 12)"
+
+    curl -s -o /dev/null -w "%{http_code}" -X POST "${BASE_URL}/api/v1/payment/refund" \
+        -H "Content-Type: application/json" \
+        -d "{\"transaction_id\": \"${txn_id}\", \"amount\": ${amount}}"
+}
+
+call_payment_transactions() {
+    local limit=$((RANDOM % 20 + 5))
+    curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/api/v1/payment/transactions?limit=${limit}"
+}
+
+# Auth namespace endpoints
+call_auth_login() {
+    local user_id=$((RANDOM % 1000))
+    local domains=("example.com" "test.org" "demo.io" "company.net")
+    local domain=${domains[$RANDOM % ${#domains[@]}]}
+
+    curl -s -o /dev/null -w "%{http_code}" -X POST "${BASE_URL}/api/v1/auth/login" \
+        -H "Content-Type: application/json" \
+        -d "{\"email\": \"user${user_id}@${domain}\", \"password\": \"password123\"}"
+}
+
+call_auth_logout() {
+    local session_id="sess_$(openssl rand -hex 16)"
+    local types=("user_initiated" "timeout" "admin_forced")
+    local type=${types[$RANDOM % ${#types[@]}]}
+
+    curl -s -o /dev/null -w "%{http_code}" -X POST "${BASE_URL}/api/v1/auth/logout" \
+        -H "Content-Type: application/json" \
+        -d "{\"session_id\": \"${session_id}\", \"type\": \"${type}\"}"
+}
+
+call_auth_refresh() {
+    curl -s -o /dev/null -w "%{http_code}" -X POST "${BASE_URL}/api/v1/auth/refresh" \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer tok_$(openssl rand -hex 32)"
+}
+
+call_auth_verify() {
+    curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/api/v1/auth/verify" \
+        -H "Authorization: Bearer tok_$(openssl rand -hex 32)"
+}
+
+call_auth_register() {
+    local user_id=$((RANDOM % 100000))
+    local domains=("gmail.com" "yahoo.com" "outlook.com" "proton.me")
+    local domain=${domains[$RANDOM % ${#domains[@]}]}
+
+    curl -s -o /dev/null -w "%{http_code}" -X POST "${BASE_URL}/api/v1/auth/register" \
+        -H "Content-Type: application/json" \
+        -d "{\"email\": \"newuser${user_id}@${domain}\", \"password\": \"securepass123\"}"
+}
+
+# Internal namespace endpoints
+call_internal_health() {
+    curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/api/v1/internal/health"
+}
+
+call_internal_metrics() {
+    local formats=("json" "prometheus" "statsd")
+    local format=${formats[$RANDOM % ${#formats[@]}]}
+    curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/api/v1/internal/metrics?format=${format}"
+}
+
+call_internal_sync() {
+    local types=("full" "incremental" "delta")
+    local type=${types[$RANDOM % ${#types[@]}]}
+    local targets=("all" "users" "orders" "inventory")
+    local target=${targets[$RANDOM % ${#targets[@]}]}
+
+    curl -s -o /dev/null -w "%{http_code}" -X POST "${BASE_URL}/api/v1/internal/sync" \
+        -H "Content-Type: application/json" \
+        -d "{\"type\": \"${type}\", \"target\": \"${target}\"}"
+}
+
+call_internal_cache_invalidate() {
+    local keys=("user:*" "session:*" "product:*" "order:*")
+    local key=${keys[$RANDOM % ${#keys[@]}]}
+    local pattern=$((RANDOM % 2))
+
+    curl -s -o /dev/null -w "%{http_code}" -X POST "${BASE_URL}/api/v1/internal/cache/invalidate" \
+        -H "Content-Type: application/json" \
+        -d "{\"key\": \"${key}\", \"pattern\": ${pattern}}"
+}
+
+call_internal_config() {
+    curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/api/v1/internal/config"
+}
+
+call_internal_trigger_job() {
+    local job_types=("cleanup" "report" "notification" "sync" "backup")
+    local job_type=${job_types[$RANDOM % ${#job_types[@]}]}
+    local priorities=("low" "normal" "high" "critical")
+    local priority=${priorities[$RANDOM % ${#priorities[@]}]}
+
+    curl -s -o /dev/null -w "%{http_code}" -X POST "${BASE_URL}/api/v1/internal/jobs/trigger" \
+        -H "Content-Type: application/json" \
+        -d "{\"job_type\": \"${job_type}\", \"priority\": \"${priority}\"}"
+}
+
+# Public endpoints (NO service.namespace)
+call_public_ping() {
+    curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/api/v1/public/ping"
+}
+
+call_public_version() {
+    curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/api/v1/public/version"
+}
+
+call_public_echo() {
+    curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/api/v1/public/echo?test=value"
+}
+
+# Users namespace endpoints
+call_users_index() {
+    curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/api/v1/users"
+}
+
+call_users_show() {
+    local user_id=$((RANDOM % 100 + 1))
+    curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/api/v1/users/${user_id}"
+}
+
+call_users_create() {
+    local user_id=$((RANDOM % 100000))
+    curl -s -o /dev/null -w "%{http_code}" -X POST "${BASE_URL}/api/v1/users" \
+        -H "Content-Type: application/json" \
+        -d "{\"name\": \"User ${user_id}\", \"email\": \"user${user_id}@example.com\"}"
+}
+
+# Array of all endpoint functions with weights (more common operations have higher weight)
+declare -a ENDPOINTS=(
+    # Payment (weight: 30%)
+    "call_payment_status"
+    "call_payment_status"
+    "call_payment_process"
+    "call_payment_process"
+    "call_payment_process"
+    "call_payment_process"
+    "call_payment_refund"
+    "call_payment_refund"
+    "call_payment_transactions"
+
+    # Auth (weight: 35%)
+    "call_auth_login"
+    "call_auth_login"
+    "call_auth_login"
+    "call_auth_login"
+    "call_auth_verify"
+    "call_auth_verify"
+    "call_auth_verify"
+    "call_auth_refresh"
+    "call_auth_refresh"
+    "call_auth_logout"
+    "call_auth_register"
+
+    # Internal (weight: 30%)
+    "call_internal_health"
+    "call_internal_health"
+    "call_internal_metrics"
+    "call_internal_metrics"
+    "call_internal_config"
+    "call_internal_config"
+    "call_internal_sync"
+    "call_internal_cache_invalidate"
+    "call_internal_trigger_job"
+
+    # Users (weight: 5%)
+    "call_users_show"
+
+    # Public - NO service.namespace (weight: 10%)
+    "call_public_ping"
+    "call_public_ping"
+    "call_public_version"
+    "call_public_echo"
+)
+
+make_request() {
+    local endpoint=${ENDPOINTS[$RANDOM % ${#ENDPOINTS[@]}]}
+    local status_code
+
+    status_code=$($endpoint 2>/dev/null || echo "000")
+
+    ((TOTAL_REQUESTS++))
+
+    if [[ "$status_code" =~ ^2[0-9][0-9]$ ]]; then
+        ((SUCCESSFUL_REQUESTS++))
+        echo -ne "\r${GREEN}✓${NC} [${TOTAL_REQUESTS}] ${endpoint##call_} -> ${status_code}     "
+    elif [[ "$status_code" =~ ^4[0-9][0-9]$ ]]; then
+        ((SUCCESSFUL_REQUESTS++))  # 4xx are expected for auth failures, etc.
+        echo -ne "\r${YELLOW}⚠${NC} [${TOTAL_REQUESTS}] ${endpoint##call_} -> ${status_code}     "
+    else
+        ((FAILED_REQUESTS++))
+        echo -ne "\r${RED}✗${NC} [${TOTAL_REQUESTS}] ${endpoint##call_} -> ${status_code}     "
+    fi
+}
+
+run_traffic() {
+    local worker_id=$1
+    local end_time=$(($(date +%s) + DURATION))
+
+    while [[ $(date +%s) -lt $end_time ]]; do
+        make_request
+        sleep "$REQUEST_DELAY"
+    done
+}
+
+print_banner() {
+    echo ""
+    echo -e "${BLUE}╔══════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${BLUE}║${NC}           ${GREEN}Chaos Traffic Generator for Rails API${NC}              ${BLUE}║${NC}"
+    echo -e "${BLUE}║${NC}                  ${YELLOW}OpenTelemetry Edition${NC}                       ${BLUE}║${NC}"
+    echo -e "${BLUE}╚══════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+}
+
+print_config() {
+    log_info "Configuration:"
+    echo "  • Base URL:     ${BASE_URL}"
+    echo "  • Duration:     ${DURATION}s"
+    echo "  • Concurrency:  ${CONCURRENCY}"
+    echo "  • Request Delay: ${REQUEST_DELAY}s"
+    echo ""
+    log_info "Namespaces being tested:"
+    echo "  • ${GREEN}payment${NC}  - /api/v1/payment/*"
+    echo "  • ${GREEN}auth${NC}     - /api/v1/auth/*"
+    echo "  • ${GREEN}internal${NC} - /api/v1/internal/*"
+    echo "  • ${GREEN}users${NC}    - /api/v1/users/*"
+    echo ""
+}
+
+print_summary() {
+    echo ""
+    echo ""
+    log_info "Traffic Generation Complete!"
+    echo ""
+    echo -e "  ${GREEN}Total Requests:${NC}      ${TOTAL_REQUESTS}"
+    echo -e "  ${GREEN}Successful:${NC}          ${SUCCESSFUL_REQUESTS}"
+    echo -e "  ${RED}Failed:${NC}              ${FAILED_REQUESTS}"
+
+    if [[ $TOTAL_REQUESTS -gt 0 ]]; then
+        local success_rate=$((SUCCESSFUL_REQUESTS * 100 / TOTAL_REQUESTS))
+        echo -e "  ${BLUE}Success Rate:${NC}        ${success_rate}%"
+    fi
+    echo ""
+}
+
+check_server() {
+    log_info "Checking if server is running at ${BASE_URL}..."
+
+    if curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/api/v1/internal/health" | grep -q "200\|503"; then
+        log_success "Server is running!"
+        return 0
+    else
+        log_error "Server is not responding at ${BASE_URL}"
+        log_info "Please start the server first with: bundle exec rails s"
+        exit 1
+    fi
+}
+
+main() {
+    print_banner
+    print_config
+    check_server
+
+    log_info "Starting traffic generation for ${DURATION} seconds..."
+    echo ""
+
+    trap print_summary EXIT
+
+    # Run traffic generators
+    for i in $(seq 1 $CONCURRENCY); do
+        run_traffic $i &
+    done
+
+    wait
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -u|--url)
+            BASE_URL="$2"
+            shift 2
+            ;;
+        -d|--duration)
+            DURATION="$2"
+            shift 2
+            ;;
+        -c|--concurrency)
+            CONCURRENCY="$2"
+            shift 2
+            ;;
+        -r|--rate)
+            REQUEST_DELAY="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  -u, --url URL         Base URL (default: http://localhost:3000)"
+            echo "  -d, --duration SECS   Duration in seconds (default: 300)"
+            echo "  -c, --concurrency N   Number of concurrent workers (default: 5)"
+            echo "  -r, --rate SECS       Delay between requests (default: 0.1)"
+            echo "  -h, --help            Show this help message"
+            echo ""
+            echo "Environment variables:"
+            echo "  BASE_URL              Same as -u"
+            echo "  DURATION              Same as -d"
+            echo "  CONCURRENCY           Same as -c"
+            echo "  REQUEST_DELAY         Same as -r"
+            exit 0
+            ;;
+        *)
+            log_error "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+main

--- a/ruby/rails-api/scripts/simple_traffic.sh
+++ b/ruby/rails-api/scripts/simple_traffic.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Simple traffic generator that generates rich traces
+
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+DURATION="${DURATION:-600}"  # 10 minutes
+count=0
+end_time=$(($(date +%s) + DURATION))
+
+echo "Generating traffic for ${DURATION} seconds..."
+
+while [[ $(date +%s) -lt $end_time ]]; do
+    # Randomly pick endpoint category
+    r=$((RANDOM % 100))
+    
+    if [[ $r -lt 35 ]]; then
+        # Payment endpoints (35%) - Rich traces with DB, cache, external calls
+        case $((RANDOM % 4)) in
+            0) curl -s -o /dev/null "${BASE_URL}/api/v1/payment/status" ;;
+            1) curl -s -o /dev/null -X POST "${BASE_URL}/api/v1/payment/process" \
+                   -H "Content-Type: application/json" \
+                   -d "{\"amount\": $((RANDOM % 500 + 10)).99, \"currency\": \"USD\"}" ;;
+            2) curl -s -o /dev/null -X POST "${BASE_URL}/api/v1/payment/refund" \
+                   -H "Content-Type: application/json" \
+                   -d "{\"transaction_id\": \"txn_$(openssl rand -hex 8)\", \"amount\": $((RANDOM % 100)).00}" ;;
+            3) curl -s -o /dev/null "${BASE_URL}/api/v1/payment/transactions?limit=$((RANDOM % 10 + 5))" ;;
+        esac
+    elif [[ $r -lt 65 ]]; then
+        # Auth endpoints (30%) - With cache and external calls
+        case $((RANDOM % 5)) in
+            0) curl -s -o /dev/null -X POST "${BASE_URL}/api/v1/auth/login" \
+                   -H "Content-Type: application/json" \
+                   -d "{\"email\": \"user$((RANDOM % 1000))@example.com\"}" ;;
+            1) curl -s -o /dev/null -X POST "${BASE_URL}/api/v1/auth/logout" \
+                   -H "Content-Type: application/json" \
+                   -d "{\"session_id\": \"sess_$(openssl rand -hex 16)\"}" ;;
+            2) curl -s -o /dev/null -X POST "${BASE_URL}/api/v1/auth/refresh" ;;
+            3) curl -s -o /dev/null "${BASE_URL}/api/v1/auth/verify" ;;
+            4) curl -s -o /dev/null -X POST "${BASE_URL}/api/v1/auth/register" \
+                   -H "Content-Type: application/json" \
+                   -d "{\"email\": \"new$((RANDOM % 10000))@test.com\"}" ;;
+        esac
+    elif [[ $r -lt 85 ]]; then
+        # Internal endpoints (20%)
+        case $((RANDOM % 5)) in
+            0) curl -s -o /dev/null "${BASE_URL}/api/v1/internal/health" ;;
+            1) curl -s -o /dev/null "${BASE_URL}/api/v1/internal/metrics" ;;
+            2) curl -s -o /dev/null -X POST "${BASE_URL}/api/v1/internal/sync" \
+                   -H "Content-Type: application/json" -d '{"type": "full"}' ;;
+            3) curl -s -o /dev/null "${BASE_URL}/api/v1/internal/config" ;;
+            4) curl -s -o /dev/null -X POST "${BASE_URL}/api/v1/internal/jobs/trigger" \
+                   -H "Content-Type: application/json" -d '{"job_type": "cleanup"}' ;;
+        esac
+    else
+        # Public endpoints (15%) - NO service.namespace
+        case $((RANDOM % 3)) in
+            0) curl -s -o /dev/null "${BASE_URL}/api/v1/public/ping" ;;
+            1) curl -s -o /dev/null "${BASE_URL}/api/v1/public/version" ;;
+            2) curl -s -o /dev/null "${BASE_URL}/api/v1/public/echo?data=test" ;;
+        esac
+    fi
+    
+    ((count++))
+    if [[ $((count % 50)) -eq 0 ]]; then
+        echo -ne "\rRequests: $count ($(( ($(date +%s) - end_time + DURATION) ))s elapsed)    "
+    fi
+    
+    sleep 0.15
+done
+
+echo ""
+echo "Traffic generation complete! Total requests: $count"


### PR DESCRIPTION
Add service namespaces (auth, payment, internal, public) with deep tracing:
- Custom NamespaceSpanProcessor to add service.namespace attribute per request
- CacheService, DatabaseService, ExternalApiService with child spans
- CurrentRequest model for request-scoped namespace storage
- Traffic generator scripts for testing trace visibility