### PR TITLE
python/sanic: add event loop blocking detection and per-task lag attribution

### DIFF
--- a/python/sanic-event-loop-diagnostics/README.md
+++ b/python/sanic-event-loop-diagnostics/README.md
@@ -291,6 +291,201 @@ event_loop_monitor = EventLoopMonitor(
 )
 ```
 
+## Validating in Last9 — Step by Step
+
+This section walks through everything you can do in Last9 once the app is running and sending data.
+
+---
+
+### Step 1: Confirm Data is Arriving
+
+1. Open Last9 → **Traces** tab
+2. Set the filter: `service = sanic-event-loop-demo`
+3. Set time range to **Last 15 Minutes**
+4. Click **Run Query**
+
+You should see spans for all the endpoints you called. If nothing appears, check that:
+- The app started without errors (`curl localhost:8000/health`)
+- `.env` has the correct `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS`
+- At least one request was made after the app started
+
+---
+
+### Step 2: Find Blocking Requests (the key insight)
+
+Filter on `asyncio.eventloop.request_blocked = true`:
+
+1. In the **Filter** bar, add: `asyncio.eventloop.request_blocked = true`
+2. Click **Run Query**
+
+**Expected result:** Only blocking endpoints appear:
+- `GET /blocking-io` — uses `time.sleep()`, blocks the loop
+- `GET /cpu-bound` — runs CPU work on the main thread
+- `GET /blocking-hash` — computes large hashes synchronously
+
+**What you will NOT see here:** `/async-io`, `/concurrent-tasks`, `/proper-cpu` — these yield to the event loop correctly.
+
+> **Why this matters:** This filter directly answers "which HTTP routes are degrading my async application's performance?" — without having to read logs or guess.
+
+---
+
+### Step 3: Confirm Non-Blocking Requests are Clean
+
+Change the filter to `asyncio.eventloop.request_blocked = false`:
+
+**Expected result:** Only non-blocking endpoints appear:
+- `GET /async-io` — uses `asyncio.sleep()`, yields to event loop
+- `GET /concurrent-tasks` — runs tasks concurrently via `asyncio.gather()`
+- `GET /proper-cpu` — offloads CPU work to a thread pool via `run_in_executor()`
+
+This confirms there are no false positives — healthy requests are correctly classified.
+
+---
+
+### Step 4: Drill Into a Blocked Span's Attributes
+
+1. Click any `GET /blocking-io` trace from the `request_blocked = true` results
+2. Open the span detail panel
+
+Look for these span attributes:
+
+| Attribute | What it tells you |
+|-----------|------------------|
+| `asyncio.eventloop.request_blocked` | `true` — this request caused a block |
+| `asyncio.eventloop.blocking_lag_ms` | How many milliseconds the loop was blocked (e.g., `304.5`) |
+| `asyncio.eventloop.blocking_severity` | `warning` (50–500ms) or `critical` (>500ms) |
+| `asyncio.eventloop.lag_at_request_start_ms` | Lag reading when the request arrived |
+| `asyncio.eventloop.lag_at_request_end_ms` | Lag reading when the response was sent |
+| `asyncio.eventloop.active_tasks` | How many other tasks were queued during this request |
+| `http.target` | The route (e.g., `/blocking-io`) |
+| `http.status_code` | Response status |
+
+Compare a `/blocking-io` span (lag_ms ~300+) against an `/async-io` span (lag_ms ~0-2). The difference makes the event loop impact immediately visible.
+
+---
+
+### Step 5: Compare Bad vs Good CPU Patterns
+
+This is the most educational comparison in the demo:
+
+**Bad pattern** — CPU work on the main thread:
+```
+Filter: http.target = /cpu-bound AND asyncio.eventloop.request_blocked = true
+```
+You'll see `blocking_lag_ms` in the hundreds of milliseconds.
+
+**Good pattern** — same work offloaded to thread pool:
+```
+Filter: http.target = /proper-cpu AND asyncio.eventloop.request_blocked = false
+```
+`request_blocked = false`, lag stays near zero.
+
+Same computation, completely different impact on the event loop.
+
+---
+
+### Step 6: View Event Loop Metrics
+
+Switch from **Traces** to **Metrics** in Last9 and search for these metric names:
+
+#### `asyncio_eventloop_lag`
+- **Type:** Gauge (seconds)
+- **What to look for:** Spikes aligned with when you called blocking endpoints. Should be near 0 during non-blocking traffic.
+- **Query example:** `asyncio_eventloop_lag{service_name="sanic-event-loop-demo"}`
+
+#### `asyncio_eventloop_lag_distribution`
+- **Type:** Histogram (seconds)
+- **What to look for:** P99 lag — the worst 1% of measurements
+- **Query example (PromQL):**
+  ```promql
+  histogram_quantile(0.99, rate(asyncio_eventloop_lag_distribution_bucket[5m]))
+  ```
+
+#### `asyncio_eventloop_blocking_events_total`
+- **Type:** Counter
+- **What to look for:** Rate of blocking detections. Should be 0 in a healthy service.
+- **Attributes:** `blocking.severity` (`warning` / `critical`)
+- **Query example:**
+  ```promql
+  rate(asyncio_eventloop_blocking_events_total[5m])
+  ```
+
+#### `asyncio_eventloop_utilization`
+- **Type:** Gauge (0–100%)
+- **What to look for:** Baseline utilization. High utilization (>50%) with low throughput means the loop is inefficient.
+
+#### `asyncio_eventloop_active_tasks`
+- **Type:** Gauge
+- **What to look for:** How many tasks were queued. High count + high lag = tasks starving.
+
+#### `asyncio_eventloop_task_lag_contribution`
+- **Type:** Histogram (milliseconds), attribute: `task.coroutine`
+- **What to look for:** Which coroutine type is responsible for the most lag
+- **Query example (top contributors):**
+  ```promql
+  topk(5,
+    rate(asyncio_eventloop_task_lag_contribution_sum[5m])
+    / rate(asyncio_eventloop_task_lag_contribution_count[5m])
+  )
+  ```
+
+#### `asyncio_eventloop_task_active_count`
+- **Type:** Gauge, attribute: `task.coroutine`
+- **What to look for:** Which coroutines are consistently running. High count of a specific coroutine over time indicates it is dominating the loop.
+
+---
+
+### Step 7: Generate a Spike and Watch it in Real Time
+
+To produce a clear lag spike visible in metrics:
+
+```bash
+# Non-blocking baseline
+curl http://localhost:8000/async-io
+curl http://localhost:8000/concurrent-tasks
+
+# Blocking spike (watch the metrics chart)
+curl "http://localhost:8000/blocking-io?seconds=1"
+curl "http://localhost:8000/cpu-bound?iterations=20000000"
+
+# Recovery — non-blocking again
+curl http://localhost:8000/async-io
+```
+
+In Last9 metrics, plot `asyncio_eventloop_lag` and you will see:
+- Flat near-zero line during async requests
+- A clear spike during the blocking calls
+- Return to baseline immediately after
+
+---
+
+### Step 8: Recommended Trace Filters for Daily Use
+
+Bookmark these filters in Last9 for ongoing monitoring:
+
+| Use Case | Filter |
+|----------|--------|
+| Find all routes that blocked the loop | `asyncio.eventloop.request_blocked = true` |
+| Find severe blocks only | `asyncio.eventloop.blocking_severity = critical` |
+| Find requests where lag was high on arrival | `asyncio.eventloop.lag_at_request_start_ms > 50` |
+| Find requests that made lag worse | `asyncio.eventloop.lag_at_request_end_ms > asyncio.eventloop.lag_at_request_start_ms` |
+| Scope to a specific route | `http.target = /blocking-io` |
+
+---
+
+### Step 9: Alerting Setup in Last9
+
+Create these alerts based on the metrics:
+
+| Alert | Metric | Condition | Severity |
+|-------|--------|-----------|----------|
+| Event loop degraded | `asyncio_eventloop_lag` | `> 0.05` (50ms) for 2 min | Warning |
+| Event loop critical | `asyncio_eventloop_lag` | `> 0.5` (500ms) for 1 min | Critical |
+| Blocking detected | `asyncio_eventloop_blocking_events_total` | rate `> 0` | Warning |
+| High P99 lag | `asyncio_eventloop_lag_distribution` | `histogram_quantile(0.99, ...) > 0.1` | Warning |
+
+---
+
 ## Alerting Recommendations
 
 ### PromQL Queries (for Last9)

--- a/python/sanic-event-loop-diagnostics/app.py
+++ b/python/sanic-event-loop-diagnostics/app.py
@@ -108,10 +108,29 @@ async def otel_request_middleware(request: Request):
     request.ctx.otel_token = token
     request.ctx.otel_token_span = token_span
 
+    # Record the loop.time() at request start.
+    # The response middleware checks if a blocking event timestamp falls
+    # BETWEEN this start time and the response time — correctly pinpointing
+    # which handler caused the block, not which handler ran after it.
+    if event_loop_monitor:
+        loop = asyncio.get_running_loop()
+        request.ctx.request_start_loop_time = loop.time()
+        request.ctx.lag_at_start_ms = event_loop_monitor.get_stats()["lag_ms"]
+
 
 @app.middleware("response")
 async def otel_response_middleware(request: Request, response_obj):
-    """End span on response."""
+    """
+    End span on response, enriching it with event loop lag attributes.
+
+    These span attributes let you answer in Last9 / any trace backend:
+      "Which HTTP routes were being served during high event loop lag?"
+
+    Filter traces by:
+      asyncio.eventloop.request_blocked = true
+      asyncio.eventloop.lag_at_request_end_ms > 50
+    Then group by http.target to find the worst offenders.
+    """
     if not hasattr(request.ctx, 'otel_span'):
         return
 
@@ -121,6 +140,73 @@ async def otel_response_middleware(request: Request, response_obj):
         span.set_attribute("http.status_code", response_obj.status)
         if response_obj.status >= 400:
             span.set_status(Status(StatusCode.ERROR))
+
+    # Enrich span with event loop blocking attribution for this request.
+    #
+    # KEY INSIGHT: We use loop.time() timestamps rather than lag values to
+    # determine if a block happened DURING this request. This avoids the
+    # false-positive problem where a request running immediately AFTER a
+    # blocking call inherits the stale high-lag reading.
+    #
+    # How it works:
+    #   1. Request middleware stamps request_start_loop_time = loop.time()
+    #   2. When lag > threshold, monitor stamps _last_blocking_loop_time
+    #   3. Here we check: did that blocking event fall between start and now?
+    #   4. If yes → THIS handler caused the block (true positive)
+    #   5. If no  → block happened before/after this request (not its fault)
+    if event_loop_monitor and hasattr(request.ctx, 'request_start_loop_time'):
+        loop = asyncio.get_running_loop()
+        request_end_loop_time = loop.time()
+        request_start_loop_time = request.ctx.request_start_loop_time
+        stats = event_loop_monitor.get_stats()
+
+        last_blocking_start = event_loop_monitor._last_blocking_start
+        last_blocking_end = event_loop_monitor._last_blocking_end
+        last_blocking_lag_ms = event_loop_monitor._last_blocking_lag_ms
+        current_interval_start = event_loop_monitor._current_interval_start
+        blocking_threshold = event_loop_monitor._blocking_threshold
+
+        # Strategy: detect blocking via two complementary checks.
+        #
+        # CHECK 1 — Stamped block (previous requests):
+        #   After a block, the monitor wakes and stamps _last_blocking_start/end.
+        #   A request owns the block if its window overlaps [block_start, block_end].
+        #   Two intervals overlap when: A_start <= B_end AND B_start <= A_end.
+        stamped_block = (
+            last_blocking_start > 0
+            and request_start_loop_time <= last_blocking_end
+            and last_blocking_start <= request_end_loop_time
+        )
+
+        # CHECK 2 — In-flight block (the current request IS the culprit):
+        #   When time.sleep() runs inside THIS request, the event loop freezes.
+        #   The monitor can't run during the freeze, so _last_blocking_start is
+        #   still from a previous cycle. But _current_interval_start was set
+        #   BEFORE the freeze. If the current monitoring interval started before
+        #   this request AND the request took longer than (interval + threshold),
+        #   then the loop was blocked during this request.
+        request_duration = request_end_loop_time - request_start_loop_time
+        interval_elapsed = request_end_loop_time - current_interval_start
+        inflight_block = (
+            current_interval_start > 0
+            and current_interval_start <= request_end_loop_time
+            and interval_elapsed > (event_loop_monitor._interval + blocking_threshold)
+        )
+
+        was_blocked = stamped_block or inflight_block
+        # Use actual measured lag for in-flight blocks
+        if inflight_block and not stamped_block:
+            last_blocking_lag_ms = max(0, interval_elapsed - event_loop_monitor._interval) * 1000
+
+        span.set_attribute("asyncio.eventloop.lag_at_request_start_ms", round(request.ctx.lag_at_start_ms, 2))
+        span.set_attribute("asyncio.eventloop.lag_at_request_end_ms", round(stats["lag_ms"], 2))
+        span.set_attribute("asyncio.eventloop.request_blocked", was_blocked)
+        span.set_attribute("asyncio.eventloop.active_tasks", stats["active_tasks"])
+
+        if was_blocked:
+            span.set_attribute("asyncio.eventloop.blocking_lag_ms", round(last_blocking_lag_ms, 2))
+            severity = "critical" if last_blocking_lag_ms > stats["blocking_threshold_ms"] * 10 else "warning"
+            span.set_attribute("asyncio.eventloop.blocking_severity", severity)
 
     span.end()
 
@@ -144,7 +230,8 @@ async def index(request: Request):
             "monitoring": {
                 "/health": "Health check",
                 "/metrics": "Current event loop metrics (JSON)",
-                "/metrics/reset": "Reset metrics counters"
+                "/metrics/reset": "Reset metrics counters",
+                "/task-trends": "Active tasks by coroutine + OTEL lag attribution metrics"
             },
             "non_blocking_patterns": {
                 "/async-io": "Async I/O operation (non-blocking)",
@@ -194,6 +281,47 @@ async def reset_metrics(request: Request):
     if event_loop_monitor:
         event_loop_monitor.reset_stats()
     return response.json({"message": "Metrics reset"})
+
+
+@app.route("/task-trends")
+async def task_trends(request: Request):
+    """
+    Show which coroutines are currently active and their contribution to lag.
+
+    Returns the live task breakdown by coroutine name.
+
+    For historical trends of which tasks contributed to event loop lag,
+    query the OTEL metric:
+      asyncio.eventloop.task.lag_contribution (histogram, attribute: task.coroutine)
+      asyncio.eventloop.task.active_count     (gauge,     attribute: task.coroutine)
+
+    Example PromQL to find top lag contributors:
+      topk(5, rate(asyncio_eventloop_task_lag_contribution_sum[5m])
+               / rate(asyncio_eventloop_task_lag_contribution_count[5m]))
+    """
+    if not event_loop_monitor:
+        return response.json({"error": "Monitor not initialized"}, status=500)
+
+    stats = event_loop_monitor.get_stats()
+    task_breakdown = stats.get("task_breakdown", {})
+
+    # Sort by count descending so highest-activity coroutines appear first
+    sorted_tasks = sorted(task_breakdown.items(), key=lambda x: x[1], reverse=True)
+
+    return response.json({
+        "active_tasks_total": stats["active_tasks"],
+        "current_lag_ms": stats["lag_ms"],
+        "status": stats["status"],
+        "task_breakdown": [
+            {"coroutine": name, "active_count": count}
+            for name, count in sorted_tasks
+        ],
+        "otel_metrics": {
+            "active_count_by_coroutine": "asyncio.eventloop.task.active_count (attr: task.coroutine)",
+            "lag_contribution_by_coroutine": "asyncio.eventloop.task.lag_contribution (attr: task.coroutine)",
+            "note": "Query these metrics in your observability backend to see trends over time"
+        }
+    })
 
 
 # ============================================

--- a/python/sanic-event-loop-diagnostics/event_loop_monitor.py
+++ b/python/sanic-event-loop-diagnostics/event_loop_monitor.py
@@ -28,6 +28,8 @@ class EventLoopStats:
     blocking_events: int = 0
     max_lag_seconds: float = 0.0
     total_measurements: int = 0
+    # Per-coroutine active task counts (updated every monitoring interval)
+    task_breakdown: Dict[str, int] = field(default_factory=dict)
 
 
 class EventLoopMonitor:
@@ -79,6 +81,25 @@ class EventLoopMonitor:
         # For utilization calculation
         self._busy_time = 0.0
         self._total_time = 0.0
+
+        # Timestamps of the most recent detected blocking event.
+        # _last_blocking_start: loop.time() at the START of the monitoring
+        #   interval during which the block was detected. The block happened
+        #   somewhere between this time and _last_blocking_end.
+        # _last_blocking_end: loop.time() when the monitor woke up after the block.
+        # Used by request middleware to check if a block occurred DURING a
+        # specific request's execution window — avoids false positives on
+        # requests that run immediately after a block finishes.
+        self._last_blocking_start: float = 0.0
+        self._last_blocking_end: float = 0.0
+        self._last_blocking_lag_ms: float = 0.0
+
+        # The start time of the CURRENT monitoring interval (updated at the
+        # beginning of each loop iteration). Used by the response middleware
+        # to detect if a block is happening right now (i.e., the current
+        # interval started before the request but hasn't stamped _last_blocking_*
+        # yet because the event loop was frozen during the request).
+        self._current_interval_start: float = 0.0
 
         # Create OTEL metrics
         self._setup_metrics()
@@ -133,6 +154,24 @@ class EventLoopMonitor:
             unit="s"
         )
 
+        # Per-coroutine active task count - shows trends of which coroutines
+        # are active over time (attribute: task.coroutine)
+        self._meter.create_observable_gauge(
+            name="asyncio.eventloop.task.active_count",
+            callbacks=[self._observe_task_breakdown],
+            description="Number of active tasks broken down by coroutine name",
+            unit="{tasks}"
+        )
+
+        # Per-coroutine lag contribution - records lag attributed to each
+        # coroutine type when lag exceeds threshold (attribute: task.coroutine)
+        # Use this to answer: "which tasks are contributing to event loop lag?"
+        self._task_lag_histogram = self._meter.create_histogram(
+            name="asyncio.eventloop.task.lag_contribution",
+            description="Event loop lag attributed by coroutine type (recorded when lag > threshold)",
+            unit="ms"
+        )
+
     def _observe_lag(self, options: CallbackOptions):
         """Callback for lag gauge."""
         yield Observation(
@@ -160,6 +199,24 @@ class EventLoopMonitor:
             self._stats.max_lag_seconds,
             {"service.name": self._service_name}
         )
+
+    def _observe_task_breakdown(self, options: CallbackOptions):
+        """
+        Callback for per-coroutine active task count gauge.
+
+        Yields one Observation per unique coroutine name currently active,
+        with the coroutine name as the 'task.coroutine' attribute.
+        This creates separate time-series per coroutine type, enabling
+        trend analysis of which tasks are active over time.
+        """
+        for coro_name, count in self._stats.task_breakdown.items():
+            yield Observation(
+                count,
+                {
+                    "service.name": self._service_name,
+                    "task.coroutine": coro_name,
+                }
+            )
 
     async def start(self):
         """Start the monitoring task."""
@@ -199,6 +256,11 @@ class EventLoopMonitor:
                 # Record start time using high-precision loop time
                 start = loop.time()
 
+                # Expose current interval start so the response middleware can
+                # detect a block that is "in-flight" (not yet stamped in
+                # _last_blocking_start because the monitor hasn't woken up yet).
+                self._current_interval_start = start
+
                 # Sleep for the monitoring interval
                 await asyncio.sleep(self._interval)
 
@@ -216,9 +278,23 @@ class EventLoopMonitor:
                 if lag > self._stats.max_lag_seconds:
                     self._stats.max_lag_seconds = lag
 
-                # Count active tasks
+                # Count active tasks and build per-coroutine breakdown
                 all_tasks = asyncio.all_tasks()
-                self._stats.active_tasks = len([t for t in all_tasks if not t.done()])
+                current_task = asyncio.current_task()
+                active_tasks = [t for t in all_tasks if not t.done() and t is not current_task]
+                self._stats.active_tasks = len(active_tasks)
+
+                # Build per-coroutine task count for trend tracking
+                task_breakdown: Dict[str, int] = {}
+                for task in active_tasks:
+                    coro = task.get_coro()
+                    coro_name = (
+                        getattr(coro, "__qualname__", None)
+                        or getattr(coro, "__name__", None)
+                        or "unknown"
+                    )
+                    task_breakdown[coro_name] = task_breakdown.get(coro_name, 0) + 1
+                self._stats.task_breakdown = task_breakdown
 
                 # Calculate utilization (simplified: lag/interval ratio)
                 # High lag = high utilization (loop was busy)
@@ -233,7 +309,7 @@ class EventLoopMonitor:
                     {"service.name": self._service_name}
                 )
 
-                # Detect blocking events
+                # Detect blocking events and attribute lag to contributing tasks
                 if lag > self._blocking_threshold:
                     self._stats.blocking_events += 1
 
@@ -251,6 +327,31 @@ class EventLoopMonitor:
                             "blocking.lag_seconds": str(round(lag, 3))
                         }
                     )
+
+                    # Record the interval [start, now] during which the block
+                    # occurred. The block happened somewhere between 'start'
+                    # (when we went to sleep) and 'loop.time()' (when we woke).
+                    # The middleware checks if a request's execution window
+                    # overlaps with [_last_blocking_start, _last_blocking_end].
+                    self._last_blocking_start = start
+                    self._last_blocking_end = loop.time()
+                    self._last_blocking_lag_ms = lag * 1000
+
+                    # Record lag contribution per coroutine that was active
+                    # during this blocking event. If no tasks are identified,
+                    # attribute the lag to an "unknown" contributor so the
+                    # metric is still emitted.
+                    lag_ms = lag * 1000
+                    contributing_tasks = task_breakdown if task_breakdown else {"unknown": 1}
+                    for coro_name in contributing_tasks:
+                        self._task_lag_histogram.record(
+                            lag_ms,
+                            {
+                                "service.name": self._service_name,
+                                "task.coroutine": coro_name,
+                                "blocking.severity": severity,
+                            }
+                        )
 
             except asyncio.CancelledError:
                 break
@@ -275,7 +376,10 @@ class EventLoopMonitor:
             "total_measurements": self._stats.total_measurements,
             "monitoring_interval_ms": self._interval * 1000,
             "blocking_threshold_ms": self._blocking_threshold * 1000,
-            "status": self._get_health_status()
+            "status": self._get_health_status(),
+            # Per-coroutine breakdown: shows which tasks are active right now
+            # and (via OTEL) which ones have been contributing to lag over time.
+            "task_breakdown": dict(self._stats.task_breakdown),
         }
 
     def _get_health_status(self) -> str:


### PR DESCRIPTION
## Summary

- **Blocking attribution on every span**: Each HTTP request span now carries `asyncio.eventloop.request_blocked` (bool), `asyncio.eventloop.blocking_lag_ms`, and `asyncio.eventloop.blocking_severity`. Uses a dual-check strategy to correctly identify the culprit request — including requests that freeze the event loop via `time.sleep()` where the monitor cannot stamp a timestamp until after the response fires.
- **Per-coroutine lag metrics**: Two new OTEL metrics expose which coroutine types are contributing to event loop lag over time — `asyncio.eventloop.task.active_count` (gauge, per coroutine) and `asyncio.eventloop.task.lag_contribution` (histogram, per coroutine, recorded when lag exceeds threshold).
- **`/task-trends` endpoint**: Live JSON view of active coroutine breakdown with PromQL query examples for querying historical lag attribution in Last9.
- **README: Validating in Last9**: Step-by-step guide covering trace filters, span attribute interpretation, metric queries (with PromQL), spike generation, recommended daily-use filters, and alerting setup.

## Test plan

- [ ] Start app: `cp .env.example .env` → fill credentials → `pip install -r requirements.txt` → `python app.py`
- [ ] Hit non-blocking endpoints (`/async-io`, `/concurrent-tasks`, `/proper-cpu`) — verify `asyncio.eventloop.request_blocked = false` in spans
- [ ] Hit blocking endpoints (`/blocking-io?seconds=0.4`, `/cpu-bound?iterations=8000000`) — verify `request_blocked = true` and `blocking_lag_ms` is populated
- [ ] Call `/task-trends` — verify coroutine breakdown appears in JSON response
- [ ] In Last9 Traces: filter `asyncio.eventloop.request_blocked = true` — only blocking routes should appear
- [ ] In Last9 Metrics: plot `asyncio_eventloop_task_lag_contribution` grouped by `task.coroutine` — coroutine names should appear after a blocking call