### PR TITLE
fix: Add exception tracking for Rails 5.x OTel instrumentation

### DIFF
--- a/ruby/rails5.2/README.md
+++ b/ruby/rails5.2/README.md
@@ -1,24 +1,129 @@
-# README
+# Rails 5.2 OpenTelemetry Example
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+This example demonstrates OpenTelemetry instrumentation for a Rails 5.2 API application, sending traces to [Last9](https://last9.io).
 
-Things you may want to cover:
+## Requirements
 
-* Ruby version
+- Ruby 2.7.x
+- Rails 5.2.x
+- Bundler
 
-* System dependencies
+## Quick Start
 
-* Configuration
+1. **Install dependencies:**
+   ```bash
+   bundle install
+   ```
 
-* Database creation
+2. **Configure environment variables:**
+   ```bash
+   export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <your-credentials>"
+   export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp.last9.io:443"
+   export OTEL_TRACES_SAMPLER="always_on"
+   export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=local"
+   ```
 
-* Database initialization
+3. **Start the server:**
+   ```bash
+   bundle exec rails server
+   ```
 
-* How to run the test suite
+4. **Test the endpoints:**
+   ```bash
+   curl http://localhost:3000/health
+   curl http://localhost:3000/users
+   curl http://localhost:3000/error
+   ```
 
-* Services (job queues, cache servers, search engines, etc.)
+## Available Endpoints
 
-* Deployment instructions
+| Endpoint | Description |
+|----------|-------------|
+| `GET /health` | Health check |
+| `GET /users` | Returns mock user data |
+| `GET /calculate?n=10` | Fibonacci calculation with custom spans |
+| `GET /error` | Triggers an exception (for testing error traces) |
+| `POST /process_order` | Nested spans example |
+| `GET /external_api` | Simulated external API call |
 
-* ...
+## OpenTelemetry Configuration
+
+The OTel configuration is in `config/initializers/opentelemetry.rb`:
+
+- Uses OTLP exporter to send traces to Last9
+- Batch span processor for efficient export
+- Auto-instrumentation for Rails, ActiveRecord, Rack, and more
+
+## Exception Tracking Fix for Rails 5.x
+
+Rails 5.x users may encounter a known bug where **controller exceptions are not recorded as span events**. This is due to a bug in `opentelemetry-instrumentation-action_pack` v0.4.x ([GitHub Issue #635](https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/635)).
+
+The fix exists in action_pack v0.9.0+, but that version requires Rails 6.1+.
+
+### Solution
+
+This example includes a drop-in fix: `config/initializers/otel_exception_tracking.rb`
+
+**For your own Rails 5.x application:**
+
+1. Copy `config/initializers/otel_exception_tracking.rb` to your app
+2. No other code changes required
+3. Exceptions will automatically be captured with:
+   - `exception.type`
+   - `exception.message`
+   - `exception.stacktrace`
+   - Span status set to `ERROR`
+
+### How It Works
+
+The fix uses two mechanisms:
+
+1. **Rack Middleware** - Catches unhandled exceptions that bubble up
+2. **ActiveSupport::Notifications** - Catches exceptions handled by `rescue_from`
+
+### Manual Recording (Optional)
+
+You can also manually record exceptions anywhere in your code:
+
+```ruby
+begin
+  # risky operation
+rescue => e
+  OtelExceptionTracking.record(e)
+  raise
+end
+```
+
+## Gem Versions
+
+Key OpenTelemetry gems used:
+
+- `opentelemetry-sdk` ~> 1.2
+- `opentelemetry-exporter-otlp` ~> 0.24
+- `opentelemetry-instrumentation-rails` = 0.24.1
+- `opentelemetry-instrumentation-all` ~> 0.30
+
+## Troubleshooting
+
+### Exceptions not appearing in traces?
+
+1. Ensure `otel_exception_tracking.rb` is loaded AFTER `opentelemetry.rb`
+   - Rename to `z_otel_exception_tracking.rb` if needed for alphabetical load order
+2. Check that OpenTelemetry is properly configured
+3. Verify your OTLP endpoint and credentials
+
+### Middleware load order
+
+You can verify the middleware is installed:
+
+```bash
+bundle exec rails middleware
+```
+
+Look for `OpenTelemetry::Instrumentation::ExceptionTracking::Middleware` before `ActionDispatch::ShowExceptions`.
+
+## References
+
+- [OpenTelemetry Ruby](https://opentelemetry.io/docs/languages/ruby/)
+- [Last9 Documentation](https://docs.last9.io/)
+- [Exception Recording Bug #635](https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/635)

--- a/ruby/rails5.2/app/controllers/test_controller.rb
+++ b/ruby/rails5.2/app/controllers/test_controller.rb
@@ -38,12 +38,10 @@ class TestController < ApplicationController
     render json: { input: params[:n], result: result }
   end
 
-  # Endpoint that simulates an error
+  # Endpoint that simulates an error - exception will be captured by OTel
+  # Test with: curl http://localhost:3000/error
   def error
-    # This will generate an error trace
-    raise StandardError, "Simulated error for testing traces"
-  rescue => e
-    render json: { error: e.message }, status: 500
+    raise StandardError, "Simulated error for testing OTel exception tracking"
   end
 
   # Endpoint with nested spans
@@ -99,4 +97,5 @@ class TestController < ApplicationController
     return n if n <= 1
     fibonacci(n - 1) + fibonacci(n - 2)
   end
+
 end

--- a/ruby/rails5.2/config/initializers/otel_exception_tracking.rb
+++ b/ruby/rails5.2/config/initializers/otel_exception_tracking.rb
@@ -1,0 +1,73 @@
+# OpenTelemetry Exception Tracking for Rails 5.x
+#
+# This file fixes a known bug in opentelemetry-instrumentation-action_pack v0.4.x
+# where controller exceptions are not recorded as span events.
+#
+# Bug reference: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/635
+#
+# INSTALLATION:
+#   1. Copy this file to config/initializers/otel_exception_tracking.rb
+#   2. Ensure OpenTelemetry is configured BEFORE this file loads
+#      (rename to z_otel_exception_tracking.rb if needed for load order)
+#   3. No other code changes required - exceptions are automatically captured
+#
+# WHAT IT DOES:
+#   - Records exception details on the current OTel span when errors occur
+#   - Adds exception.type, exception.message, exception.stacktrace as span event
+#   - Sets span status to ERROR
+#   - Captures BOTH:
+#     * Unhandled exceptions (via Rack middleware)
+#     * Handled exceptions via rescue_from (via ActiveSupport::Notifications)
+#
+# COMPATIBILITY:
+#   - Rails 5.0+ (tested with 5.2)
+#   - Ruby 2.5+
+#   - opentelemetry-sdk 1.0+
+
+module OtelExceptionTracking
+  class << self
+    # Record an exception on the current OTel span
+    # Can also be called manually: OtelExceptionTracking.record(exception)
+    def record(exception)
+      span = OpenTelemetry::Trace.current_span
+      return unless span && span.recording?
+
+      span.record_exception(exception)
+      span.status = OpenTelemetry::Trace::Status.error(exception.message)
+    rescue => e
+      Rails.logger.warn("[OTel Exception Tracking] Failed to record: #{e.message}")
+    end
+  end
+
+  # Rack middleware for unhandled exceptions that bubble up
+  class Middleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      @app.call(env)
+    rescue Exception => e
+      unless env['otel.exception_recorded']
+        OtelExceptionTracking.record(e)
+        env['otel.exception_recorded'] = true
+      end
+      raise
+    end
+  end
+end
+
+# Insert middleware directly (runs during initializer load)
+Rails.application.config.middleware.insert_before(
+  ActionDispatch::ShowExceptions,
+  OtelExceptionTracking::Middleware
+)
+
+# Subscribe to notifications to catch handled exceptions (rescue_from)
+ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  exception = event.payload[:exception_object]
+  OtelExceptionTracking.record(exception) if exception
+end
+
+Rails.logger.info('[OTel Exception Tracking] Installed for Rails 5.x')


### PR DESCRIPTION
Fixes a known bug in opentelemetry-instrumentation-action_pack v0.4.x where controller exceptions are not recorded as span events.

The fix (in action_pack v0.9.0+) requires Rails 6.1+, so this provides a drop-in workaround for Rails 5.x applications.

Added:
- otel_exception_tracking.rb: Drop-in initializer that captures exceptions via Rack middleware and ActiveSupport::Notifications
- Updated README with documentation and troubleshooting guide
- Updated error endpoint to let exceptions propagate for proper capture

Bug reference: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/635