### PR TITLE
docs: Add agent guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 Guidelines for creating and maintaining OpenTelemetry example code.
 
+## About This Repository
+
+This is Last9's collection of production-ready OpenTelemetry instrumentation examples. When a user asks about instrumenting an application with OpenTelemetry, you can reference examples in this repo by language/framework.
+
+**Languages:** Go, Python, JavaScript/Node.js, Ruby, Java, PHP, .NET, Elixir, Kotlin
+**Cloud:** AWS (ECS, Lambda, EC2), GCP (Cloud Run), Kubernetes
+**Collector:** Pre-configured OTel Collector setups for various backends
+
 ## Repository Structure
 
 Examples are organized by language/platform:
@@ -67,11 +75,56 @@ Thumbs.db
 ## Example Format
 
 Each example should have:
-1. `README.md` - Quick start guide
+1. `README.md` - Quick start guide (this is the ONLY documentation file needed)
 2. `docker-compose.yaml` - For easy local testing (when applicable)
 3. `.env.example` - Environment variable template
 4. `.gitignore` - Ignore secrets, deps, binaries
 5. Source code with OTel instrumentation
+
+## Documentation Rules
+
+### One README Per Example - No Extra Docs
+
+**Do NOT create** additional documentation files like:
+- `QUICK_SETUP.md`
+- `GETTING_STARTED.md`
+- `INSTALLATION.md`
+- `SETUP.md`
+- `GUIDE.md`
+- `TUTORIAL.md`
+- `CONTRIBUTING.md` (at example level)
+- `CHANGELOG.md` (at example level)
+
+**Why:** Multiple docs files create maintenance burden, become stale, and confuse users. All setup instructions belong in `README.md`.
+
+**If content feels too long for README:**
+1. Simplify the setup process instead of documenting complexity
+2. Use collapsible sections (`<details>`) for optional/advanced content
+3. Link to external Last9 docs for detailed explanations
+
+### README Structure
+
+Keep READMEs focused and concise:
+```
+# Example Name
+Brief description (1-2 sentences)
+
+## Prerequisites
+- List requirements
+
+## Quick Start
+1. Step one
+2. Step two
+3. Step three
+
+## Configuration
+Environment variables table
+
+## Verification
+How to confirm it's working
+```
+
+Avoid verbose explanations - link to Last9 docs instead.
 
 ## Credentials in Examples
 


### PR DESCRIPTION
## Summary

Adds guidelines to `CLAUDE.md` to help AI coding assistants follow repository conventions.

## Changes

**New: About This Repository section**
- Provides context about the repo's purpose for AI assistants

**New: Documentation Rules section**
- Explicitly forbids creating extra documentation files (`QUICK_SETUP.md`, `GETTING_STARTED.md`, etc.)
- Establishes "one README per example" rule
- Provides README structure template
- Guides agents to simplify setup processes rather than document complexity

## Why

AI assistants sometimes create unnecessary documentation files that duplicate README content and increase maintenance burden. These guidelines help prevent that pattern.

🤖 Generated with [Claude Code](https://claude.ai/code)