### PR TITLE
fix: Remove invalid IpProtocolRanges parameter from Lambda security group function

### DIFF
--- a/aws/rds-postgresql-ecs/cloudformation/quick-setup.yaml
+++ b/aws/rds-postgresql-ecs/cloudformation/quick-setup.yaml
@@ -631,8 +631,7 @@ Resources:
                                   'IpProtocol': 'tcp',
                                   'FromPort': port,
                                   'ToPort': port,
-                                  'UserIdGroupPairs': [{'GroupId': collector_sg}],
-                                  'IpProtocolRanges': []
+                                  'UserIdGroupPairs': [{'GroupId': collector_sg}]
                               }]
                           )
                           print(f"Added ingress to {sg_id}")


### PR DESCRIPTION
## Summary

Fixes CloudFormation deployment failure caused by invalid parameter in the RDSSecurityGroupIngressFunction Lambda.

## Issue

Customer deployment failed with error:
```
Unknown parameter in IpPermissions[0]: "IpProtocolRanges", 
must be one of: IpProtocol, FromPort, ToPort, UserIdGroupPairs, 
IpRanges, Ipv6Ranges, PrefixListIds
```

**CloudFormation Status:**
- `RDSSecurityGroupIngress` - CREATE_FAILED
- `ExecutionRole` - CREATE_FAILED (cancelled due to rollback)
- Stack rolled back completely

## Root Cause

The Lambda function that adds security group ingress rules (introduced in PR #95) had a typo:

**Line 635 in `cloudformation/quick-setup.yaml`:**
```python
IpPermissions=[{
    'IpProtocol': 'tcp',
    'FromPort': port,
    'ToPort': port,
    'UserIdGroupPairs': [{'GroupId': collector_sg}],
    'IpProtocolRanges': []  # ❌ This parameter doesn't exist!
}]
```

**Valid parameters for EC2 authorize_security_group_ingress:**
- `IpProtocol`, `FromPort`, `ToPort`, `UserIdGroupPairs`, `IpRanges`, `Ipv6Ranges`, `PrefixListIds`

`IpProtocolRanges` is **not a valid parameter**.

## Fix

Removed the invalid `'IpProtocolRanges': []` line:

```python
IpPermissions=[{
    'IpProtocol': 'tcp',
    'FromPort': port,
    'ToPort': port,
    'UserIdGroupPairs': [{'GroupId': collector_sg}]  # ✅ Clean
}]
```

When using `UserIdGroupPairs` for security group references, IP-related parameters are not needed.

## Changes

**File:** `aws/rds-postgresql-ecs/cloudformation/quick-setup.yaml`
- **Line 635:** Removed `'IpProtocolRanges': []`
- **Changes:** 1 insertion, 2 deletions

## Testing

- [x] Customer reported CloudFormation CREATE_FAILED
- [x] Identified issue via Lambda logs
- [x] Applied fix
- [ ] Customer to re-deploy and confirm success

## Impact

**Before:** CloudFormation deployment fails immediately during stack creation
**After:** Lambda successfully adds ingress rules to all RDS security groups

## Related

- Introduced in: PR #95
- Customer issue: CloudFormation rollback on first deployment
- Lambda log stream: `2026/01/13/[$LATEST]8aafb59122864e55b6a66d2790aa0a71`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>