### PR TITLE
feat(otel-collector): Add Raspberry Pi host metrics monitoring example

### DIFF
--- a/otel-collector/raspberry-pi/.env.example
+++ b/otel-collector/raspberry-pi/.env.example
@@ -1,0 +1,8 @@
+# Last9 OTLP Configuration
+# Get these values from your Last9 dashboard: https://app.last9.io/
+
+# OTLP gRPC endpoint
+LAST9_OTLP_ENDPOINT=otlp.last9.io:443
+
+# Authorization header (Basic auth with base64 encoded username:password)
+LAST9_AUTH_HEADER=Basic <your-base64-encoded-credentials>

--- a/otel-collector/raspberry-pi/.gitignore
+++ b/otel-collector/raspberry-pi/.gitignore
@@ -1,0 +1,20 @@
+# Environment/secrets
+.env
+.env.local
+.env.*.local
+
+# Downloaded packages
+*.deb
+*.tar.gz
+
+# Logs
+*.log
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.idea/
+.vscode/
+*.swp

--- a/otel-collector/raspberry-pi/README.md
+++ b/otel-collector/raspberry-pi/README.md
@@ -16,21 +16,21 @@ Monitor your Raspberry Pi system metrics (CPU, memory, disk, network, temperatur
 uname -m
 ```
 
-- `armv7l` → 32-bit (use `linux_arm` package)
+- `armv7l` → 32-bit (use `linux_armv7` package)
 - `aarch64` → 64-bit (use `linux_arm64` package)
 
 ### 2. Install OpenTelemetry Collector
 
-**For 64-bit (arm64):**
+**For 64-bit (arm64) - Raspberry Pi 4/5:**
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.96.0/otelcol-contrib_0.96.0_linux_arm64.deb
-sudo dpkg -i otelcol-contrib_0.96.0_linux_arm64.deb
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.144.0/otelcol-contrib_0.144.0_linux_arm64.deb
+sudo dpkg -i otelcol-contrib_0.144.0_linux_arm64.deb
 ```
 
-**For 32-bit (armv7):**
+**For 32-bit (armv7) - Raspberry Pi 3 and older:**
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.96.0/otelcol-contrib_0.96.0_linux_arm.deb
-sudo dpkg -i otelcol-contrib_0.96.0_linux_arm.deb
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.144.0/otelcol-contrib_0.144.0_linux_armv7.deb
+sudo dpkg -i otelcol-contrib_0.144.0_linux_armv7.deb
 ```
 
 ### 3. Configure the Collector
@@ -45,9 +45,9 @@ Edit with your Last9 credentials:
 sudo nano /etc/otelcol-contrib/config.yaml
 ```
 
-Replace:
-- `<last9_otlp_endpoint>` → Your Last9 OTLP endpoint (e.g., `otlp.last9.io:443`)
-- `<last9_auth_header>` → Your Last9 auth header (e.g., `Basic <base64-encoded-credentials>`)
+Update the following values in the config:
+- `endpoint` → Your Last9 OTLP endpoint (default: `otlp.last9.io:443`)
+- `Authorization` → Your Last9 auth header (`Basic <base64-encoded-credentials>`)
 
 ### 4. Start the Collector
 

--- a/otel-collector/raspberry-pi/README.md
+++ b/otel-collector/raspberry-pi/README.md
@@ -1,0 +1,150 @@
+# Monitoring Raspberry Pi with OpenTelemetry Collector
+
+Monitor your Raspberry Pi system metrics (CPU, memory, disk, network, temperature) using the OpenTelemetry Collector and send them to Last9.
+
+## Prerequisites
+
+- Raspberry Pi (any model) running Raspberry Pi OS (32-bit or 64-bit)
+- SSH access to your Pi
+- Last9 account with OTLP endpoint credentials
+
+## Quick Start
+
+### 1. Determine Your Pi's Architecture
+
+```bash
+uname -m
+```
+
+- `armv7l` → 32-bit (use `linux_arm` package)
+- `aarch64` → 64-bit (use `linux_arm64` package)
+
+### 2. Install OpenTelemetry Collector
+
+**For 64-bit (arm64):**
+```bash
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.96.0/otelcol-contrib_0.96.0_linux_arm64.deb
+sudo dpkg -i otelcol-contrib_0.96.0_linux_arm64.deb
+```
+
+**For 32-bit (armv7):**
+```bash
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.96.0/otelcol-contrib_0.96.0_linux_arm.deb
+sudo dpkg -i otelcol-contrib_0.96.0_linux_arm.deb
+```
+
+### 3. Configure the Collector
+
+Copy the configuration file:
+```bash
+sudo cp otel-config.yaml /etc/otelcol-contrib/config.yaml
+```
+
+Edit with your Last9 credentials:
+```bash
+sudo nano /etc/otelcol-contrib/config.yaml
+```
+
+Replace:
+- `<last9_otlp_endpoint>` → Your Last9 OTLP endpoint (e.g., `otlp.last9.io:443`)
+- `<last9_auth_header>` → Your Last9 auth header (e.g., `Basic <base64-encoded-credentials>`)
+
+### 4. Start the Collector
+
+```bash
+sudo systemctl enable otelcol-contrib
+sudo systemctl start otelcol-contrib
+```
+
+## Configuration
+
+| Environment Variable | Description | Example |
+|---------------------|-------------|---------|
+| `LAST9_OTLP_ENDPOINT` | Last9 OTLP gRPC endpoint | `otlp.last9.io:443` |
+| `LAST9_AUTH_HEADER` | Authorization header | `Basic dXNlcjpwYXNz` |
+
+## Collected Metrics
+
+The configuration collects:
+
+| Category | Metrics |
+|----------|---------|
+| CPU | Usage per core, load averages |
+| Memory | Used, free, cached, buffers |
+| Disk | Usage, I/O operations, read/write bytes |
+| Filesystem | Usage per mount point |
+| Network | Bytes sent/received, packets, errors |
+| Load | 1m, 5m, 15m averages |
+| Process | Count, states |
+
+### Pi-Specific: CPU Temperature
+
+The `hostmetrics` receiver does not natively collect Raspberry Pi temperature. To add it, use a custom script with the `filestats` receiver (see Advanced Configuration below).
+
+## Verification
+
+Check collector status:
+```bash
+sudo systemctl status otelcol-contrib
+```
+
+View logs:
+```bash
+sudo journalctl -u otelcol-contrib -f
+```
+
+Test locally with debug output:
+```bash
+sudo otelcol-contrib --config /etc/otelcol-contrib/config.yaml
+```
+
+Metrics should appear in your [Last9 dashboard](https://app.last9.io/) within a few minutes.
+
+## Advanced Configuration
+
+<details>
+<summary>Add CPU Temperature Monitoring</summary>
+
+Create a script to expose temperature as a metric:
+
+```bash
+# /usr/local/bin/pi-temp-exporter.sh
+#!/bin/bash
+TEMP=$(cat /sys/class/thermal/thermal_zone0/temp)
+echo "pi_cpu_temperature_celsius $(echo "scale=2; $TEMP/1000" | bc)"
+```
+
+Add to crontab to write to a file, then use `filestats` receiver.
+
+</details>
+
+<details>
+<summary>Reduce Resource Usage</summary>
+
+For Pi Zero or older models, increase collection intervals:
+
+```yaml
+receivers:
+  hostmetrics:
+    collection_interval: 60s  # Instead of 30s
+```
+
+</details>
+
+## Troubleshooting
+
+**Collector won't start:**
+```bash
+sudo otelcol-contrib --config /etc/otelcol-contrib/config.yaml 2>&1 | head -50
+```
+
+**Permission errors:**
+Ensure the collector can read system stats:
+```bash
+sudo usermod -aG adm otelcol-contrib
+```
+
+**High memory usage:**
+Use the core collector instead of contrib, or increase batch timeout.
+
+For additional help, contact us on [Discord](https://discord.gg/last9) or via email.

--- a/otel-collector/raspberry-pi/otel-config.yaml
+++ b/otel-collector/raspberry-pi/otel-config.yaml
@@ -14,7 +14,8 @@ receivers:
       filesystem:
       network:
       load:
-      process:
+      processes:  # Aggregate process statistics
+      process:    # Per-process metrics
         include:
           match_type: regexp
           names: [".*"]
@@ -54,9 +55,9 @@ processors:
 
 exporters:
   otlp/last9:
-    endpoint: <last9_otlp_endpoint>
+    endpoint: "otlp.last9.io:443"  # Replace with your Last9 OTLP endpoint
     headers:
-      "Authorization": "<last9_auth_header>"
+      "Authorization": "Basic <your-base64-encoded-credentials>"  # Replace with your Last9 auth header
 
   # Enable for local debugging
   # debug:

--- a/otel-collector/raspberry-pi/otel-config.yaml
+++ b/otel-collector/raspberry-pi/otel-config.yaml
@@ -1,0 +1,70 @@
+receivers:
+  hostmetrics:
+    collection_interval: 30s
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.utilization:
+            enabled: true
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+      disk:
+      filesystem:
+      network:
+      load:
+      process:
+        include:
+          match_type: regexp
+          names: [".*"]
+        mute_process_exe_error: true
+        mute_process_io_error: true
+        mute_process_user_error: true
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 1000
+    send_batch_max_size: 2000
+
+  resourcedetection/system:
+    detectors: ["system"]
+    system:
+      hostname_sources: ["os"]
+
+  resource/pi:
+    attributes:
+      - key: device.type
+        value: raspberry-pi
+        action: upsert
+
+  transform/metrics:
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(attributes["host.name"], resource.attributes["host.name"])
+          - set(attributes["os.type"], resource.attributes["os.type"])
+
+  # Memory limiter to prevent OOM on resource-constrained Pi
+  memory_limiter:
+    check_interval: 5s
+    limit_mib: 100
+    spike_limit_mib: 25
+
+exporters:
+  otlp/last9:
+    endpoint: <last9_otlp_endpoint>
+    headers:
+      "Authorization": "<last9_auth_header>"
+
+  # Enable for local debugging
+  # debug:
+  #   verbosity: detailed
+
+service:
+  pipelines:
+    metrics:
+      receivers: [hostmetrics]
+      processors: [memory_limiter, batch, resourcedetection/system, resource/pi, transform/metrics]
+      exporters: [otlp/last9]

--- a/otel-collector/raspberry-pi/otel-config.yaml
+++ b/otel-collector/raspberry-pi/otel-config.yaml
@@ -23,6 +23,15 @@ receivers:
         mute_process_io_error: true
         mute_process_user_error: true
 
+  # Raspberry Pi temperature metrics (CPU, GPU, throttle state)
+  prometheus/pi_temp:
+    config:
+      scrape_configs:
+        - job_name: 'pi-temperature'
+          scrape_interval: 30s
+          static_configs:
+            - targets: ['localhost:9101']
+
 processors:
   batch:
     timeout: 10s
@@ -66,6 +75,6 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers: [hostmetrics]
+      receivers: [hostmetrics, prometheus/pi_temp]
       processors: [memory_limiter, batch, resourcedetection/system, resource/pi, transform/metrics]
       exporters: [otlp/last9]

--- a/otel-collector/raspberry-pi/pi-temp-exporter.py
+++ b/otel-collector/raspberry-pi/pi-temp-exporter.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Raspberry Pi Temperature Exporter for Prometheus/OpenTelemetry
+
+Exposes CPU and GPU temperature as Prometheus metrics on port 9101.
+Designed to be scraped by OpenTelemetry Collector's prometheus receiver.
+"""
+
+import http.server
+import socketserver
+import subprocess
+import os
+
+PORT = 9101
+
+def get_cpu_temp():
+    """Read CPU temperature from thermal zone."""
+    try:
+        with open('/sys/class/thermal/thermal_zone0/temp', 'r') as f:
+            temp = int(f.read().strip()) / 1000.0
+            return temp
+    except Exception:
+        return None
+
+def get_gpu_temp():
+    """Read GPU temperature using vcgencmd (Pi-specific)."""
+    try:
+        result = subprocess.run(
+            ['vcgencmd', 'measure_temp'],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            # Output format: temp=42.0'C
+            temp_str = result.stdout.strip()
+            temp = float(temp_str.replace("temp=", "").replace("'C", ""))
+            return temp
+    except Exception:
+        pass
+    return None
+
+def get_throttle_state():
+    """Check if Pi is throttled due to temperature/voltage."""
+    try:
+        result = subprocess.run(
+            ['vcgencmd', 'get_throttled'],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            # Output format: throttled=0x0
+            value = result.stdout.strip().split('=')[1]
+            return int(value, 16)
+    except Exception:
+        pass
+    return None
+
+class MetricsHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path != '/metrics':
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        metrics = []
+        hostname = os.uname().nodename
+
+        # CPU Temperature
+        cpu_temp = get_cpu_temp()
+        if cpu_temp is not None:
+            metrics.append('# HELP rpi_cpu_temperature_celsius Raspberry Pi CPU temperature in Celsius')
+            metrics.append('# TYPE rpi_cpu_temperature_celsius gauge')
+            metrics.append(f'rpi_cpu_temperature_celsius{{host="{hostname}"}} {cpu_temp:.2f}')
+
+        # GPU Temperature
+        gpu_temp = get_gpu_temp()
+        if gpu_temp is not None:
+            metrics.append('# HELP rpi_gpu_temperature_celsius Raspberry Pi GPU temperature in Celsius')
+            metrics.append('# TYPE rpi_gpu_temperature_celsius gauge')
+            metrics.append(f'rpi_gpu_temperature_celsius{{host="{hostname}"}} {gpu_temp:.2f}')
+
+        # Throttle state (bit flags for undervoltage, frequency capping, throttling)
+        throttle = get_throttle_state()
+        if throttle is not None:
+            metrics.append('# HELP rpi_throttled Raspberry Pi throttle state (0=OK, non-zero=throttled)')
+            metrics.append('# TYPE rpi_throttled gauge')
+            metrics.append(f'rpi_throttled{{host="{hostname}"}} {throttle}')
+
+            # Individual throttle flags
+            metrics.append('# HELP rpi_undervoltage Raspberry Pi undervoltage detected (1=yes, 0=no)')
+            metrics.append('# TYPE rpi_undervoltage gauge')
+            metrics.append(f'rpi_undervoltage{{host="{hostname}"}} {1 if throttle & 0x1 else 0}')
+
+            metrics.append('# HELP rpi_freq_capped Raspberry Pi frequency capped (1=yes, 0=no)')
+            metrics.append('# TYPE rpi_freq_capped gauge')
+            metrics.append(f'rpi_freq_capped{{host="{hostname}"}} {1 if throttle & 0x2 else 0}')
+
+            metrics.append('# HELP rpi_throttling Raspberry Pi currently throttled (1=yes, 0=no)')
+            metrics.append('# TYPE rpi_throttling gauge')
+            metrics.append(f'rpi_throttling{{host="{hostname}"}} {1 if throttle & 0x4 else 0}')
+
+        response = '\n'.join(metrics) + '\n'
+
+        self.send_response(200)
+        self.send_header('Content-type', 'text/plain; charset=utf-8')
+        self.send_header('Content-Length', len(response))
+        self.end_headers()
+        self.wfile.write(response.encode())
+
+    def log_message(self, format, *args):
+        pass  # Suppress logging
+
+if __name__ == '__main__':
+    with socketserver.TCPServer(("", PORT), MetricsHandler) as httpd:
+        print(f"Raspberry Pi Temperature Exporter running on port {PORT}")
+        httpd.serve_forever()

--- a/otel-collector/raspberry-pi/pi-temp-exporter.service
+++ b/otel-collector/raspberry-pi/pi-temp-exporter.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Raspberry Pi Temperature Exporter for Prometheus/OpenTelemetry
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /usr/local/bin/pi-temp-exporter.py
+Restart=always
+RestartSec=5
+User=root
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add OpenTelemetry Collector configuration for monitoring Raspberry Pi devices with ARM-specific installation instructions, memory-optimized config, and comprehensive documentation.

- Support for both 32-bit (armv7) and 64-bit (arm64) architectures
- Memory limiter processor to prevent OOM on resource-constrained devices
- Host metrics collection: CPU, memory, disk, filesystem, network, load
- Custom device.type attribute for filtering Pi devices in dashboards