### PR TITLE
feat: Google Play Developer Reporting → Last9 OTel metrics integration

### DIFF
--- a/python/google-play-reporting/.env.example
+++ b/python/google-play-reporting/.env.example
@@ -5,20 +5,22 @@ GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/service-account.json
 
 # Comma-separated list of Android package names to monitor
 # Example: com.example.app,com.example.tv
-ANDROID_PACKAGE_NAMES=com.example.app
+ANDROID_PACKAGE_NAMES=com.example.app,com.example.tv
 
 # How often to poll the Play Developer Reporting API (seconds)
 # Google data freshness is 24–48 hours regardless of poll frequency
 # Default: 1800 (30 minutes)
 POLL_INTERVAL_SECONDS=1800
 
-# How many days back to query each poll. Sparse apps may only have data on a
-# few dates per month so a wider window is needed. Default: 30
+# Set to "true" to also poll crash/ANR hourly (~2-4h lag, costs more API quota)
+ENABLE_HOURLY=false
+
+# How many days back to query each poll. Default: 30
 POLL_DAYS_BACK=30
 
 # Dimension breakdown for metrics. Leave empty for aggregate totals.
-# Google withholds per-dimension data below ~500 DAU — use empty first, then
-# enable once you confirm data flows.
+# Low-traffic apps may return empty rows for per-dimension queries.
+# Start empty, then enable once you confirm aggregate data flows.
 # Example: ANDROID_DIMENSIONS=versionCode,apiLevel
 ANDROID_DIMENSIONS=
 

--- a/python/google-play-reporting/.env.example
+++ b/python/google-play-reporting/.env.example
@@ -1,0 +1,33 @@
+# Path to the Google service account JSON file (never commit the actual file)
+# The file must have "View app information and download bulk reports" permission
+# in Google Play Console → Setup → API access
+GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/service-account.json
+
+# Comma-separated list of Android package names to monitor
+# Example: com.example.app,com.example.tv
+ANDROID_PACKAGE_NAMES=com.example.app
+
+# How often to poll the Play Developer Reporting API (seconds)
+# Google data freshness is 24–48 hours regardless of poll frequency
+# Default: 1800 (30 minutes)
+POLL_INTERVAL_SECONDS=1800
+
+# How many days back to query each poll. Sparse apps may only have data on a
+# few dates per month so a wider window is needed. Default: 30
+POLL_DAYS_BACK=30
+
+# Dimension breakdown for metrics. Leave empty for aggregate totals.
+# Google withholds per-dimension data below ~500 DAU — use empty first, then
+# enable once you confirm data flows.
+# Example: ANDROID_DIMENSIONS=versionCode,apiLevel
+ANDROID_DIMENSIONS=
+
+# Last9 OTLP endpoint (get from Last9 dashboard → Integrations → OTLP)
+OTLP_ENDPOINT=https://otlp.last9.io
+
+# Last9 auth header: Authorization=Basic <base64-encoded-credentials>
+# Get from Last9 dashboard → Integrations → Copy OTLP headers
+OTLP_HEADERS=Authorization=Basic <your-last9-otlp-token>
+
+# Service name shown in Last9
+OTEL_SERVICE_NAME=google-play-reporting

--- a/python/google-play-reporting/.gitignore
+++ b/python/google-play-reporting/.gitignore
@@ -1,0 +1,26 @@
+# Environment / secrets — NEVER commit these
+.env
+.env.local
+.env.*.local
+*.json
+!package.json
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+.venv/
+venv/
+env/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log

--- a/python/google-play-reporting/Dockerfile
+++ b/python/google-play-reporting/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+
+CMD ["python", "main.py"]

