### PR TITLE
Fix RDS PostgreSQL multi-database monitoring setup

### DIFF
--- a/aws/rds-postgresql-ecs/.env.example
+++ b/aws/rds-postgresql-ecs/.env.example
@@ -7,7 +7,10 @@ PG_PASSWORD=<your-monitoring-password>
 # PostgreSQL Connection (for standalone usage, not needed for quick_setup.sh)
 PG_ENDPOINT=<your-rds-endpoint>
 PG_PORT=5432
-PG_DATABASE=<your-database-name>
+# IMPORTANT: Set this to 'postgres' to monitor ALL databases on the instance
+# The PostgreSQL receiver can see metrics for all databases from system views
+# However, you must run setup-db-user.sql on EACH database for query-level monitoring
+PG_DATABASE=postgres
 
 # AWS Configuration
 AWS_REGION=us-east-1

--- a/aws/rds-postgresql-ecs/config/otel-collector-config.yaml
+++ b/aws/rds-postgresql-ecs/config/otel-collector-config.yaml
@@ -8,6 +8,11 @@ receivers:
     transport: tcp
     username: ${env:PG_USERNAME}
     password: ${env:PG_PASSWORD}
+    # Monitor all databases on the RDS instance
+    # When connected to 'postgres', the receiver sees instance-wide metrics for ALL databases
+    # via system catalogs (pg_stat_database, etc.)
+    # For query-level monitoring (pg_stat_statements), you must run setup-db-user.sql
+    # on each database you want to monitor
     databases:
       - ${env:PG_DATABASE}
     collection_interval: 30s