--- a/python/google-play-reporting/README.md
+++ b/python/google-play-reporting/README.md
@@ -1,0 +1,87 @@
+# Google Play Developer Reporting → Last9
+
+Polls Android vitals (crash rate, ANR rate, slow rendering, slow start) from the
+[Google Play Developer Reporting API](https://developers.google.com/play/developer/reporting)
+and exports them as OpenTelemetry metrics to Last9.
+
+**Data freshness:** Google processes Android vitals with a 24–48 hour lag. This is
+a Google-side constraint, not an integration limitation.
+
+## Prerequisites
+
+- Python 3.13+ or Docker
+- Google Play Console service account with **View app information and download bulk reports** permission
+- Last9 account with OTLP ingestion enabled
+
+## Google Play Console Setup
+
+1. Go to **Play Console → Setup → API access**
+2. Link or create a Google Cloud project
+3. Create a service account (or use an existing one)
+4. Grant the service account **View app information and download bulk reports (read-only)**
+5. Download the JSON key file — store it securely, never commit it
+
+## Quick Start
+
+```bash
+cp .env.example .env
+# Edit .env with your values
+
+# Set the path to your service account JSON
+export SERVICE_ACCOUNT_JSON_PATH=/path/to/your/service-account.json
+
+docker compose up
+```
+
+## Configuration
+
+| Variable | Description | Default |
+|---|---|---|
+| `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account JSON inside container | `/run/secrets/service-account.json` |
+| `ANDROID_PACKAGE_NAMES` | Comma-separated package names to monitor | `com.example.app` |
+| `POLL_INTERVAL_SECONDS` | Poll frequency (Google data is 24–48hr stale regardless) | `1800` |
+| `OTLP_ENDPOINT` | Last9 OTLP endpoint | `https://otlp.last9.io` |
+| `OTLP_HEADERS` | Auth headers (`Authorization=Basic <token>`) | — |
+| `OTEL_SERVICE_NAME` | Service name in Last9 | `google-play-reporting` |
+
+## Metrics Exported
+
+| Metric | Unit | Description |
+|---|---|---|
+| `android.vitals.crash_rate` | fraction | Daily crash rate |
+| `android.vitals.crash_rate_7d` | fraction | 7-day user-weighted crash rate |
+| `android.vitals.user_perceived_crash_rate` | fraction | Foreground crash rate |
+| `android.vitals.anr_rate` | fraction | Daily ANR rate |
+| `android.vitals.anr_rate_7d` | fraction | 7-day user-weighted ANR rate |
+| `android.vitals.user_perceived_anr_rate` | fraction | Foreground ANR rate |
+| `android.vitals.slow_rendering_rate_20fps` | fraction | Sessions with <20 FPS rendering |
+| `android.vitals.slow_rendering_rate_30fps` | fraction | Sessions with <30 FPS rendering |
+| `android.vitals.slow_start_rate` | fraction | Fraction of slow app starts |
+
+All metrics carry `android.package`, `android.versionCode`, and `android.apiLevel` attributes.
+
+## Run without Docker
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+export ANDROID_PACKAGE_NAMES=com.example.app
+export OTLP_ENDPOINT=https://otlp.last9.io
+export OTLP_HEADERS="Authorization=Basic <your-token>"
+
+python main.py
+```
+
+## Verification
+
+After starting the collector, check Last9 for metrics with the prefix `android.vitals.*`.
+You can also check the container logs:
+
+```
+2026-02-26 10:00:00 INFO Polling package: com.example.app
+2026-02-26 10:00:02 INFO Fetched 142 rows from com.example.app / crashRateMetricSet
+2026-02-26 10:00:03 INFO Fetched 138 rows from com.example.app / anrRateMetricSet
+```

--- a/python/google-play-reporting/README.md
+++ b/python/google-play-reporting/README.md
@@ -1,11 +1,11 @@
 # Google Play Developer Reporting → Last9
 
-Polls Android vitals (crash rate, ANR rate, slow rendering, slow start) from the
+Polls all Android vitals metric sets from the
 [Google Play Developer Reporting API](https://developers.google.com/play/developer/reporting)
-and exports them as OpenTelemetry metrics to Last9.
+and exports them as OpenTelemetry metrics (+ anomaly log events) to Last9.
 
-**Data freshness:** Google processes Android vitals with a 24–48 hour lag. This is
-a Google-side constraint, not an integration limitation.
+**Data freshness:** Daily metrics lag 24–48 hours; hourly error counts lag ~2–4 hours.
+Both are Google-side constraints, not integration limitations.
 
 ## Prerequisites
 
@@ -39,26 +39,91 @@ docker compose up
 |---|---|---|
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account JSON inside container | `/run/secrets/service-account.json` |
 | `ANDROID_PACKAGE_NAMES` | Comma-separated package names to monitor | `com.example.app` |
-| `POLL_INTERVAL_SECONDS` | Poll frequency (Google data is 24–48hr stale regardless) | `1800` |
+| `POLL_INTERVAL_SECONDS` | Poll frequency in seconds | `1800` |
+| `POLL_DAYS_BACK` | Days of history to fetch each poll | `30` |
+| `ENABLE_HOURLY` | Also poll crash/ANR at hourly granularity (~2–4h lag) | `false` |
+| `ANDROID_DIMENSIONS` | Comma-separated dimensions (e.g. `versionCode,apiLevel`) | _(aggregate)_ |
 | `OTLP_ENDPOINT` | Last9 OTLP endpoint | `https://otlp.last9.io` |
 | `OTLP_HEADERS` | Auth headers (`Authorization=Basic <token>`) | — |
-| `OTEL_SERVICE_NAME` | Service name in Last9 | `google-play-reporting` |
+| `OTEL_SERVICE_NAME` | Service name shown in Last9 | `google-play-reporting` |
+
+> **Dimension note:** Google may return empty rows for per-dimension queries on low-traffic apps.
+> Start with `ANDROID_DIMENSIONS=` (empty) and only enable dimensions once you confirm aggregate data flows.
 
 ## Metrics Exported
 
-| Metric | Unit | Description |
-|---|---|---|
-| `android.vitals.crash_rate` | fraction | Daily crash rate |
-| `android.vitals.crash_rate_7d` | fraction | 7-day user-weighted crash rate |
-| `android.vitals.user_perceived_crash_rate` | fraction | Foreground crash rate |
-| `android.vitals.anr_rate` | fraction | Daily ANR rate |
-| `android.vitals.anr_rate_7d` | fraction | 7-day user-weighted ANR rate |
-| `android.vitals.user_perceived_anr_rate` | fraction | Foreground ANR rate |
-| `android.vitals.slow_rendering_rate_20fps` | fraction | Sessions with <20 FPS rendering |
-| `android.vitals.slow_rendering_rate_30fps` | fraction | Sessions with <30 FPS rendering |
-| `android.vitals.slow_start_rate` | fraction | Fraction of slow app starts |
+### Crash rate (`crashRateMetricSet`)
+| Metric | Description |
+|---|---|
+| `android.vitals.crash_rate` | Daily crash rate |
+| `android.vitals.crash_rate_7d` | 7-day user-weighted crash rate |
+| `android.vitals.crash_rate_28d` | 28-day user-weighted crash rate |
+| `android.vitals.user_perceived_crash_rate` | Foreground crash rate |
+| `android.vitals.user_perceived_crash_rate_7d` | 7-day user-perceived crash rate |
+| `android.vitals.user_perceived_crash_rate_28d` | 28-day user-perceived crash rate |
 
-All metrics carry `android.package`, `android.versionCode`, and `android.apiLevel` attributes.
+### ANR rate (`anrRateMetricSet`)
+| Metric | Description |
+|---|---|
+| `android.vitals.anr_rate` | Daily ANR rate |
+| `android.vitals.anr_rate_7d` | 7-day user-weighted ANR rate |
+| `android.vitals.anr_rate_28d` | 28-day user-weighted ANR rate |
+| `android.vitals.user_perceived_anr_rate` | Foreground ANR rate |
+| `android.vitals.user_perceived_anr_rate_7d` | 7-day user-perceived ANR rate |
+| `android.vitals.user_perceived_anr_rate_28d` | 28-day user-perceived ANR rate |
+
+### Slow rendering (`slowRenderingRateMetricSet`)
+| Metric | Description |
+|---|---|
+| `android.vitals.slow_rendering_rate_20fps` | Sessions rendering below 20 FPS |
+| `android.vitals.slow_rendering_rate_20fps_7d` | 7-day slow rendering <20 FPS |
+| `android.vitals.slow_rendering_rate_30fps` | Sessions rendering below 30 FPS |
+| `android.vitals.slow_rendering_rate_30fps_7d` | 7-day slow rendering <30 FPS |
+
+### Slow start (`slowStartRateMetricSet`)
+Broken down by `android.startType` dimension (COLD / WARM / HOT).
+
+| Metric | Description |
+|---|---|
+| `android.vitals.slow_start_rate` | Fraction of slow app starts |
+| `android.vitals.slow_start_rate_7d` | 7-day slow start rate |
+| `android.vitals.slow_start_rate_28d` | 28-day slow start rate |
+
+### Excessive wakeup (`excessiveWakeupRateMetricSet`)
+| Metric | Description |
+|---|---|
+| `android.vitals.excessive_wakeup_rate` | Sessions with >10 AlarmManager wakeups/hour |
+| `android.vitals.excessive_wakeup_rate_7d` | 7-day excessive wakeup rate |
+| `android.vitals.excessive_wakeup_rate_28d` | 28-day excessive wakeup rate |
+
+### Stuck background wakelock (`stuckBackgroundWakelockRateMetricSet`)
+| Metric | Description |
+|---|---|
+| `android.vitals.stuck_background_wakelock_rate` | Sessions with wakelock held >1 hour in background |
+| `android.vitals.stuck_background_wakelock_rate_7d` | 7-day stuck wakelock rate |
+| `android.vitals.stuck_background_wakelock_rate_28d` | 28-day stuck wakelock rate |
+
+### Low Memory Kill (`lmkRateMetricSet`)
+| Metric | Description |
+|---|---|
+| `android.vitals.lmk_rate` | App killed by Android OOM killer during active use |
+| `android.vitals.lmk_rate_7d` | 7-day LMK rate |
+| `android.vitals.lmk_rate_28d` | 28-day LMK rate |
+
+### Error counts (`errorCountMetricSet`, hourly)
+Broken down by `android.reportType` dimension (CRASH / ANR).
+
+| Metric | Description |
+|---|---|
+| `android.vitals.error_report_count` | Hourly error report count (leading indicator, ~2–4h lag) |
+| `android.vitals.error_distinct_users` | Distinct users with errors |
+
+### Anomalies
+Google-detected anomalies (metric deviates from 28-day baseline) are exported as
+**OTel WARN log records** with attributes:
+- `android.package`
+- `android.vitals.anomaly.metric`
+- Any dimension values (e.g. `android.versionCode`)
 
 ## Run without Docker
 
@@ -77,11 +142,14 @@ python main.py
 
 ## Verification
 
-After starting the collector, check Last9 for metrics with the prefix `android.vitals.*`.
-You can also check the container logs:
+After starting, check Last9 for metrics with prefix `android.vitals.*`.
+Container logs show polling progress:
 
 ```
-2026-02-26 10:00:00 INFO Polling package: com.example.app
-2026-02-26 10:00:02 INFO Fetched 142 rows from com.example.app / crashRateMetricSet
-2026-02-26 10:00:03 INFO Fetched 138 rows from com.example.app / anrRateMetricSet
+2026-02-26 10:00:00 INFO Google Play Reporting collector starting
+2026-02-26 10:00:00 INFO Packages       : ['com.example.app']
+2026-02-26 10:00:01 INFO Polling: com.example.app
+2026-02-26 10:00:03 INFO   crashRateMetricSet                        142 rows
+2026-02-26 10:00:04 INFO   anrRateMetricSet                          138 rows
+2026-02-26 10:00:05 INFO   errorCountMetricSet                        96 rows
 ```

--- a/python/google-play-reporting/README.md
+++ b/python/google-play-reporting/README.md
@@ -52,71 +52,80 @@ docker compose up
 
 ## Metrics Exported
 
+All rate metrics have unit `1` (dimensionless ratio, range 0–1). In Last9/Prometheus the metric name gets a `_ratio` suffix. Count metrics use annotation units (`{user}`, `{error}`) and have no suffix.
+
 ### Crash rate (`crashRateMetricSet`)
-| Metric | Description |
-|---|---|
-| `android.vitals.crash_rate` | Daily crash rate |
-| `android.vitals.crash_rate_7d` | 7-day user-weighted crash rate |
-| `android.vitals.crash_rate_28d` | 28-day user-weighted crash rate |
-| `android.vitals.user_perceived_crash_rate` | Foreground crash rate |
-| `android.vitals.user_perceived_crash_rate_7d` | 7-day user-perceived crash rate |
-| `android.vitals.user_perceived_crash_rate_28d` | 28-day user-perceived crash rate |
+| Metric | Unit | Description |
+|---|---|---|
+| `android.vitals.crash_rate` | `1` | Daily crash rate |
+| `android.vitals.crash_rate_7d` | `1` | 7-day user-weighted crash rate |
+| `android.vitals.crash_rate_28d` | `1` | 28-day user-weighted crash rate |
+| `android.vitals.user_perceived_crash_rate` | `1` | Foreground crash rate |
+| `android.vitals.user_perceived_crash_rate_7d` | `1` | 7-day user-perceived crash rate |
+| `android.vitals.user_perceived_crash_rate_28d` | `1` | 28-day user-perceived crash rate |
+| `android.vitals.crash_distinct_users` | `{user}` | Distinct users in the crash rate denominator |
 
 ### ANR rate (`anrRateMetricSet`)
-| Metric | Description |
-|---|---|
-| `android.vitals.anr_rate` | Daily ANR rate |
-| `android.vitals.anr_rate_7d` | 7-day user-weighted ANR rate |
-| `android.vitals.anr_rate_28d` | 28-day user-weighted ANR rate |
-| `android.vitals.user_perceived_anr_rate` | Foreground ANR rate |
-| `android.vitals.user_perceived_anr_rate_7d` | 7-day user-perceived ANR rate |
-| `android.vitals.user_perceived_anr_rate_28d` | 28-day user-perceived ANR rate |
+| Metric | Unit | Description |
+|---|---|---|
+| `android.vitals.anr_rate` | `1` | Daily ANR rate |
+| `android.vitals.anr_rate_7d` | `1` | 7-day user-weighted ANR rate |
+| `android.vitals.anr_rate_28d` | `1` | 28-day user-weighted ANR rate |
+| `android.vitals.user_perceived_anr_rate` | `1` | Foreground ANR rate |
+| `android.vitals.user_perceived_anr_rate_7d` | `1` | 7-day user-perceived ANR rate |
+| `android.vitals.user_perceived_anr_rate_28d` | `1` | 28-day user-perceived ANR rate |
+| `android.vitals.anr_distinct_users` | `{user}` | Distinct users in the ANR rate denominator |
 
 ### Slow rendering (`slowRenderingRateMetricSet`)
-| Metric | Description |
-|---|---|
-| `android.vitals.slow_rendering_rate_20fps` | Sessions rendering below 20 FPS |
-| `android.vitals.slow_rendering_rate_20fps_7d` | 7-day slow rendering <20 FPS |
-| `android.vitals.slow_rendering_rate_30fps` | Sessions rendering below 30 FPS |
-| `android.vitals.slow_rendering_rate_30fps_7d` | 7-day slow rendering <30 FPS |
+| Metric | Unit | Description |
+|---|---|---|
+| `android.vitals.slow_rendering_rate_20fps` | `1` | Sessions rendering below 20 FPS |
+| `android.vitals.slow_rendering_rate_20fps_7d` | `1` | 7-day slow rendering <20 FPS |
+| `android.vitals.slow_rendering_rate_30fps` | `1` | Sessions rendering below 30 FPS |
+| `android.vitals.slow_rendering_rate_30fps_7d` | `1` | 7-day slow rendering <30 FPS |
+| `android.vitals.slow_rendering_distinct_users` | `{user}` | Distinct users in the slow rendering denominator |
 
 ### Slow start (`slowStartRateMetricSet`)
 Broken down by `android.startType` dimension (COLD / WARM / HOT).
 
-| Metric | Description |
-|---|---|
-| `android.vitals.slow_start_rate` | Fraction of slow app starts |
-| `android.vitals.slow_start_rate_7d` | 7-day slow start rate |
-| `android.vitals.slow_start_rate_28d` | 28-day slow start rate |
+| Metric | Unit | Description |
+|---|---|---|
+| `android.vitals.slow_start_rate` | `1` | Fraction of slow app starts |
+| `android.vitals.slow_start_rate_7d` | `1` | 7-day slow start rate |
+| `android.vitals.slow_start_rate_28d` | `1` | 28-day slow start rate |
+| `android.vitals.slow_start_distinct_users` | `{user}` | Distinct users in the slow start denominator |
 
 ### Excessive wakeup (`excessiveWakeupRateMetricSet`)
-| Metric | Description |
-|---|---|
-| `android.vitals.excessive_wakeup_rate` | Sessions with >10 AlarmManager wakeups/hour |
-| `android.vitals.excessive_wakeup_rate_7d` | 7-day excessive wakeup rate |
-| `android.vitals.excessive_wakeup_rate_28d` | 28-day excessive wakeup rate |
+| Metric | Unit | Description |
+|---|---|---|
+| `android.vitals.excessive_wakeup_rate` | `1` | Sessions with >10 AlarmManager wakeups/hour |
+| `android.vitals.excessive_wakeup_rate_7d` | `1` | 7-day excessive wakeup rate |
+| `android.vitals.excessive_wakeup_rate_28d` | `1` | 28-day excessive wakeup rate |
+| `android.vitals.excessive_wakeup_distinct_users` | `{user}` | Distinct users in the excessive wakeup denominator |
 
 ### Stuck background wakelock (`stuckBackgroundWakelockRateMetricSet`)
-| Metric | Description |
-|---|---|
-| `android.vitals.stuck_background_wakelock_rate` | Sessions with wakelock held >1 hour in background |
-| `android.vitals.stuck_background_wakelock_rate_7d` | 7-day stuck wakelock rate |
-| `android.vitals.stuck_background_wakelock_rate_28d` | 28-day stuck wakelock rate |
+| Metric | Unit | Description |
+|---|---|---|
+| `android.vitals.stuck_background_wakelock_rate` | `1` | Sessions with wakelock held >1 hour in background |
+| `android.vitals.stuck_background_wakelock_rate_7d` | `1` | 7-day stuck wakelock rate |
+| `android.vitals.stuck_background_wakelock_rate_28d` | `1` | 28-day stuck wakelock rate |
+| `android.vitals.stuck_wakelock_distinct_users` | `{user}` | Distinct users in the stuck wakelock denominator |
 
 ### Low Memory Kill (`lmkRateMetricSet`)
-| Metric | Description |
-|---|---|
-| `android.vitals.lmk_rate` | App killed by Android OOM killer during active use |
-| `android.vitals.lmk_rate_7d` | 7-day LMK rate |
-| `android.vitals.lmk_rate_28d` | 28-day LMK rate |
+| Metric | Unit | Description |
+|---|---|---|
+| `android.vitals.lmk_rate` | `1` | App killed by Android OOM killer during active use |
+| `android.vitals.lmk_rate_7d` | `1` | 7-day LMK rate |
+| `android.vitals.lmk_rate_28d` | `1` | 28-day LMK rate |
+| `android.vitals.lmk_distinct_users` | `{user}` | Distinct users in the LMK denominator |
 
 ### Error counts (`errorCountMetricSet`, hourly)
 Broken down by `android.reportType` dimension (CRASH / ANR).
 
-| Metric | Description |
-|---|---|
-| `android.vitals.error_report_count` | Hourly error report count (leading indicator, ~2–4h lag) |
-| `android.vitals.error_distinct_users` | Distinct users with errors |
+| Metric | Unit | Description |
+|---|---|---|
+| `android.vitals.error_report_count` | `{error}` | Hourly error report count (leading indicator, ~2–4h lag) |
+| `android.vitals.error_distinct_users` | `{user}` | Distinct users with errors |
 
 ### Anomalies
 Google-detected anomalies (metric deviates from 28-day baseline) are exported as

--- a/python/google-play-reporting/docker-compose.yaml
+++ b/python/google-play-reporting/docker-compose.yaml
@@ -1,0 +1,11 @@
+services:
+  play-reporting-collector:
+    build: .
+    env_file:
+      - .env
+    volumes:
+      # Mount the service account JSON at the path referenced by
+      # GOOGLE_APPLICATION_CREDENTIALS — the file is never baked into the image.
+      # Adjust the host path to wherever you stored the file locally.
+      - ${SERVICE_ACCOUNT_JSON_PATH:-/tmp/service-account.json}:/run/secrets/service-account.json:ro
+    restart: unless-stopped

--- a/python/google-play-reporting/main.py
+++ b/python/google-play-reporting/main.py
@@ -1,0 +1,328 @@
+"""
+Google Play Developer Reporting API → OpenTelemetry Metrics Pipeline
+
+Polls Android vitals (crash rate, ANR rate, slow rendering, slow start) from
+the Play Developer Reporting API and exports them as OTel gauge metrics via OTLP.
+
+Data freshness: Google processes data with a 24–48hr lag. Poll interval default
+is 30 minutes — increasing this does not improve freshness.
+
+Credentials: Set GOOGLE_APPLICATION_CREDENTIALS to the path of your service account
+JSON file. The file is never baked into the container image; mount it at runtime.
+"""
+
+import os
+import time
+import logging
+import requests
+
+from datetime import date, timedelta
+from google.auth.transport.requests import Request
+from google.oauth2 import service_account
+
+from opentelemetry import metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.resources import Resource
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger(__name__)
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+GOOGLE_APPLICATION_CREDENTIALS = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+PACKAGE_NAMES = [
+    p.strip()
+    for p in os.environ.get("ANDROID_PACKAGE_NAMES", "com.example.app").split(",")
+    if p.strip()
+]
+POLL_INTERVAL_SECONDS = int(os.environ.get("POLL_INTERVAL_SECONDS", "1800"))
+# How many days back to query. Google requires data to exist for a date range;
+# sparse apps (< ~500 DAU) may only have data for a few dates per month.
+POLL_DAYS_BACK = int(os.environ.get("POLL_DAYS_BACK", "30"))
+
+OTLP_ENDPOINT = os.environ.get("OTLP_ENDPOINT", "https://otlp.last9.io")
+OTLP_HEADERS = os.environ.get("OTLP_HEADERS", "")
+OTEL_SERVICE_NAME = os.environ.get("OTEL_SERVICE_NAME", "google-play-reporting")
+
+REPORTING_API_BASE = "https://playdeveloperreporting.googleapis.com/v1beta1"
+SCOPES = ["https://www.googleapis.com/auth/playdeveloperreporting"]
+
+# Dimensions to break metrics down by. Leave empty for aggregate totals.
+# Google withholds dimension-broken data when an app has fewer than ~500 DAU.
+# Set ANDROID_DIMENSIONS=versionCode,apiLevel once you have sufficient user volume.
+_raw_dims = os.environ.get("ANDROID_DIMENSIONS", "")
+DIMENSIONS = [d.strip() for d in _raw_dims.split(",") if d.strip()]
+
+# ── OTel setup ────────────────────────────────────────────────────────────────
+
+
+def _parse_otlp_headers(raw: str) -> dict:
+    """Parse 'k=v,k2=v2' style header string into a dict."""
+    if not raw:
+        return {}
+    headers = {}
+    for pair in raw.split(","):
+        if "=" in pair:
+            k, v = pair.split("=", 1)
+            headers[k.strip()] = v.strip()
+    return headers
+
+
+def build_meter_provider() -> MeterProvider:
+    resource = Resource.create({"service.name": OTEL_SERVICE_NAME})
+    exporter = OTLPMetricExporter(
+        endpoint=f"{OTLP_ENDPOINT.rstrip('/')}/v1/metrics",
+        headers=_parse_otlp_headers(OTLP_HEADERS),
+    )
+    reader = PeriodicExportingMetricReader(exporter, export_interval_millis=60_000)
+    return MeterProvider(resource=resource, metric_readers=[reader])
+
+
+# ── Google auth ───────────────────────────────────────────────────────────────
+
+
+def get_credentials() -> service_account.Credentials:
+    if not GOOGLE_APPLICATION_CREDENTIALS:
+        raise RuntimeError(
+            "GOOGLE_APPLICATION_CREDENTIALS env var is not set. "
+            "Point it to the service account JSON file path."
+        )
+    return service_account.Credentials.from_service_account_file(
+        GOOGLE_APPLICATION_CREDENTIALS,
+        scopes=SCOPES,
+    )
+
+
+def refresh_token(creds: service_account.Credentials) -> str:
+    if not creds.valid:
+        creds.refresh(Request())
+    return creds.token
+
+
+# ── API helpers ───────────────────────────────────────────────────────────────
+
+
+def _api_date(d: date) -> dict:
+    return {"year": d.year, "month": d.month, "day": d.day}
+
+
+def get_latest_date(token: str, package: str, metric_set: str) -> date:
+    """Return the most recent date for which daily data is available."""
+    url = f"{REPORTING_API_BASE}/apps/{package}/{metric_set}"
+    resp = requests.get(
+        url,
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=15,
+    )
+    resp.raise_for_status()
+    freshnesses = resp.json().get("freshnessInfo", {}).get("freshnesses", [])
+    for f in freshnesses:
+        if f.get("aggregationPeriod") == "DAILY":
+            t = f["latestEndTime"]
+            return date(t["year"], t["month"], t["day"])
+    return date.today() - timedelta(days=2)
+
+
+def query_metric_set(
+    token: str,
+    package: str,
+    metric_set: str,
+    metric_names: list[str],
+    end_date: date,
+) -> list[dict]:
+    """
+    Query a Play Developer Reporting metric set.
+    Returns rows with dimensionValues[] and metrics[{metric, decimalValue}].
+    """
+    start_date = end_date - timedelta(days=POLL_DAYS_BACK - 1)
+    url = f"{REPORTING_API_BASE}/apps/{package}/{metric_set}:query"
+    payload = {
+        "timelineSpec": {
+            "aggregationPeriod": "DAILY",
+            "startTime": _api_date(start_date),
+            "endTime": _api_date(end_date),
+        },
+        "dimensions": DIMENSIONS,
+        "metrics": metric_names,
+        "pageSize": 1000,
+    }
+    resp = requests.post(
+        url,
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=30,
+    )
+    if resp.status_code == 403:
+        log.error(
+            "403 Forbidden for %s/%s — check the service account has "
+            "'View app information and download bulk reports' in Play Console → Setup → API access",
+            package,
+            metric_set,
+        )
+        return []
+    resp.raise_for_status()
+    rows = resp.json().get("rows", [])
+    log.info("  %s: %d rows", metric_set, len(rows))
+    return rows
+
+
+# ── Metric recording ──────────────────────────────────────────────────────────
+
+
+def _row_attrs(row: dict, package: str) -> dict:
+    """Build OTel attribute dict from a row's dimensionValues."""
+    attrs = {"android.package": package}
+    dim_vals = row.get("dimensionValues", [])
+    for i, dim_name in enumerate(DIMENSIONS):
+        if i < len(dim_vals):
+            v = dim_vals[i]
+            val = v.get("stringValue") or str(v.get("int64Value", ""))
+            attrs[f"android.{dim_name}"] = val
+    return attrs
+
+
+def _metric_float(metric_entry: dict) -> float:
+    """Extract float value from a metric entry (decimalValue or int64Value)."""
+    dec = metric_entry.get("decimalValue")
+    if dec:
+        return float(dec.get("value", 0))
+    return float(metric_entry.get("int64Value", 0))
+
+
+def record_rows(rows: list[dict], gauges: dict, package: str) -> None:
+    """
+    Write the latest observation for each (package, dimension-combo) into gauges.
+
+    Each row contains metrics[] where each entry has a 'metric' name field.
+    We look up the matching gauge by name rather than relying on array position.
+    """
+    for row in rows:
+        attrs = _row_attrs(row, package)
+        for metric_entry in row.get("metrics", []):
+            name = metric_entry.get("metric")
+            if name and name in gauges:
+                gauges[name].set(_metric_float(metric_entry), attrs)
+
+
+# ── Poll loop ─────────────────────────────────────────────────────────────────
+
+
+def poll_once(creds: service_account.Credentials, gauges_by_set: dict) -> None:
+    token = refresh_token(creds)
+    for package in PACKAGE_NAMES:
+        log.info("Polling package: %s", package)
+        for metric_set, (metric_names, gauges) in gauges_by_set.items():
+            try:
+                end_date = get_latest_date(token, package, metric_set)
+                rows = query_metric_set(token, package, metric_set, metric_names, end_date)
+                record_rows(rows, gauges, package)
+            except requests.HTTPError as exc:
+                log.error("HTTP error — %s/%s: %s", package, metric_set, exc)
+            except Exception as exc:  # noqa: BLE001
+                log.error("Unexpected error — %s/%s: %s", package, metric_set, exc)
+
+
+def main() -> None:
+    log.info("Starting Google Play Reporting collector")
+    log.info("Packages: %s", PACKAGE_NAMES)
+    log.info("Poll interval: %ds", POLL_INTERVAL_SECONDS)
+    log.info("OTLP endpoint: %s", OTLP_ENDPOINT)
+
+    creds = get_credentials()
+
+    provider = build_meter_provider()
+    metrics.set_meter_provider(provider)
+    meter = metrics.get_meter("google.play.reporting", version="1.0.0")
+
+    def gauge(name: str, unit: str, description: str):
+        return meter.create_gauge(name, unit=unit, description=description)
+
+    # Each entry: metric_set_name → (api_metric_names[], {api_name: OTel gauge})
+    gauges_by_set: dict[str, tuple[list, dict]] = {
+        "crashRateMetricSet": (
+            ["crashRate", "crashRate7dUserWeighted", "userPerceivedCrashRate", "distinctUsers"],
+            {
+                "crashRate": gauge(
+                    "android.vitals.crash_rate", "1",
+                    "Daily crash rate (fraction of sessions with a crash)",
+                ),
+                "crashRate7dUserWeighted": gauge(
+                    "android.vitals.crash_rate_7d", "1",
+                    "7-day user-weighted crash rate",
+                ),
+                "userPerceivedCrashRate": gauge(
+                    "android.vitals.user_perceived_crash_rate", "1",
+                    "Foreground crash rate as perceived by users",
+                ),
+                "distinctUsers": gauge(
+                    "android.vitals.crash_distinct_users", "1",
+                    "Distinct users counted in the crash rate denominator",
+                ),
+            },
+        ),
+        "anrRateMetricSet": (
+            ["anrRate", "anrRate7dUserWeighted", "userPerceivedAnrRate", "distinctUsers"],
+            {
+                "anrRate": gauge(
+                    "android.vitals.anr_rate", "1",
+                    "Daily ANR rate",
+                ),
+                "anrRate7dUserWeighted": gauge(
+                    "android.vitals.anr_rate_7d", "1",
+                    "7-day user-weighted ANR rate",
+                ),
+                "userPerceivedAnrRate": gauge(
+                    "android.vitals.user_perceived_anr_rate", "1",
+                    "Foreground ANR rate as perceived by users",
+                ),
+                "distinctUsers": gauge(
+                    "android.vitals.anr_distinct_users", "1",
+                    "Distinct users counted in the ANR rate denominator",
+                ),
+            },
+        ),
+        "slowRenderingRateMetricSet": (
+            ["slowRenderingRate20Fps", "slowRenderingRate30Fps", "distinctUsers"],
+            {
+                "slowRenderingRate20Fps": gauge(
+                    "android.vitals.slow_rendering_rate_20fps", "1",
+                    "Fraction of sessions with slow rendering (below 20 FPS)",
+                ),
+                "slowRenderingRate30Fps": gauge(
+                    "android.vitals.slow_rendering_rate_30fps", "1",
+                    "Fraction of sessions with slow rendering (below 30 FPS)",
+                ),
+                "distinctUsers": gauge(
+                    "android.vitals.slow_rendering_distinct_users", "1",
+                    "Distinct users in slow rendering denominator",
+                ),
+            },
+        ),
+        "slowStartRateMetricSet": (
+            ["slowStartRate", "distinctUsers"],
+            {
+                "slowStartRate": gauge(
+                    "android.vitals.slow_start_rate", "1",
+                    "Fraction of app starts that are slow",
+                ),
+                "distinctUsers": gauge(
+                    "android.vitals.slow_start_distinct_users", "1",
+                    "Distinct users in slow start denominator",
+                ),
+            },
+        ),
+    }
+
+    while True:
+        poll_once(creds, gauges_by_set)
+        log.info("Sleeping %ds until next poll…", POLL_INTERVAL_SECONDS)
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/google-play-reporting/main.py
+++ b/python/google-play-reporting/main.py
@@ -1,71 +1,194 @@
 """
-Google Play Developer Reporting API → OpenTelemetry Metrics Pipeline
+Google Play Developer Reporting API → OpenTelemetry Pipeline
 
-Polls Android vitals (crash rate, ANR rate, slow rendering, slow start) from
-the Play Developer Reporting API and exports them as OTel gauge metrics via OTLP.
+Polls all Android vitals metric sets from the Play Developer Reporting API
+and exports them as OTLP gauge metrics + anomaly log events.
 
-Data freshness: Google processes data with a 24–48hr lag. Poll interval default
-is 30 minutes — increasing this does not improve freshness.
+Each API row carries a startTime (the measurement date). We POST OTLP/HTTP JSON
+directly — bypassing the OTel SDK gauge abstraction — so every row is exported
+as a distinct data point with its correct historical timestamp.
 
-Credentials: Set GOOGLE_APPLICATION_CREDENTIALS to the path of your service account
-JSON file. The file is never baked into the container image; mount it at runtime.
+Metric sets covered:
+  - crashRateMetricSet         (daily)
+  - anrRateMetricSet           (daily)
+  - slowRenderingRateMetricSet (daily)
+  - slowStartRateMetricSet     (daily, startType dimension required)
+  - excessiveWakeupRateMetricSet  (daily)
+  - stuckBackgroundWakelockRateMetricSet (daily)
+  - lmkRateMetricSet           (daily — Low Memory Kill)
+  - errorCountMetricSet        (hourly — leading indicator, 2-4h lag)
+  - anomalies                  → exported as OTel WARN log records
+
+Data freshness: daily metrics lag 24-48h; hourly metrics lag ~2-4h.
 """
 
-import os
-import time
-import logging
-import requests
+from __future__ import annotations
 
-from datetime import date, timedelta
+import logging
+import os
+import signal
+import time
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+import requests
 from google.auth.transport.requests import Request
 from google.oauth2 import service_account
-
-from opentelemetry import metrics
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry._logs import SeverityNumber, set_logger_provider
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.resources import Resource
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s %(message)s",
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 log = logging.getLogger(__name__)
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
 GOOGLE_APPLICATION_CREDENTIALS = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+
 PACKAGE_NAMES = [
     p.strip()
     for p in os.environ.get("ANDROID_PACKAGE_NAMES", "com.example.app").split(",")
     if p.strip()
 ]
+
 POLL_INTERVAL_SECONDS = int(os.environ.get("POLL_INTERVAL_SECONDS", "1800"))
-# How many days back to query. Google requires data to exist for a date range;
-# sparse apps (< ~500 DAU) may only have data for a few dates per month.
 POLL_DAYS_BACK = int(os.environ.get("POLL_DAYS_BACK", "30"))
+ENABLE_HOURLY = os.environ.get("ENABLE_HOURLY", "false").lower() == "true"
 
 OTLP_ENDPOINT = os.environ.get("OTLP_ENDPOINT", "https://otlp.last9.io")
-OTLP_HEADERS = os.environ.get("OTLP_HEADERS", "")
+OTLP_HEADERS_RAW = os.environ.get("OTLP_HEADERS", "")
 OTEL_SERVICE_NAME = os.environ.get("OTEL_SERVICE_NAME", "google-play-reporting")
+
+_raw_dims = os.environ.get("ANDROID_DIMENSIONS", "")
+DIMENSIONS: list[str] = [d.strip() for d in _raw_dims.split(",") if d.strip()]
 
 REPORTING_API_BASE = "https://playdeveloperreporting.googleapis.com/v1beta1"
 SCOPES = ["https://www.googleapis.com/auth/playdeveloperreporting"]
 
-# Dimensions to break metrics down by. Leave empty for aggregate totals.
-# Google withholds dimension-broken data when an app has fewer than ~500 DAU.
-# Set ANDROID_DIMENSIONS=versionCode,apiLevel once you have sufficient user volume.
-_raw_dims = os.environ.get("ANDROID_DIMENSIONS", "")
-DIMENSIONS = [d.strip() for d in _raw_dims.split(",") if d.strip()]
+# ── Metric catalogue ──────────────────────────────────────────────────────────
+# Maps: metric_set → { api_metric_name → (otel_name, unit, description) }
 
-# ── OTel setup ────────────────────────────────────────────────────────────────
+METRIC_CATALOGUE: dict[str, dict[str, tuple[str, str, str]]] = {
+    "crashRateMetricSet": {
+        "crashRate": ("android.vitals.crash_rate", "1",
+                      "Daily crash rate (fraction of sessions with a crash)"),
+        "crashRate7dUserWeighted": ("android.vitals.crash_rate_7d", "1",
+                                    "7-day user-weighted crash rate"),
+        "crashRate28dUserWeighted": ("android.vitals.crash_rate_28d", "1",
+                                     "28-day user-weighted crash rate"),
+        "userPerceivedCrashRate": ("android.vitals.user_perceived_crash_rate", "1",
+                                   "Foreground crash rate (user-visible crashes only)"),
+        "userPerceivedCrashRate7dUserWeighted": ("android.vitals.user_perceived_crash_rate_7d",
+                                                 "1", "7-day user-perceived crash rate"),
+        "userPerceivedCrashRate28dUserWeighted": ("android.vitals.user_perceived_crash_rate_28d",
+                                                  "1", "28-day user-perceived crash rate"),
+        "distinctUsers": ("android.vitals.crash_distinct_users", "{user}",
+                          "Distinct users in the crash rate denominator"),
+    },
+    "anrRateMetricSet": {
+        "anrRate": ("android.vitals.anr_rate", "1", "Daily ANR rate"),
+        "anrRate7dUserWeighted": ("android.vitals.anr_rate_7d", "1",
+                                  "7-day user-weighted ANR rate"),
+        "anrRate28dUserWeighted": ("android.vitals.anr_rate_28d", "1",
+                                   "28-day user-weighted ANR rate"),
+        "userPerceivedAnrRate": ("android.vitals.user_perceived_anr_rate", "1",
+                                 "Foreground ANR rate (user-visible only)"),
+        "userPerceivedAnrRate7dUserWeighted": ("android.vitals.user_perceived_anr_rate_7d",
+                                               "1", "7-day user-perceived ANR rate"),
+        "userPerceivedAnrRate28dUserWeighted": ("android.vitals.user_perceived_anr_rate_28d",
+                                                "1", "28-day user-perceived ANR rate"),
+        "distinctUsers": ("android.vitals.anr_distinct_users", "{user}",
+                          "Distinct users in the ANR rate denominator"),
+    },
+    "slowRenderingRateMetricSet": {
+        "slowRenderingRate20Fps": ("android.vitals.slow_rendering_rate_20fps", "1",
+                                   "Sessions with rendering below 20 FPS"),
+        "slowRenderingRate20Fps7dUserWeighted": ("android.vitals.slow_rendering_rate_20fps_7d",
+                                                 "1", "7-day slow rendering <20fps"),
+        "slowRenderingRate30Fps": ("android.vitals.slow_rendering_rate_30fps", "1",
+                                   "Sessions with rendering below 30 FPS"),
+        "slowRenderingRate30Fps7dUserWeighted": ("android.vitals.slow_rendering_rate_30fps_7d",
+                                                 "1", "7-day slow rendering <30fps"),
+        "distinctUsers": ("android.vitals.slow_rendering_distinct_users", "{user}",
+                          "Distinct users in the slow rendering denominator"),
+    },
+    "slowStartRateMetricSet": {
+        "slowStartRate": ("android.vitals.slow_start_rate", "1",
+                          "Fraction of slow app starts (threshold varies by startType)"),
+        "slowStartRate7dUserWeighted": ("android.vitals.slow_start_rate_7d", "1",
+                                        "7-day slow start rate"),
+        "slowStartRate28dUserWeighted": ("android.vitals.slow_start_rate_28d", "1",
+                                         "28-day slow start rate"),
+        "distinctUsers": ("android.vitals.slow_start_distinct_users", "{user}",
+                          "Distinct users in the slow start denominator"),
+    },
+    "excessiveWakeupRateMetricSet": {
+        "excessiveWakeupRate": ("android.vitals.excessive_wakeup_rate", "1",
+                                "Sessions with >10 AlarmManager wakeups/hour"),
+        "excessiveWakeupRate7dUserWeighted": ("android.vitals.excessive_wakeup_rate_7d", "1",
+                                              "7-day excessive wakeup rate"),
+        "excessiveWakeupRate28dUserWeighted": ("android.vitals.excessive_wakeup_rate_28d", "1",
+                                               "28-day excessive wakeup rate"),
+        "distinctUsers": ("android.vitals.excessive_wakeup_distinct_users", "{user}",
+                          "Distinct users in the excessive wakeup denominator"),
+    },
+    "stuckBackgroundWakelockRateMetricSet": {
+        "stuckBgWakelockRate": ("android.vitals.stuck_background_wakelock_rate", "1",
+                                "Sessions where a background wakelock was held >1 hour"),
+        "stuckBgWakelockRate7dUserWeighted": ("android.vitals.stuck_background_wakelock_rate_7d",
+                                              "1", "7-day stuck background wakelock rate"),
+        "stuckBgWakelockRate28dUserWeighted": ("android.vitals.stuck_background_wakelock_rate_28d",
+                                               "1", "28-day stuck background wakelock rate"),
+        "distinctUsers": ("android.vitals.stuck_wakelock_distinct_users", "{user}",
+                          "Distinct users in the stuck wakelock denominator"),
+    },
+    "lmkRateMetricSet": {
+        "userPerceivedLmkRate": ("android.vitals.lmk_rate", "1",
+                                 "Active-use LMK rate (app killed by Android OOM killer)"),
+        "userPerceivedLmkRate7dUserWeighted": ("android.vitals.lmk_rate_7d", "1",
+                                               "7-day LMK rate"),
+        "userPerceivedLmkRate28dUserWeighted": ("android.vitals.lmk_rate_28d", "1",
+                                                "28-day LMK rate"),
+        "distinctUsers": ("android.vitals.lmk_distinct_users", "{user}",
+                          "Distinct users in the LMK denominator"),
+    },
+    "errorCountMetricSet": {
+        "errorReportCount": ("android.vitals.error_report_count", "{error}",
+                             "Hourly error report count (leading indicator, ~2-4h lag)"),
+        "distinctUsers": ("android.vitals.error_distinct_users", "{user}",
+                          "Distinct users with errors in this hour"),
+    },
+}
+
+# ── Query config ──────────────────────────────────────────────────────────────
+
+DAILY_METRIC_NAMES: dict[str, list[str]] = {
+    ms: list(catalogue.keys())
+    for ms, catalogue in METRIC_CATALOGUE.items()
+    if ms != "errorCountMetricSet"
+}
+
+HOURLY_METRIC_NAMES: dict[str, list[str]] = {
+    "crashRateMetricSet": ["crashRate", "userPerceivedCrashRate", "distinctUsers"],
+    "anrRateMetricSet": ["anrRate", "userPerceivedAnrRate", "distinctUsers"],
+}
+
+# slowStartRateMetricSet requires startType as a mandatory extra dimension.
+DAILY_REQUIRED_EXTRA_DIMS: dict[str, list[str]] = {
+    "slowStartRateMetricSet": ["startType"],
+}
+
+# errorCountMetricSet requires reportType and does not support countryCode.
+ERROR_COUNT_EXTRA_DIMS = ["reportType"]
+ERROR_COUNT_UNSUPPORTED_DIMS = frozenset(["countryCode"])
+
+# ── OTel log provider (anomalies only) ────────────────────────────────────────
 
 
-def _parse_otlp_headers(raw: str) -> dict:
-    """Parse 'k=v,k2=v2' style header string into a dict."""
-    if not raw:
-        return {}
-    headers = {}
+def _parse_headers(raw: str) -> dict[str, str]:
+    headers: dict[str, str] = {}
     for pair in raw.split(","):
         if "=" in pair:
             k, v = pair.split("=", 1)
@@ -73,32 +196,32 @@ def _parse_otlp_headers(raw: str) -> dict:
     return headers
 
 
-def build_meter_provider() -> MeterProvider:
+def build_logger_provider() -> LoggerProvider:
     resource = Resource.create({"service.name": OTEL_SERVICE_NAME})
-    exporter = OTLPMetricExporter(
-        endpoint=f"{OTLP_ENDPOINT.rstrip('/')}/v1/metrics",
-        headers=_parse_otlp_headers(OTLP_HEADERS),
+    exporter = OTLPLogExporter(
+        endpoint=f"{OTLP_ENDPOINT.rstrip('/')}/v1/logs",
+        headers=_parse_headers(OTLP_HEADERS_RAW),
     )
-    reader = PeriodicExportingMetricReader(exporter, export_interval_millis=60_000)
-    return MeterProvider(resource=resource, metric_readers=[reader])
+    provider = LoggerProvider(resource=resource)
+    provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+    return provider
 
 
 # ── Google auth ───────────────────────────────────────────────────────────────
 
 
-def get_credentials() -> service_account.Credentials:
+def load_credentials() -> service_account.Credentials:
     if not GOOGLE_APPLICATION_CREDENTIALS:
         raise RuntimeError(
-            "GOOGLE_APPLICATION_CREDENTIALS env var is not set. "
+            "GOOGLE_APPLICATION_CREDENTIALS is not set. "
             "Point it to the service account JSON file path."
         )
     return service_account.Credentials.from_service_account_file(
-        GOOGLE_APPLICATION_CREDENTIALS,
-        scopes=SCOPES,
+        GOOGLE_APPLICATION_CREDENTIALS, scopes=SCOPES
     )
 
 
-def refresh_token(creds: service_account.Credentials) -> str:
+def bearer_token(creds: service_account.Credentials) -> str:
     if not creds.valid:
         creds.refresh(Request())
     return creds.token
@@ -107,220 +230,331 @@ def refresh_token(creds: service_account.Credentials) -> str:
 # ── API helpers ───────────────────────────────────────────────────────────────
 
 
-def _api_date(d: date) -> dict:
+def _to_api_date(d: date) -> dict:
     return {"year": d.year, "month": d.month, "day": d.day}
 
 
-def get_latest_date(token: str, package: str, metric_set: str) -> date:
-    """Return the most recent date for which daily data is available."""
+def _to_api_datetime(dt: datetime) -> dict:
+    return {"year": dt.year, "month": dt.month, "day": dt.day,
+            "hours": dt.hour, "minutes": dt.minute}
+
+
+def get_freshness(token: str, package: str, metric_set: str) -> dict[str, date]:
     url = f"{REPORTING_API_BASE}/apps/{package}/{metric_set}"
-    resp = requests.get(
-        url,
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=15,
-    )
+    resp = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=15)
     resp.raise_for_status()
-    freshnesses = resp.json().get("freshnessInfo", {}).get("freshnesses", [])
-    for f in freshnesses:
-        if f.get("aggregationPeriod") == "DAILY":
-            t = f["latestEndTime"]
-            return date(t["year"], t["month"], t["day"])
-    return date.today() - timedelta(days=2)
+    result: dict[str, date] = {}
+    for f in resp.json().get("freshnessInfo", {}).get("freshnesses", []):
+        period = f.get("aggregationPeriod")
+        t = f.get("latestEndTime", {})
+        if period and t:
+            result[period] = date(t["year"], t["month"], t["day"])
+    return result
 
 
-def query_metric_set(
-    token: str,
-    package: str,
-    metric_set: str,
-    metric_names: list[str],
-    end_date: date,
+def query_daily(
+    token: str, package: str, metric_set: str, metric_names: list[str],
+    end: date, extra_dims: list[str] | None = None, base_dims: list[str] | None = None,
 ) -> list[dict]:
-    """
-    Query a Play Developer Reporting metric set.
-    Returns rows with dimensionValues[] and metrics[{metric, decimalValue}].
-    """
-    start_date = end_date - timedelta(days=POLL_DAYS_BACK - 1)
+    start = end - timedelta(days=POLL_DAYS_BACK - 1)
+    dims = (base_dims if base_dims is not None else DIMENSIONS) + (extra_dims or [])
+    return _post_query(token, package, metric_set, {
+        "timelineSpec": {"aggregationPeriod": "DAILY",
+                         "startTime": _to_api_date(start), "endTime": _to_api_date(end)},
+        "dimensions": dims, "metrics": metric_names, "pageSize": 1000,
+    })
+
+
+def query_hourly(
+    token: str, package: str, metric_set: str, metric_names: list[str],
+    end: date, extra_dims: list[str] | None = None, base_dims: list[str] | None = None,
+) -> list[dict]:
+    end_dt = datetime(end.year, end.month, end.day, tzinfo=timezone.utc)
+    start_dt = end_dt - timedelta(hours=48)
+    dims = (base_dims if base_dims is not None else DIMENSIONS) + (extra_dims or [])
+    return _post_query(token, package, metric_set, {
+        "timelineSpec": {"aggregationPeriod": "HOURLY",
+                         "startTime": _to_api_datetime(start_dt),
+                         "endTime": _to_api_datetime(end_dt)},
+        "dimensions": dims, "metrics": metric_names, "pageSize": 1000,
+    })
+
+
+def _post_query(token: str, package: str, metric_set: str, payload: dict) -> list[dict]:
     url = f"{REPORTING_API_BASE}/apps/{package}/{metric_set}:query"
-    payload = {
-        "timelineSpec": {
-            "aggregationPeriod": "DAILY",
-            "startTime": _api_date(start_date),
-            "endTime": _api_date(end_date),
-        },
-        "dimensions": DIMENSIONS,
-        "metrics": metric_names,
-        "pageSize": 1000,
-    }
-    resp = requests.post(
-        url,
-        json=payload,
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=30,
-    )
+    resp = requests.post(url, json=payload,
+                         headers={"Authorization": f"Bearer {token}"}, timeout=30)
     if resp.status_code == 403:
-        log.error(
-            "403 Forbidden for %s/%s — check the service account has "
-            "'View app information and download bulk reports' in Play Console → Setup → API access",
-            package,
-            metric_set,
-        )
+        log.warning("403 Forbidden: %s/%s — check service account permissions",
+                    package, metric_set)
+        return []
+    if resp.status_code == 400:
+        log.warning("400 Bad Request: %s/%s — %s", package, metric_set,
+                    resp.json().get("error", {}).get("message", ""))
         return []
     resp.raise_for_status()
     rows = resp.json().get("rows", [])
-    log.info("  %s: %d rows", metric_set, len(rows))
+    log.info("  %-40s %3d rows", metric_set, len(rows))
     return rows
 
 
-# ── Metric recording ──────────────────────────────────────────────────────────
+def list_anomalies(token: str, package: str) -> list[dict]:
+    url = f"{REPORTING_API_BASE}/apps/{package}/anomalies"
+    resp = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=15)
+    if resp.status_code in (403, 404):
+        return []
+    resp.raise_for_status()
+    items = resp.json().get("anomalies", [])
+    log.info("  %-40s %3d anomalies", "anomalies", len(items))
+    return items
 
 
-def _row_attrs(row: dict, package: str) -> dict:
-    """Build OTel attribute dict from a row's dimensionValues."""
-    attrs = {"android.package": package}
-    dim_vals = row.get("dimensionValues", [])
-    for i, dim_name in enumerate(DIMENSIONS):
-        if i < len(dim_vals):
-            v = dim_vals[i]
-            val = v.get("stringValue") or str(v.get("int64Value", ""))
-            attrs[f"android.{dim_name}"] = val
+# ── OTLP/HTTP JSON export ─────────────────────────────────────────────────────
+
+
+def _row_time_ns(row: dict) -> str:
+    """Extract the row's startTime as a Unix nanosecond string for OTLP JSON."""
+    st = row.get("startTime", {})
+    if st:
+        dt = datetime(st["year"], st["month"], st["day"], 12, 0, 0, tzinfo=timezone.utc)
+    else:
+        dt = datetime.now(timezone.utc)
+    return str(int(dt.timestamp() * 1_000_000_000))
+
+
+_DIM_KEY_MAP = {
+    "reportType": "report_type",
+    "startType": "start_type",
+    "versionCode": "version_code",
+    "apiLevel": "api_level",
+    "countryCode": "country_code",
+    "deviceType": "device_type",
+    "deviceRamBucket": "device_ram_bucket",
+    "deviceSocMake": "device_soc_make",
+    "deviceSocModel": "device_soc_model",
+    "deviceAvailableRam": "device_available_ram",
+    "deviceLargeRam": "device_large_ram",
+}
+
+
+def _otlp_attrs(package: str, row: dict) -> list[dict]:
+    """Build OTLP attribute list from a row's dimensions."""
+    attrs = [
+        {"key": "android.package", "value": {"stringValue": package}},
+    ]
+    # Always include the measurement date so users can filter by specific days in Last9.
+    st = row.get("startTime", {})
+    if st:
+        date_str = f"{st['year']}-{st['month']:02d}-{st['day']:02d}"
+        attrs.append({"key": "android.date", "value": {"stringValue": date_str}})
+    # The API returns dimensions as [{dimension: "reportType", stringValue: "ANR"}, ...]
+    for dim_entry in row.get("dimensions", []):
+        api_name = dim_entry.get("dimension", "")
+        if not api_name:
+            continue
+        val = dim_entry.get("stringValue") or str(dim_entry.get("int64Value", ""))
+        attr_key = f"android.{_DIM_KEY_MAP.get(api_name, api_name)}"
+        attrs.append({"key": attr_key, "value": {"stringValue": val}})
     return attrs
 
 
-def _metric_float(metric_entry: dict) -> float:
-    """Extract float value from a metric entry (decimalValue or int64Value)."""
-    dec = metric_entry.get("decimalValue")
+def _metric_value(entry: dict) -> tuple[str, Any]:
+    """Return ('asDouble', float) or ('asInt', int) for an OTLP data point."""
+    dec = entry.get("decimalValue")
     if dec:
-        return float(dec.get("value", 0))
-    return float(metric_entry.get("int64Value", 0))
+        return "asDouble", float(dec["value"])
+    i64 = entry.get("int64Value")
+    if i64 is not None:
+        return "asInt", str(int(i64))
+    return "asDouble", 0.0
 
 
-def record_rows(rows: list[dict], gauges: dict, package: str) -> None:
+def send_otlp_metrics(
+    rows_by_set: list[tuple[str, list[dict]]],
+    package: str,
+) -> None:
     """
-    Write the latest observation for each (package, dimension-combo) into gauges.
+    POST all rows to Last9 as OTLP/HTTP JSON gauge data points.
 
-    Each row contains metrics[] where each entry has a 'metric' name field.
-    We look up the matching gauge by name rather than relying on array position.
+    rows_by_set: list of (metric_set, rows)
+    Each row gets its own data point with the row's startTime as the timestamp.
     """
-    for row in rows:
-        attrs = _row_attrs(row, package)
-        for metric_entry in row.get("metrics", []):
-            name = metric_entry.get("metric")
-            if name and name in gauges:
-                gauges[name].set(_metric_float(metric_entry), attrs)
+    data_points_by_otel_name: dict[str, tuple[str, str, list[dict]]] = {}
+
+    for metric_set, rows in rows_by_set:
+        catalogue = METRIC_CATALOGUE.get(metric_set, {})
+        for row in rows:
+            time_ns = _row_time_ns(row)
+            attrs = _otlp_attrs(package, row)
+            for entry in row.get("metrics", []):
+                api_name = entry.get("metric")
+                if api_name not in catalogue:
+                    continue
+                otel_name, unit, description = catalogue[api_name]
+                val_key, val = _metric_value(entry)
+                dp = {"attributes": attrs, "timeUnixNano": time_ns, val_key: val}
+                if otel_name not in data_points_by_otel_name:
+                    data_points_by_otel_name[otel_name] = (unit, description, [])
+                data_points_by_otel_name[otel_name][2].append(dp)
+
+    if not data_points_by_otel_name:
+        return
+
+    metrics_payload = [
+        {
+            "name": otel_name,
+            "unit": unit,
+            "description": description,
+            "gauge": {"dataPoints": dps},
+        }
+        for otel_name, (unit, description, dps) in data_points_by_otel_name.items()
+    ]
+
+    payload = {
+        "resourceMetrics": [{
+            "resource": {
+                "attributes": [
+                    {"key": "service.name", "value": {"stringValue": OTEL_SERVICE_NAME}},
+                    {"key": "telemetry.sdk.language", "value": {"stringValue": "python"}},
+                ]
+            },
+            "scopeMetrics": [{
+                "scope": {"name": "google.play.reporting", "version": "1.0.0"},
+                "metrics": metrics_payload,
+            }],
+        }]
+    }
+
+    headers = {**_parse_headers(OTLP_HEADERS_RAW), "Content-Type": "application/json"}
+    resp = requests.post(
+        f"{OTLP_ENDPOINT.rstrip('/')}/v1/metrics",
+        json=payload,
+        headers=headers,
+        timeout=30,
+    )
+    if resp.status_code not in (200, 204):
+        log.warning("OTLP export failed: HTTP %s — %s", resp.status_code, resp.text[:200])
+    else:
+        total_dps = sum(len(v[2]) for v in data_points_by_otel_name.values())
+        log.info("Exported %d data points (%d metrics) to Last9",
+                 total_dps, len(data_points_by_otel_name))
 
 
-# ── Poll loop ─────────────────────────────────────────────────────────────────
+# ── Anomaly log records ───────────────────────────────────────────────────────
 
 
-def poll_once(creds: service_account.Credentials, gauges_by_set: dict) -> None:
-    token = refresh_token(creds)
-    for package in PACKAGE_NAMES:
-        log.info("Polling package: %s", package)
-        for metric_set, (metric_names, gauges) in gauges_by_set.items():
+def emit_anomalies(anomalies: list[dict], package: str, otel_logger: Any) -> None:
+    for a in anomalies:
+        metric_name = a.get("metric", "unknown")
+        dims = {d.get("dimension"): d.get("stringValue") or str(d.get("int64Value", ""))
+                for d in a.get("dimensionValue", [])}
+        body = (f"Android vitals anomaly: {metric_name} is outside 28-day baseline"
+                + (f" for {dims}" if dims else ""))
+        record = otel_logger.create_log_record(
+            timestamp=int(datetime.now(timezone.utc).timestamp() * 1e9),
+            severity_number=SeverityNumber.WARN,
+            severity_text="WARN",
+            body=body,
+            attributes={
+                "android.package": package,
+                "android.vitals.anomaly.metric": metric_name,
+                "android.vitals.anomaly.name": a.get("name", ""),
+                **{f"android.{k}": v for k, v in dims.items()},
+            },
+        )
+        otel_logger.emit(record)
+
+
+# ── Poll one package ──────────────────────────────────────────────────────────
+
+
+def poll_package(token: str, package: str, otel_logger: Any) -> None:
+    log.info("Polling: %s", package)
+    rows_by_set: list[tuple[str, list[dict]]] = []
+
+    # ── Daily metric sets ─────────────────────────────────────────────────────
+    for metric_set, metric_names in DAILY_METRIC_NAMES.items():
+        extra_dims = DAILY_REQUIRED_EXTRA_DIMS.get(metric_set)
+        try:
+            freshness = get_freshness(token, package, metric_set)
+            end = freshness.get("DAILY", date.today() - timedelta(days=2))
+            rows = query_daily(token, package, metric_set, metric_names, end,
+                               extra_dims=extra_dims)
+            rows_by_set.append((metric_set, rows))
+        except requests.HTTPError as exc:
+            log.error("HTTP error — %s/%s: %s", package, metric_set, exc)
+        except Exception as exc:  # noqa: BLE001
+            log.error("Error — %s/%s: %s", package, metric_set, exc)
+
+    # ── Hourly crash/ANR (optional, ~2-4h lag) ────────────────────────────────
+    if ENABLE_HOURLY:
+        for metric_set, metric_names in HOURLY_METRIC_NAMES.items():
             try:
-                end_date = get_latest_date(token, package, metric_set)
-                rows = query_metric_set(token, package, metric_set, metric_names, end_date)
-                record_rows(rows, gauges, package)
-            except requests.HTTPError as exc:
-                log.error("HTTP error — %s/%s: %s", package, metric_set, exc)
+                freshness = get_freshness(token, package, metric_set)
+                end = freshness.get("HOURLY", date.today() - timedelta(days=1))
+                rows = query_hourly(token, package, metric_set, metric_names, end)
+                rows_by_set.append((metric_set, rows))
             except Exception as exc:  # noqa: BLE001
-                log.error("Unexpected error — %s/%s: %s", package, metric_set, exc)
+                log.error("Hourly error — %s/%s: %s", package, metric_set, exc)
+
+    # ── Error counts (hourly, leading indicator) ──────────────────────────────
+    error_count_base_dims = [d for d in DIMENSIONS if d not in ERROR_COUNT_UNSUPPORTED_DIMS]
+    try:
+        freshness = get_freshness(token, package, "errorCountMetricSet")
+        end = freshness.get("HOURLY", date.today() - timedelta(days=1))
+        rows = query_hourly(
+            token, package, "errorCountMetricSet",
+            list(METRIC_CATALOGUE["errorCountMetricSet"].keys()), end,
+            extra_dims=ERROR_COUNT_EXTRA_DIMS,
+            base_dims=error_count_base_dims,
+        )
+        rows_by_set.append(("errorCountMetricSet", rows))
+    except Exception as exc:  # noqa: BLE001
+        log.error("Error — %s/errorCountMetricSet: %s", package, exc)
+
+    # ── Export all rows to Last9 ──────────────────────────────────────────────
+    send_otlp_metrics(rows_by_set, package)
+
+    # ── Anomalies → OTel log records ──────────────────────────────────────────
+    try:
+        anomalies = list_anomalies(token, package)
+        if anomalies:
+            emit_anomalies(anomalies, package, otel_logger)
+    except Exception as exc:  # noqa: BLE001
+        log.error("Anomaly fetch error — %s: %s", package, exc)
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
 
 
 def main() -> None:
-    log.info("Starting Google Play Reporting collector")
-    log.info("Packages: %s", PACKAGE_NAMES)
-    log.info("Poll interval: %ds", POLL_INTERVAL_SECONDS)
-    log.info("OTLP endpoint: %s", OTLP_ENDPOINT)
+    log.info("Google Play Reporting collector starting")
+    log.info("Packages       : %s", PACKAGE_NAMES)
+    log.info("Poll interval  : %ds", POLL_INTERVAL_SECONDS)
+    log.info("Days back      : %d", POLL_DAYS_BACK)
+    log.info("Hourly enabled : %s", ENABLE_HOURLY)
+    log.info("Dimensions     : %s", DIMENSIONS or ["(aggregate)"])
+    log.info("OTLP endpoint  : %s", OTLP_ENDPOINT)
 
-    creds = get_credentials()
+    creds = load_credentials()
 
-    provider = build_meter_provider()
-    metrics.set_meter_provider(provider)
-    meter = metrics.get_meter("google.play.reporting", version="1.0.0")
+    logger_provider = build_logger_provider()
+    set_logger_provider(logger_provider)
+    otel_logger = logger_provider.get_logger("google.play.reporting.anomalies")
 
-    def gauge(name: str, unit: str, description: str):
-        return meter.create_gauge(name, unit=unit, description=description)
+    def _shutdown(sig, _frame):
+        log.info("Shutting down…")
+        logger_provider.shutdown()
+        raise SystemExit(0)
 
-    # Each entry: metric_set_name → (api_metric_names[], {api_name: OTel gauge})
-    gauges_by_set: dict[str, tuple[list, dict]] = {
-        "crashRateMetricSet": (
-            ["crashRate", "crashRate7dUserWeighted", "userPerceivedCrashRate", "distinctUsers"],
-            {
-                "crashRate": gauge(
-                    "android.vitals.crash_rate", "1",
-                    "Daily crash rate (fraction of sessions with a crash)",
-                ),
-                "crashRate7dUserWeighted": gauge(
-                    "android.vitals.crash_rate_7d", "1",
-                    "7-day user-weighted crash rate",
-                ),
-                "userPerceivedCrashRate": gauge(
-                    "android.vitals.user_perceived_crash_rate", "1",
-                    "Foreground crash rate as perceived by users",
-                ),
-                "distinctUsers": gauge(
-                    "android.vitals.crash_distinct_users", "1",
-                    "Distinct users counted in the crash rate denominator",
-                ),
-            },
-        ),
-        "anrRateMetricSet": (
-            ["anrRate", "anrRate7dUserWeighted", "userPerceivedAnrRate", "distinctUsers"],
-            {
-                "anrRate": gauge(
-                    "android.vitals.anr_rate", "1",
-                    "Daily ANR rate",
-                ),
-                "anrRate7dUserWeighted": gauge(
-                    "android.vitals.anr_rate_7d", "1",
-                    "7-day user-weighted ANR rate",
-                ),
-                "userPerceivedAnrRate": gauge(
-                    "android.vitals.user_perceived_anr_rate", "1",
-                    "Foreground ANR rate as perceived by users",
-                ),
-                "distinctUsers": gauge(
-                    "android.vitals.anr_distinct_users", "1",
-                    "Distinct users counted in the ANR rate denominator",
-                ),
-            },
-        ),
-        "slowRenderingRateMetricSet": (
-            ["slowRenderingRate20Fps", "slowRenderingRate30Fps", "distinctUsers"],
-            {
-                "slowRenderingRate20Fps": gauge(
-                    "android.vitals.slow_rendering_rate_20fps", "1",
-                    "Fraction of sessions with slow rendering (below 20 FPS)",
-                ),
-                "slowRenderingRate30Fps": gauge(
-                    "android.vitals.slow_rendering_rate_30fps", "1",
-                    "Fraction of sessions with slow rendering (below 30 FPS)",
-                ),
-                "distinctUsers": gauge(
-                    "android.vitals.slow_rendering_distinct_users", "1",
-                    "Distinct users in slow rendering denominator",
-                ),
-            },
-        ),
-        "slowStartRateMetricSet": (
-            ["slowStartRate", "distinctUsers"],
-            {
-                "slowStartRate": gauge(
-                    "android.vitals.slow_start_rate", "1",
-                    "Fraction of app starts that are slow",
-                ),
-                "distinctUsers": gauge(
-                    "android.vitals.slow_start_distinct_users", "1",
-                    "Distinct users in slow start denominator",
-                ),
-            },
-        ),
-    }
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
 
     while True:
-        poll_once(creds, gauges_by_set)
-        log.info("Sleeping %ds until next poll…", POLL_INTERVAL_SECONDS)
+        token = bearer_token(creds)
+        for package in PACKAGE_NAMES:
+            poll_package(token, package, otel_logger)
+        log.info("Sleeping %ds…", POLL_INTERVAL_SECONDS)
         time.sleep(POLL_INTERVAL_SECONDS)
 
 

--- a/python/google-play-reporting/requirements.txt
+++ b/python/google-play-reporting/requirements.txt
@@ -1,0 +1,5 @@
+google-auth==2.38.0
+requests==2.32.3
+opentelemetry-api==1.31.1
+opentelemetry-sdk==1.31.1
+opentelemetry-exporter-otlp-proto-http==1.31.1


### PR DESCRIPTION
## Summary

- Polls all Android vitals metric sets from the [Google Play Developer Reporting API](https://developers.google.com/play/developer/reporting) and exports them as OTLP gauge metrics to Last9
- Bypasses OTel SDK gauge abstraction to POST OTLP/HTTP JSON directly, preserving historical timestamps from each row's `startTime`
- Exports anomalies as OTel WARN log records

## Metric sets covered

- `crashRateMetricSet` — daily crash rate (1d / 7d / 28d)
- `anrRateMetricSet` — daily ANR rate (1d / 7d / 28d)
- `slowRenderingRateMetricSet` — slow rendering <20fps and <30fps
- `slowStartRateMetricSet` — slow app starts (COLD / WARM / HOT)
- `excessiveWakeupRateMetricSet` — excessive AlarmManager wakeups
- `stuckBackgroundWakelockRateMetricSet` — background wakelocks held >1h
- `lmkRateMetricSet` — Low Memory Kill rate
- `errorCountMetricSet` — hourly error counts (~2–4h lag)

## Labels on every data point

| Label | Example |
|---|---|
| `android_package` | `com.example.app` |
| `android_date` | `2026-02-24` |
| `android_report_type` | `CRASH` or `ANR` (errorCount only) |
| `android_start_type` | `COLD`, `WARM`, or `HOT` (slowStart only) |
| `android_version_code` etc. | when `ANDROID_DIMENSIONS` is set |

## Test plan

- [x] Copy `.env.example` to `.env`, fill in service account path and OTLP credentials
- [x] `docker compose up` and confirm `Exported N data points` in logs
- [x] Verify metrics appear in Last9 under `android_vitals_*` prefix
- [x] Confirm `android_date` and `android_report_type` labels are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)