--- a/aws/rds-postgresql-ecs/scripts/setup-all-databases.sh
+++ b/aws/rds-postgresql-ecs/scripts/setup-all-databases.sh
@@ -158,7 +158,6 @@ IFS=',' read -ra DB_ARRAY <<< "$DATABASES"
 TOTAL=${#DB_ARRAY[@]}
 SUCCESS=0
 FAILED=0
-SKIPPED=0
 
 print_info ""
 print_info "Starting setup on $TOTAL database(s)..."
@@ -197,9 +196,6 @@ print_info "Total databases: $TOTAL"
 print_success "Successful: $SUCCESS"
 if [[ $FAILED -gt 0 ]]; then
     print_error "Failed: $FAILED"
-fi
-if [[ $SKIPPED -gt 0 ]]; then
-    print_warning "Skipped: $SKIPPED"
 fi
 print_info "==================================================================="
 

--- a/aws/rds-postgresql-ecs/scripts/setup-all-databases.sh
+++ b/aws/rds-postgresql-ecs/scripts/setup-all-databases.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+
+# =============================================================================
+# PostgreSQL Multi-Database Monitoring Setup Script
+# Runs setup-db-user.sql on all databases in an RDS PostgreSQL instance
+# =============================================================================
+
+set -e  # Exit on error
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SQL_SCRIPT="${SCRIPT_DIR}/setup-db-user.sql"
+
+# Function to print colored messages
+print_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to display usage
+usage() {
+    cat << EOF
+Usage: $0 -h HOST -U USER [-p PORT] [-d DATABASES]
+
+Setup OpenTelemetry monitoring user across all databases in RDS PostgreSQL.
+
+Required arguments:
+  -h HOST        PostgreSQL host (e.g., your-rds.amazonaws.com)
+  -U USER        PostgreSQL admin user (usually 'postgres')
+
+Optional arguments:
+  -p PORT        PostgreSQL port (default: 5432)
+  -d DATABASES   Comma-separated list of databases (default: auto-detect all)
+  --help         Show this help message
+
+Examples:
+  # Setup on all databases (auto-detect)
+  $0 -h my-rds.amazonaws.com -U postgres
+
+  # Setup on specific databases only
+  $0 -h my-rds.amazonaws.com -U postgres -d "app_db,analytics_db,staging_db"
+
+  # With custom port
+  $0 -h my-rds.amazonaws.com -U postgres -p 5433
+
+Environment variables:
+  PGPASSWORD     Set this to avoid password prompts
+                 Example: export PGPASSWORD='your_password'
+
+EOF
+}
+
+# Parse command line arguments
+HOST=""
+USER=""
+PORT="5432"
+DATABASES=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h)
+            HOST="$2"
+            shift 2
+            ;;
+        -U)
+            USER="$2"
+            shift 2
+            ;;
+        -p)
+            PORT="$2"
+            shift 2
+            ;;
+        -d)
+            DATABASES="$2"
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# Validate required arguments
+if [[ -z "$HOST" ]] || [[ -z "$USER" ]]; then
+    print_error "Missing required arguments"
+    usage
+    exit 1
+fi
+
+# Check if SQL script exists
+if [[ ! -f "$SQL_SCRIPT" ]]; then
+    print_error "SQL script not found: $SQL_SCRIPT"
+    exit 1
+fi
+
+# Check if psql is installed
+if ! command -v psql &> /dev/null; then
+    print_error "psql command not found. Please install PostgreSQL client."
+    exit 1
+fi
+
+print_info "==================================================================="
+print_info "PostgreSQL Multi-Database Monitoring Setup"
+print_info "==================================================================="
+print_info "Host: $HOST"
+print_info "Port: $PORT"
+print_info "User: $USER"
+print_info "SQL Script: $SQL_SCRIPT"
+print_info "==================================================================="
+
+# If DATABASES not specified, auto-detect all databases
+if [[ -z "$DATABASES" ]]; then
+    print_info "Auto-detecting databases..."
+
+    # Get list of databases, excluding templates and system databases
+    DATABASES=$(PAGER=cat psql -h "$HOST" -p "$PORT" -U "$USER" -d postgres -t -P pager=off -c \
+        "SELECT datname FROM pg_database WHERE datistemplate = false AND datname NOT IN ('rdsadmin') ORDER BY datname;" \
+        2>/dev/null | tr -d ' ' | grep -v '^$' | paste -sd ',' -)
+
+    if [[ -z "$DATABASES" ]]; then
+        print_error "Failed to detect databases. Please specify databases with -d option."
+        exit 1
+    fi
+
+    print_success "Found databases: $DATABASES"
+else
+    print_info "Using specified databases: $DATABASES"
+fi
+
+# Convert comma-separated string to array
+IFS=',' read -ra DB_ARRAY <<< "$DATABASES"
+
+# Counters
+TOTAL=${#DB_ARRAY[@]}
+SUCCESS=0
+FAILED=0
+SKIPPED=0
+
+print_info ""
+print_info "Starting setup on $TOTAL database(s)..."
+print_info ""
+
+# Process each database
+for db in "${DB_ARRAY[@]}"; do
+    # Trim whitespace
+    db=$(echo "$db" | xargs)
+
+    print_info "-------------------------------------------------------------------"
+    print_info "Processing database: $db"
+    print_info "-------------------------------------------------------------------"
+
+    # Run the setup script with pager completely disabled
+    # Using multiple methods to ensure no pager interference:
+    # 1. PAGER=cat - override system pager
+    # 2. -P pager=off - PostgreSQL pager setting
+    # 3. --pset=pager=off - Alternative pager setting
+    if PAGER=cat psql -h "$HOST" -p "$PORT" -U "$USER" -d "$db" -P pager=off --pset=pager=off -f "$SQL_SCRIPT" 2>&1; then
+        print_success "✓ Setup completed successfully for database: $db"
+        ((SUCCESS++))
+    else
+        print_error "✗ Setup failed for database: $db"
+        ((FAILED++))
+    fi
+
+    print_info ""
+done
+
+# Summary
+print_info "==================================================================="
+print_info "SETUP SUMMARY"
+print_info "==================================================================="
+print_info "Total databases: $TOTAL"
+print_success "Successful: $SUCCESS"
+if [[ $FAILED -gt 0 ]]; then
+    print_error "Failed: $FAILED"
+fi
+if [[ $SKIPPED -gt 0 ]]; then
+    print_warning "Skipped: $SKIPPED"
+fi
+print_info "==================================================================="
+
+# Exit with appropriate code
+if [[ $FAILED -gt 0 ]]; then
+    print_error "Some databases failed to setup. Please review the errors above."
+    exit 1
+else
+    print_success "All databases setup successfully!"
+    print_info ""
+    print_info "Next steps:"
+    print_info "1. Verify the setup by connecting with otel_monitor user"
+    print_info "2. Test queries: SELECT * FROM otel_monitor.pg_stat_statements() LIMIT 5;"
+    print_info "3. Configure your OpenTelemetry collector to use the otel_monitor user"
+    exit 0
+fi

--- a/aws/rds-postgresql-ecs/scripts/setup-db-user.sql
+++ b/aws/rds-postgresql-ecs/scripts/setup-db-user.sql
@@ -355,7 +355,17 @@ Then run this full script on each database to create the schema and functions.
 -- To remove all monitoring objects:
 DROP SCHEMA IF EXISTS otel_monitor CASCADE;
 REVOKE pg_monitor FROM otel_monitor;
-REVOKE CONNECT ON DATABASE current_database() FROM otel_monitor;
+
+-- Revoke CONNECT using dynamic SQL (same pattern as GRANT above)
+DO $$
+DECLARE
+    db_name TEXT;
+BEGIN
+    SELECT current_database() INTO db_name;
+    EXECUTE format('REVOKE CONNECT ON DATABASE %I FROM otel_monitor', db_name);
+END
+$$;
+
 DROP USER IF EXISTS otel_monitor;
 */
 


### PR DESCRIPTION
## Problem

Customers with multiple databases on a single RDS PostgreSQL instance were experiencing issues where only one database was being monitored.

### Root Causes

1. **Syntax Error in setup-db-user.sql (Line 237)**
   - `GRANT CONNECT ON DATABASE current_database()` is invalid SQL
   - Functions cannot be used directly in GRANT statements
   - Caused script failures during customer deployments

2. **PostgreSQL Version Incompatibility**
   - `slow_queries` view referenced `query_id` column
   - `query_id` only exists in PostgreSQL 14+
   - Failed on PostgreSQL 11-13 instances (common in RDS)

3. **Multi-Database Setup Not Clear**
   - Monitoring setup only ran on one database
   - `pg_stat_statements` and monitoring views are database-specific
   - Customers weren't aware they needed to run setup on EACH database
   - No tooling to make multi-database setup easy

## Solution

### 1. Fixed Syntax Error
- Replaced direct function call with dynamic SQL using `DO $$ ... $$` block
- Uses `format()` with `%I` for safe identifier interpolation
- Now works correctly on all PostgreSQL versions

### 2. Added Version Compatibility
- Detects PostgreSQL version at runtime
- Creates `slow_queries` view **with** `query_id` for PostgreSQL 14+
- Creates `slow_queries` view **without** `query_id` for PostgreSQL 11-13
- Eliminates all version-specific errors

### 3. Created Multi-Database Helper Script
**New file: `scripts/setup-all-databases.sh`**

Features:
- ✅ Auto-detects all databases on RDS instance
- ✅ Runs setup-db-user.sql on each database automatically
- ✅ Proper pager handling (no interactive prompts blocking execution)
- ✅ Colored output with progress tracking
- ✅ Summary report showing successes/failures
- ✅ Makes multi-database setup trivial for customers

Usage:
```bash
cd scripts
export PGPASSWORD='your-master-password'
./setup-all-databases.sh -h your-rds-endpoint -U postgres
```

### 4. Updated Documentation
- **README.md**: Added multi-database setup instructions with both automated and manual options
- **QUICK_SETUP.md**: Added Step 1.5 explaining multi-database requirement
- **.env.example**: Clarified `PG_DATABASE` behavior
- **otel-collector-config.yaml**: Explained instance-wide vs query-level metrics

## Testing

Tested on `last9-last9-alpha-postgres` (PostgreSQL 11.22) with 4 databases:

### Before
- ❌ **ai_db**: No monitoring
- ✅ **external_api**: Monitoring (only this worked)
- ❌ **last9api**: No monitoring  
- ❌ **postgres**: No monitoring

### After running setup-all-databases.sh
```
[INFO] Found databases: ai_db,external_api,last9api,postgres
[SUCCESS] ✓ Setup completed successfully for database: ai_db
[SUCCESS] ✓ Setup completed successfully for database: external_api
[SUCCESS] ✓ Setup completed successfully for database: last9api
[SUCCESS] ✓ Setup completed successfully for database: postgres
[SUCCESS] All databases setup successfully!
```

### Verification Results
| Database | pg_stat_statements | blocking_queries | slow_queries | wait_events |
|----------|-------------------|------------------|--------------|-------------|
| ai_db | ✅ 4,794 queries | ✅ Accessible | ✅ Works (no errors) | ✅ Accessible |
| external_api | ✅ 4,798 queries | ✅ Accessible | ✅ Works (no errors) | ✅ Accessible |
| last9api | ✅ 4,802 queries | ✅ Accessible | ✅ Works (no errors) | ✅ Accessible |
| postgres | ✅ 4,806 queries | ✅ Accessible | ✅ Works (no errors) | ✅ Accessible |

## Impact

### For Customers
1. ✅ Clear documentation about multi-database requirements
2. ✅ Automated script to set up all databases easily
3. ✅ No syntax errors on any PostgreSQL version
4. ✅ Successfully monitor ALL databases on RDS instances
5. ✅ Complete query-level metrics from pg_stat_statements

### For Support Team
1. ✅ Fewer customer issues with database setup
2. ✅ Easy troubleshooting with automated script
3. ✅ Clear documentation to share with customers

## Files Changed

- `aws/rds-postgresql-ecs/scripts/setup-db-user.sql` - Fixed syntax error & added version compatibility
- `aws/rds-postgresql-ecs/scripts/setup-all-databases.sh` - **NEW** automated setup script
- `aws/rds-postgresql-ecs/README.md` - Added multi-database documentation
- `aws/rds-postgresql-ecs/QUICK_SETUP.md` - Added Step 1.5 with detailed explanation
- `aws/rds-postgresql-ecs/.env.example` - Clarified PG_DATABASE usage
- `aws/rds-postgresql-ecs/config/otel-collector-config.yaml` - Updated comments

## Checklist

- [x] Tested on real RDS PostgreSQL instance
- [x] Verified all 4 databases now have monitoring
- [x] Confirmed no syntax errors on PostgreSQL 11
- [x] Documentation updated
- [x] Helper script created and tested
- [x] All monitoring views and functions working

## Additional Notes

**Instance-wide metrics vs Query-level metrics:**
- The collector connects to ONE database (typically `postgres`)
- Instance-wide metrics (connections, transactions) are collected for ALL databases automatically via system catalogs
- Query-level metrics (`pg_stat_statements`) only work for databases where setup was run
- This is why the multi-database setup is critical