### PR TITLE
FDE-39: Add Argo Rollouts OTel Collector monitoring example

### DIFF
--- a/otel-collector/argo-rollouts/.env.example
+++ b/otel-collector/argo-rollouts/.env.example
@@ -1,0 +1,7 @@
+# Last9 credentials — get these from https://app.last9.io/integrations
+LAST9_OTLP_ENDPOINT=<your-last9-otlp-endpoint>
+LAST9_AUTH_HEADER=<your-last9-auth-header>
+
+# Kubernetes cluster info
+K8S_CLUSTER_NAME=<your-cluster-name>
+DEPLOYMENT_ENVIRONMENT=production

--- a/otel-collector/argo-rollouts/.gitignore
+++ b/otel-collector/argo-rollouts/.gitignore
@@ -1,0 +1,27 @@
+# Environment/secrets
+.env
+.env.local
+.env.*.local
+
+# Dependencies
+/vendor/
+/node_modules/
+/.venv/
+/target/
+/bin/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Build artifacts
+/dist/
+/build/

--- a/otel-collector/argo-rollouts/README.md
+++ b/otel-collector/argo-rollouts/README.md
@@ -106,7 +106,7 @@ kubectl create secret generic last9-prometheus-credentials \
 
 ### 2. Apply the AnalysisTemplates
 
-Edit `analysis-template.yaml` and replace `<your-last9-org>` and `<your-org>` with the values from your Last9 Prometheus endpoint URL:
+Edit `analysis-template.yaml` and replace `<your-last9-prometheus-read-endpoint>` with the full read URL from the Last9 Integrations page (Prometheus section):
 
 ```bash
 kubectl apply -f analysis-template.yaml

--- a/otel-collector/argo-rollouts/README.md
+++ b/otel-collector/argo-rollouts/README.md
@@ -1,0 +1,148 @@
+# Monitoring Argo Rollouts with OpenTelemetry and Last9
+
+Monitor Argo Rollouts canary deployments by scraping Prometheus metrics via the OpenTelemetry Collector and shipping them to Last9. This enables dashboards that track rollout phase, canary traffic weight, and pod-level canary vs stable comparisons.
+
+## Prerequisites
+
+- Kubernetes cluster with [Argo Rollouts installed](https://argo-rollouts.readthedocs.io/en/stable/installation/)
+- `kubectl` configured with cluster access
+- Last9 account — get your OTLP endpoint and auth header from the [Integrations page](https://app.last9.io/integrations)
+
+Verify Argo Rollouts is running:
+
+```bash
+kubectl get deploy -n argo-rollouts
+kubectl get svc -n argo-rollouts
+```
+
+The metrics service should be present on port `8090`:
+
+```bash
+kubectl get svc argo-rollouts-metrics -n argo-rollouts
+```
+
+## Quick Start
+
+### 1. Deploy the OTel Collector
+
+Edit `collector-deployment.yaml` and replace the placeholders:
+
+| Placeholder | Value |
+|---|---|
+| `YOUR_LAST9_OTLP_ENDPOINT` | From Last9 Integrations page |
+| `YOUR_LAST9_AUTH_HEADER` | From Last9 Integrations page |
+| `YOUR_CLUSTER_NAME` | Your cluster identifier |
+
+Apply the manifest:
+
+```bash
+kubectl apply -f collector-deployment.yaml
+```
+
+This creates the `monitoring` namespace, a ConfigMap with the OTel config, the Collector Deployment, and the RBAC resources needed for Prometheus scraping.
+
+### 2. Verify the Collector is Running
+
+```bash
+kubectl get pods -n monitoring -l app=otel-collector
+kubectl logs -n monitoring -l app=otel-collector --tail=50
+```
+
+Look for log lines showing successful scrape of `argo-rollouts` and metric export to Last9.
+
+### 3. Confirm Metrics in Last9
+
+Port-forward the Argo Rollouts metrics endpoint to verify it's reachable:
+
+```bash
+kubectl port-forward svc/argo-rollouts-metrics -n argo-rollouts 8090:8090
+curl -s http://localhost:8090/metrics | grep -E "^rollout_info|^rollout_reconcile"
+```
+
+Then open [Metrics Explorer](https://app.last9.io/metrics) and search for `rollout_info`.
+
+## Configuration
+
+### Environment Variables
+
+See `.env.example` for all required variables.
+
+| Variable | Description |
+|---|---|
+| `LAST9_OTLP_ENDPOINT` | Last9 OTLP write endpoint |
+| `LAST9_AUTH_HEADER` | Last9 authorization header |
+| `K8S_CLUSTER_NAME` | Cluster label for multi-cluster dashboards |
+| `DEPLOYMENT_ENVIRONMENT` | Environment label (`production`, `staging`, etc.) |
+
+### Using `otel-config.yaml` with an Existing Collector
+
+If you already have an OTel Collector running, copy the receiver and pipeline config from `otel-config.yaml` into your existing configuration instead of deploying a new one.
+
+## Metrics Reference
+
+| Metric | Description | Key Labels |
+|---|---|---|
+| `rollout_info` | Rollout status, phase, canary weight | `namespace`, `rollout`, `phase`, `canary_weight` |
+| `rollout_reconcile` | Reconcile duration histogram | `namespace`, `rollout` |
+| `rollout_reconcile_error` | Reconcile error count | `namespace`, `rollout` |
+| `analysis_run_info` | Analysis run status | `namespace`, `rollout`, `phase` |
+| `experiment_info` | Experiment status | `namespace`, `experiment` |
+| `argo_rollouts_controller_workqueue_depth` | Controller queue backlog | `name` |
+
+## Dashboard Attributes
+
+| Attribute | Example | Use |
+|---|---|---|
+| `service.name` | `argo-rollouts` | Filter all rollout metrics |
+| `k8s.cluster.name` | `prod-us-east-1` | Multi-cluster view |
+| `deployment.environment` | `production` | Environment comparison |
+| `namespace` | `payments` | Per-namespace health |
+| `rollout` | `checkout-rollout` | Per-rollout panels |
+| `canary_weight` | `0`–`100` | Canary traffic split |
+| `phase` | `Progressing`, `Paused`, `Healthy`, `Degraded` | Rollout status |
+
+<details>
+<summary>Canary vs Stable Pod Metrics</summary>
+
+To compare canary vs stable pods in dashboards, the collector config also scrapes `kube-state-metrics`. Argo Rollouts automatically labels pods with `rollouts-pod-template-hash` during progressive delivery.
+
+Use `rollout_info{canary_weight="X"}` to see current traffic split, and filter pod metrics by `label_rollouts_pod_template_hash` to compare canary vs stable performance.
+
+| Kubernetes Label | Description |
+|---|---|
+| `rollouts-pod-template-hash` | Distinguishes canary vs stable pod revision |
+| `app` | Application name |
+
+</details>
+
+<details>
+<summary>Suggested Dashboard Panels</summary>
+
+1. **Canary Traffic Weight Over Time** — `rollout_info` grouped by `canary_weight`
+2. **Rollout Phase Status** — `rollout_info` grouped by `phase` and `rollout`
+3. **Reconcile Error Rate** — `rate(rollout_reconcile_error[5m])` grouped by `rollout`, `namespace`
+4. **Analysis Run Success/Failure** — `analysis_run_info` grouped by `phase`, `rollout`
+5. **Pod Count: Canary vs Stable** — `kube_pod_status_phase` filtered by `label_rollouts_pod_template_hash`
+
+</details>
+
+<details>
+<summary>Troubleshooting</summary>
+
+**Metrics endpoint not accessible:**
+```bash
+kubectl get svc -n argo-rollouts
+kubectl logs -n argo-rollouts deploy/argo-rollouts
+```
+
+**Collector not scraping:**
+```bash
+kubectl logs -n monitoring -l app=otel-collector | grep -i error
+```
+
+**No data in Last9:**
+1. Verify the OTLP endpoint and auth header are correct in the ConfigMap
+2. Check that `compression: gzip` is supported by your Last9 endpoint
+3. Remove the `debug` exporter if you want to reduce log verbosity
+
+</details>

--- a/otel-collector/argo-rollouts/README.md
+++ b/otel-collector/argo-rollouts/README.md
@@ -89,6 +89,61 @@ If you already have an OTel Collector running, copy the receiver and pipeline co
 | `experiment_info` | Experiment status | `namespace`, `experiment` |
 | `argo_rollouts_controller_workqueue_depth` | Controller queue backlog | `name` |
 
+## Automated Canary Analysis with Last9
+
+Beyond dashboards, Last9's Prometheus-compatible endpoint can act as an **automated canary gate** — Argo Rollouts queries your metrics at each rollout step and promotes or rolls back automatically.
+
+### 1. Create the credentials Secret
+
+Get your Prometheus username and password from the [Last9 Integrations page](https://app.last9.io/integrations) (Prometheus section):
+
+```bash
+kubectl create secret generic last9-prometheus-credentials \
+  --namespace <your-app-namespace> \
+  --from-literal=username=<your-last9-username> \
+  --from-literal=password=<your-last9-write-token>
+```
+
+### 2. Apply the AnalysisTemplates
+
+Edit `analysis-template.yaml` and replace `<your-last9-org>` and `<your-org>` with the values from your Last9 Prometheus endpoint URL:
+
+```bash
+kubectl apply -f analysis-template.yaml
+```
+
+This creates two templates:
+- **`last9-http-error-rate`** — rolls back if HTTP 5xx error rate ≥ 10%, promotes if < 5%
+- **`last9-latency-p99`** — rolls back if p99 latency ≥ 1s, promotes if < 500ms
+
+### 3. Reference them in your Rollout
+
+`rollout-example.yaml` shows how to wire both templates into a canary rollout with 10% → 25% → 50% → 100% steps. Apply and adapt it:
+
+```bash
+kubectl apply -f rollout-example.yaml
+```
+
+Watch analysis runs live:
+
+```bash
+kubectl argo rollouts get rollout my-app --watch
+kubectl argo rollouts list analysisruns
+```
+
+### How it works
+
+```
+Canary at 10% traffic
+      ↓
+Argo Rollouts queries Last9 every 2 min
+      ↓
+error rate < 5%?  →  promote to 25%
+error rate ≥ 10%? →  auto rollback (after 3 failures)
+```
+
+> **Note:** Your application must emit `http_requests_total` and `http_request_duration_seconds_bucket` metrics (standard Prometheus HTTP metrics). If you use different metric names, update the PromQL in `analysis-template.yaml`.
+
 ## Dashboard Attributes
 
 | Attribute | Example | Use |

--- a/otel-collector/argo-rollouts/README.md
+++ b/otel-collector/argo-rollouts/README.md
@@ -82,12 +82,18 @@ If you already have an OTel Collector running, copy the receiver and pipeline co
 
 | Metric | Description | Key Labels |
 |---|---|---|
-| `rollout_info` | Rollout status, phase, canary weight | `namespace`, `rollout`, `phase`, `canary_weight` |
-| `rollout_reconcile` | Reconcile duration histogram | `namespace`, `rollout` |
-| `rollout_reconcile_error` | Reconcile error count | `namespace`, `rollout` |
-| `analysis_run_info` | Analysis run status | `namespace`, `rollout`, `phase` |
-| `experiment_info` | Experiment status | `namespace`, `experiment` |
+| `rollout_info` | Rollout presence and current phase | `name`, `namespace`, `phase`, `strategy` |
+| `rollout_phase` | Phase gauge — one series per phase, value is 0 or 1 | `name`, `namespace`, `phase`, `strategy` |
+| `rollout_info_replicas_available` | Available replica count | `name`, `namespace` |
+| `rollout_info_replicas_updated` | Updated (canary) replica count | `name`, `namespace` |
+| `rollout_reconcile` | Reconcile duration histogram | `name`, `namespace` |
+| `rollout_reconcile_error` | Reconcile error count | `name`, `namespace` |
+| `rollout_events_total` | Rollout lifecycle events | `name`, `namespace`, `reason`, `type` |
+| `analysis_run_info` | Analysis run status | `name`, `namespace`, `phase` |
+| `experiment_info` | Experiment status | `name`, `namespace` |
 | `argo_rollouts_controller_workqueue_depth` | Controller queue backlog | `name` |
+
+> **Note on canary traffic percentage:** Current Argo Rollouts versions do not expose `canary_weight` as a metric label. Track the canary replica fraction via `rollout_info_replicas_updated / rollout_info_replicas_desired`.
 
 ## Automated Canary Analysis with Last9
 
@@ -95,14 +101,17 @@ Beyond dashboards, Last9's Prometheus-compatible endpoint can act as an **automa
 
 ### 1. Create the credentials Secret
 
-Get your Prometheus username and password from the [Last9 Integrations page](https://app.last9.io/integrations) (Prometheus section):
+Get your Prometheus username and password from the [Last9 Integrations page](https://app.last9.io/integrations) (Prometheus section).
+
+> **Note:** The Argo Rollouts Prometheus provider does not support `basic_auth` natively. Pass credentials as a pre-encoded `Authorization` header stored in a K8s Secret:
 
 ```bash
-kubectl create secret generic last9-prometheus-credentials \
+kubectl create secret generic last9-prometheus-auth \
   --namespace <your-app-namespace> \
-  --from-literal=username=<your-last9-username> \
-  --from-literal=password=<your-last9-write-token>
+  --from-literal=authorization="Basic $(printf '<your-last9-username>:<your-last9-password>' | base64 | tr -d '\n')"
 ```
+
+> Use `printf` and `tr -d '\n'` to avoid trailing newlines in the base64 output, which cause `invalid header field value` errors at runtime.
 
 ### 2. Apply the AnalysisTemplates
 
@@ -152,16 +161,15 @@ error rate ≥ 10%? →  auto rollback (after 3 failures)
 | `k8s.cluster.name` | `prod-us-east-1` | Multi-cluster view |
 | `deployment.environment` | `production` | Environment comparison |
 | `namespace` | `payments` | Per-namespace health |
-| `rollout` | `checkout-rollout` | Per-rollout panels |
-| `canary_weight` | `0`–`100` | Canary traffic split |
-| `phase` | `Progressing`, `Paused`, `Healthy`, `Degraded` | Rollout status |
+| `name` | `checkout-rollout` | Per-rollout panels |
+| `phase` | `Progressing`, `Paused`, `Completed`, `Error` | Rollout status via `rollout_phase` |
 
 <details>
 <summary>Canary vs Stable Pod Metrics</summary>
 
 To compare canary vs stable pods in dashboards, the collector config also scrapes `kube-state-metrics`. Argo Rollouts automatically labels pods with `rollouts-pod-template-hash` during progressive delivery.
 
-Use `rollout_info{canary_weight="X"}` to see current traffic split, and filter pod metrics by `label_rollouts_pod_template_hash` to compare canary vs stable performance.
+Use `rollout_info_replicas_updated / rollout_info_replicas_desired` to see the current canary replica fraction, and filter pod metrics by `label_rollouts_pod_template_hash` to compare canary vs stable performance.
 
 | Kubernetes Label | Description |
 |---|---|
@@ -173,10 +181,10 @@ Use `rollout_info{canary_weight="X"}` to see current traffic split, and filter p
 <details>
 <summary>Suggested Dashboard Panels</summary>
 
-1. **Canary Traffic Weight Over Time** — `rollout_info` grouped by `canary_weight`
-2. **Rollout Phase Status** — `rollout_info` grouped by `phase` and `rollout`
-3. **Reconcile Error Rate** — `rate(rollout_reconcile_error[5m])` grouped by `rollout`, `namespace`
-4. **Analysis Run Success/Failure** — `analysis_run_info` grouped by `phase`, `rollout`
+1. **Canary Replica Fraction** — `rollout_info_replicas_updated / rollout_info_replicas_desired` grouped by `name`
+2. **Rollout Phase Status** — `rollout_phase{phase="Progressing"}` or `rollout_phase` grouped by `phase` and `name`
+3. **Reconcile Error Rate** — `rate(rollout_reconcile_error[5m])` grouped by `name`, `namespace`
+4. **Analysis Run Success/Failure** — `analysis_run_info` grouped by `phase`, `name`
 5. **Pod Count: Canary vs Stable** — `kube_pod_status_phase` filtered by `label_rollouts_pod_template_hash`
 
 </details>

--- a/otel-collector/argo-rollouts/README.md
+++ b/otel-collector/argo-rollouts/README.md
@@ -1,6 +1,6 @@
 # Monitoring Argo Rollouts with OpenTelemetry and Last9
 
-Monitor Argo Rollouts canary deployments by scraping Prometheus metrics via the OpenTelemetry Collector and shipping them to Last9. This enables dashboards that track rollout phase, canary traffic weight, and pod-level canary vs stable comparisons.
+Monitor Argo Rollouts canary deployments with Last9 using the OpenTelemetry Collector. Ships metrics (rollout phase, replica counts, analysis run status) and pod logs (enriched with `rollouts-pod-template-hash` for canary vs stable filtering) to Last9 via OTLP.
 
 ## Prerequisites
 
@@ -39,13 +39,13 @@ Apply the manifest:
 kubectl apply -f collector-deployment.yaml
 ```
 
-This creates the `monitoring` namespace, a ConfigMap with the OTel config, the Collector Deployment, and the RBAC resources needed for Prometheus scraping.
+This creates the `last9` namespace, a ConfigMap with the OTel config, a DaemonSet (required for pod log access), and RBAC resources.
 
 ### 2. Verify the Collector is Running
 
 ```bash
-kubectl get pods -n monitoring -l app=otel-collector
-kubectl logs -n monitoring -l app=otel-collector --tail=50
+kubectl get pods -n last9 -l app=otel-collector
+kubectl logs -n last9 -l app=otel-collector --tail=50
 ```
 
 Look for log lines showing successful scrape of `argo-rollouts` and metric export to Last9.
@@ -73,6 +73,26 @@ See `.env.example` for all required variables.
 | `LAST9_AUTH_HEADER` | Last9 authorization header |
 | `K8S_CLUSTER_NAME` | Cluster label for multi-cluster dashboards |
 | `DEPLOYMENT_ENVIRONMENT` | Environment label (`production`, `staging`, etc.) |
+
+### APM Correlation via `service.name` and `deployment.environment`
+
+By default, rollout metrics land under `service.name = "argo-rollouts"` (the controller). To correlate rollout health with your **APM traces and metrics** in Last9, the config uses two processors to map the rollout `name` label to `service.name`:
+
+```
+rollout_info{name="checkout", ...}
+        ↓ transform/apm_labels
+service.name = "checkout"          ← matches APM service
+service.namespace = "payments"
+deployment.environment = "production"
+        ↓ groupbyattrs/service
+Resource: {service.name="checkout", deployment.environment="production"}
+```
+
+**Prerequisite:** your Rollout name must match the `service.name` your application sets in its OTel SDK. This is the natural convention — a Rollout named `checkout` deploys the `checkout` service.
+
+After this, in Last9 you can query:
+- `rollout_phase{service_name="checkout"}` alongside `http_request_duration_seconds{service_name="checkout"}`
+- Filter by `deployment_environment="production"` across both rollout and APM metrics in the same dashboard
 
 ### Using `otel-config.yaml` with an Existing Collector
 
@@ -200,7 +220,7 @@ kubectl logs -n argo-rollouts deploy/argo-rollouts
 
 **Collector not scraping:**
 ```bash
-kubectl logs -n monitoring -l app=otel-collector | grep -i error
+kubectl logs -n last9 -l app=otel-collector | grep -i error
 ```
 
 **No data in Last9:**

--- a/otel-collector/argo-rollouts/analysis-template.yaml
+++ b/otel-collector/argo-rollouts/analysis-template.yaml
@@ -1,0 +1,98 @@
+---
+# AnalysisTemplate: Last9 HTTP Error Rate Check
+# Queries Last9's Prometheus-compatible endpoint to evaluate canary health.
+# Argo Rollouts will auto-promote if error rate stays below 5%,
+# and auto-rollback after 3 consecutive failures above 10%.
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: last9-http-error-rate
+spec:
+  args:
+    - name: service-name
+    - name: namespace
+  metrics:
+    - name: http-error-rate
+      # How often to evaluate the metric during the analysis window
+      interval: 2m
+      # Promote if error rate is below 5%
+      successCondition: result[0] < 0.05
+      # Rollback if error rate is at or above 10%
+      failureCondition: result[0] >= 0.10
+      # Allow up to 3 consecutive failures before rolling back
+      failureLimit: 3
+      provider:
+        prometheus:
+          # Last9 Prometheus-compatible query endpoint.
+          # Get this from https://app.last9.io/integrations (Prometheus section).
+          # Use the base URL without /api/v1/query — Argo Rollouts appends that.
+          address: https://<your-last9-org>.last9.io/api/v1/organizations/<your-org>/prometheus
+          authentication:
+            sigv4: {}     # Leave empty — use basic_auth below instead
+          basicAuth:
+            username:
+              secretKeyRef:
+                name: last9-prometheus-credentials
+                key: username
+            password:
+              secretKeyRef:
+                name: last9-prometheus-credentials
+                key: password
+          query: |
+            sum(rate(http_requests_total{
+              namespace="{{args.namespace}}",
+              service="{{args.service-name}}",
+              status=~"5.."
+            }[5m]))
+            /
+            sum(rate(http_requests_total{
+              namespace="{{args.namespace}}",
+              service="{{args.service-name}}"
+            }[5m]))
+---
+# AnalysisTemplate: Last9 P99 Latency Check
+# Rolls back if the canary's p99 response time exceeds 500ms.
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: last9-latency-p99
+spec:
+  args:
+    - name: service-name
+    - name: namespace
+  metrics:
+    - name: p99-latency
+      interval: 2m
+      # Promote if p99 latency is below 500ms
+      successCondition: result[0] < 0.5
+      # Rollback if p99 latency exceeds 1s
+      failureCondition: result[0] >= 1.0
+      failureLimit: 3
+      provider:
+        prometheus:
+          address: https://<your-last9-org>.last9.io/api/v1/organizations/<your-org>/prometheus
+          basicAuth:
+            username:
+              secretKeyRef:
+                name: last9-prometheus-credentials
+                key: username
+            password:
+              secretKeyRef:
+                name: last9-prometheus-credentials
+                key: password
+          query: |
+            histogram_quantile(0.99,
+              sum(rate(http_request_duration_seconds_bucket{
+                namespace="{{args.namespace}}",
+                service="{{args.service-name}}"
+              }[5m])) by (le)
+            )
+---
+# Secret: Last9 Prometheus credentials
+# Create this before applying the AnalysisTemplates.
+# Get credentials from https://app.last9.io/integrations (Prometheus section).
+#
+# kubectl create secret generic last9-prometheus-credentials \
+#   --namespace <your-app-namespace> \
+#   --from-literal=username=<your-last9-username> \
+#   --from-literal=password=<your-last9-write-token>

--- a/otel-collector/argo-rollouts/analysis-template.yaml
+++ b/otel-collector/argo-rollouts/analysis-template.yaml
@@ -3,6 +3,19 @@
 # Queries Last9's Prometheus-compatible endpoint to evaluate canary health.
 # Argo Rollouts will auto-promote if error rate stays below 5%,
 # and auto-rollback after 3 consecutive failures above 10%.
+#
+# Auth: The Prometheus provider passes credentials via an arg that sources
+# a pre-encoded "Basic <base64(username:password)>" value from a K8s Secret:
+#
+#   kubectl create secret generic last9-prometheus-auth \
+#     --namespace <your-app-namespace> \
+#     --from-literal=authorization="Basic $(printf '<username>:<password>' | base64 | tr -d '\n')"
+#
+# Note: use printf + tr -d '\n' to avoid newlines in the base64 output,
+# which would cause "invalid header field value" errors at runtime.
+#
+# Get the read endpoint, username, and password from:
+# https://app.last9.io/integrations (Prometheus section)
 apiVersion: argoproj.io/v1alpha1
 kind: AnalysisTemplate
 metadata:
@@ -11,9 +24,13 @@ spec:
   args:
     - name: service-name
     - name: namespace
+    - name: last9-auth
+      valueFrom:
+        secretKeyRef:
+          name: last9-prometheus-auth
+          key: authorization
   metrics:
     - name: http-error-rate
-      # How often to evaluate the metric during the analysis window
       interval: 2m
       # Promote if error rate is below 5%
       successCondition: result[0] < 0.05
@@ -23,19 +40,13 @@ spec:
       failureLimit: 3
       provider:
         prometheus:
-          # Last9 Prometheus-compatible query endpoint (read URL).
+          # Last9 Prometheus-compatible read endpoint.
           # Get the full URL from https://app.last9.io/integrations (Prometheus section).
-          # Use the base URL as-is — Argo Rollouts appends /api/v1/query automatically.
+          # Argo Rollouts appends /api/v1/query to this base URL automatically.
           address: <your-last9-prometheus-read-endpoint>
-          basicAuth:
-            username:
-              secretKeyRef:
-                name: last9-prometheus-credentials
-                key: username
-            password:
-              secretKeyRef:
-                name: last9-prometheus-credentials
-                key: password
+          headers:
+            - key: Authorization
+              value: "{{args.last9-auth}}"
           query: |
             sum(rate(http_requests_total{
               namespace="{{args.namespace}}",
@@ -58,6 +69,11 @@ spec:
   args:
     - name: service-name
     - name: namespace
+    - name: last9-auth
+      valueFrom:
+        secretKeyRef:
+          name: last9-prometheus-auth
+          key: authorization
   metrics:
     - name: p99-latency
       interval: 2m
@@ -69,15 +85,9 @@ spec:
       provider:
         prometheus:
           address: <your-last9-prometheus-read-endpoint>
-          basicAuth:
-            username:
-              secretKeyRef:
-                name: last9-prometheus-credentials
-                key: username
-            password:
-              secretKeyRef:
-                name: last9-prometheus-credentials
-                key: password
+          headers:
+            - key: Authorization
+              value: "{{args.last9-auth}}"
           query: |
             histogram_quantile(0.99,
               sum(rate(http_request_duration_seconds_bucket{
@@ -85,12 +95,3 @@ spec:
                 service="{{args.service-name}}"
               }[5m])) by (le)
             )
----
-# Secret: Last9 Prometheus credentials
-# Create this before applying the AnalysisTemplates.
-# Get credentials from https://app.last9.io/integrations (Prometheus section).
-#
-# kubectl create secret generic last9-prometheus-credentials \
-#   --namespace <your-app-namespace> \
-#   --from-literal=username=<your-last9-username> \
-#   --from-literal=password=<your-last9-write-token>

--- a/otel-collector/argo-rollouts/analysis-template.yaml
+++ b/otel-collector/argo-rollouts/analysis-template.yaml
@@ -23,12 +23,10 @@ spec:
       failureLimit: 3
       provider:
         prometheus:
-          # Last9 Prometheus-compatible query endpoint.
-          # Get this from https://app.last9.io/integrations (Prometheus section).
-          # Use the base URL without /api/v1/query — Argo Rollouts appends that.
-          address: https://<your-last9-org>.last9.io/api/v1/organizations/<your-org>/prometheus
-          authentication:
-            sigv4: {}     # Leave empty — use basic_auth below instead
+          # Last9 Prometheus-compatible query endpoint (read URL).
+          # Get the full URL from https://app.last9.io/integrations (Prometheus section).
+          # Use the base URL as-is — Argo Rollouts appends /api/v1/query automatically.
+          address: <your-last9-prometheus-read-endpoint>
           basicAuth:
             username:
               secretKeyRef:
@@ -70,7 +68,7 @@ spec:
       failureLimit: 3
       provider:
         prometheus:
-          address: https://<your-last9-org>.last9.io/api/v1/organizations/<your-org>/prometheus
+          address: <your-last9-prometheus-read-endpoint>
           basicAuth:
             username:
               secretKeyRef:

--- a/otel-collector/argo-rollouts/collector-deployment.yaml
+++ b/otel-collector/argo-rollouts/collector-deployment.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: monitoring
+  name: last9
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: otel-collector-config
-  namespace: monitoring
+  namespace: last9
 data:
   config.yaml: |
     receivers:
@@ -36,22 +36,82 @@ data:
                   regex: ".+"
                   action: keep
 
+      filelog:
+        include:
+          - /var/log/pods/*/*/*.log
+        exclude:
+          - /var/log/pods/last9_*/*/*.log
+        start_at: end
+        include_file_path: true
+        include_file_name: false
+        operators:
+          - type: regex_parser
+            id: extract_k8s_metadata
+            # Matches both UUID pods (regular) and hex-hash pods (static: etcd, kube-apiserver)
+            regex: '/var/log/pods/(?P<namespace>[^_]+)_(?P<pod_name>.+)_(?P<uid>[0-9a-f-]{32,36})/(?P<container_name>[^/]+)/[0-9]+\.log'
+            parse_from: attributes["log.file.path"]
+            on_error: send
+          - type: move
+            from: attributes.pod_name
+            to: resource["k8s.pod.name"]
+            if: 'attributes.pod_name != nil'
+          - type: move
+            from: attributes.namespace
+            to: resource["k8s.namespace.name"]
+            if: 'attributes.namespace != nil'
+          - type: move
+            from: attributes.uid
+            to: resource["k8s.pod.uid"]
+            if: 'attributes.uid != nil'
+          - type: move
+            from: attributes.container_name
+            to: resource["k8s.container.name"]
+            if: 'attributes.container_name != nil'
+
     processors:
+      transform/apm_labels:
+        metric_statements:
+          - context: datapoint
+            statements:
+              - set(attributes["service.name"], attributes["name"]) where attributes["name"] != nil
+              - set(attributes["service.namespace"], attributes["namespace"]) where attributes["namespace"] != nil
+              - set(attributes["deployment.environment"], "YOUR_ENVIRONMENT")
+      groupbyattrs/service:
+        keys:
+          - service.name
+          - service.namespace
+          - deployment.environment
+      k8sattributes:
+        auth_type: serviceAccount
+        extract:
+          metadata:
+            - k8s.pod.name
+            - k8s.namespace.name
+            - k8s.node.name
+            - k8s.deployment.name
+          labels:
+            - tag_name: k8s.pod.labels.app
+              key: app
+              from: pod
+            - tag_name: k8s.pod.labels.rollouts-pod-template-hash
+              key: rollouts-pod-template-hash
+              from: pod
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.uid
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+      resource:
+        attributes:
+          - key: k8s.cluster.name
+            value: "YOUR_CLUSTER_NAME"
+            action: upsert
       batch:
         timeout: 10s
         send_batch_size: 10000
         send_batch_max_size: 10000
-      resource:
-        attributes:
-          - key: service.name
-            value: "argo-rollouts"
-            action: upsert
-          - key: k8s.cluster.name
-            value: "YOUR_CLUSTER_NAME"
-            action: upsert
-          - key: deployment.environment
-            value: "production"
-            action: upsert
 
     exporters:
       otlp/last9:
@@ -64,18 +124,25 @@ data:
       pipelines:
         metrics:
           receivers: [prometheus]
-          processors: [resource, batch]
+          processors: [transform/apm_labels, groupbyattrs/service, resource, batch]
+          exporters: [otlp/last9]
+        logs:
+          receivers: [filelog]
+          processors: [k8sattributes, resource, batch]
           exporters: [otlp/last9]
 ---
+# DaemonSet so each node's /var/log/pods is accessible.
+# Note: the prometheus receiver scrapes cluster-wide endpoints (Argo Rollouts, kube-state-metrics)
+# from every node. In multi-node clusters, run a separate single-replica Deployment for the
+# metrics pipeline and a separate DaemonSet for the logs pipeline to avoid duplicate metric scrapes.
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: otel-collector
-  namespace: monitoring
+  namespace: last9
   labels:
     app: otel-collector
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: otel-collector
@@ -84,6 +151,7 @@ spec:
       labels:
         app: otel-collector
     spec:
+      serviceAccountName: otel-collector
       containers:
         - name: otel-collector
           image: otel/opentelemetry-collector-contrib:0.144.0
@@ -98,16 +166,28 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/otel
+            - name: varlogpods
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
       volumes:
         - name: config
           configMap:
             name: otel-collector-config
+        - name: varlogpods
+          hostPath:
+            path: /var/log/pods
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: otel-collector
-  namespace: monitoring
+  namespace: last9
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -115,7 +195,7 @@ metadata:
   name: otel-collector-metrics-reader
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "services", "endpoints"]
+    resources: ["nodes", "pods", "services", "endpoints", "namespaces"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["extensions", "apps"]
     resources: ["deployments", "replicasets"]
@@ -134,4 +214,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: otel-collector
-    namespace: monitoring
+    namespace: last9

--- a/otel-collector/argo-rollouts/collector-deployment.yaml
+++ b/otel-collector/argo-rollouts/collector-deployment.yaml
@@ -1,0 +1,137 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: monitoring
+data:
+  config.yaml: |
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: "argo-rollouts"
+              scrape_interval: 30s
+              static_configs:
+                - targets: ["argo-rollouts-metrics.argo-rollouts.svc.cluster.local:8090"]
+              metric_relabel_configs:
+                - source_labels: [__name__]
+                  regex: "rollout_.*|argo_rollouts_.*|analysis_run_.*|experiment_.*"
+                  action: keep
+
+            - job_name: "kube-state-metrics-rollouts"
+              scrape_interval: 30s
+              static_configs:
+                - targets: ["kube-state-metrics.kube-system.svc.cluster.local:8080"]
+              metric_relabel_configs:
+                - source_labels: [__name__]
+                  regex: "kube_pod_labels|kube_pod_status_phase|kube_pod_container_.*"
+                  action: keep
+                - source_labels: [label_rollouts_pod_template_hash]
+                  regex: ".+"
+                  action: keep
+
+    processors:
+      batch:
+        timeout: 10s
+        send_batch_size: 10000
+        send_batch_max_size: 10000
+      resource:
+        attributes:
+          - key: service.name
+            value: "argo-rollouts"
+            action: upsert
+          - key: k8s.cluster.name
+            value: "YOUR_CLUSTER_NAME"
+            action: upsert
+          - key: deployment.environment
+            value: "production"
+            action: upsert
+
+    exporters:
+      otlp/last9:
+        endpoint: "YOUR_LAST9_OTLP_ENDPOINT"
+        headers:
+          "Authorization": "YOUR_LAST9_AUTH_HEADER"
+        compression: gzip
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          processors: [resource, batch]
+          exporters: [otlp/last9]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: monitoring
+  labels:
+    app: otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.144.0
+          args: ["--config=/etc/otel/config.yaml"]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otel
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-config
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-collector-metrics-reader
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "pods", "services", "endpoints"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions", "apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-collector-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-collector-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: otel-collector
+    namespace: monitoring

--- a/otel-collector/argo-rollouts/otel-config.yaml
+++ b/otel-collector/argo-rollouts/otel-config.yaml
@@ -23,22 +23,96 @@ receivers:
               regex: ".+"
               action: keep
 
+  filelog:
+    include:
+      - /var/log/pods/*/*/*.log
+    exclude:
+      - /var/log/pods/last9_*/*/*.log
+    start_at: end
+    include_file_path: true
+    include_file_name: false
+    operators:
+      # Parse pod identity from the log file path:
+      # /var/log/pods/<namespace>_<pod-name>_<pod-uid>/<container>/<n>.log
+      # The UUID anchor lets us handle pod names that contain dashes.
+      - type: regex_parser
+        id: extract_k8s_metadata
+        # Matches both UUID pods (regular) and hex-hash pods (static: etcd, kube-apiserver)
+        regex: '/var/log/pods/(?P<namespace>[^_]+)_(?P<pod_name>.+)_(?P<uid>[0-9a-f-]{32,36})/(?P<container_name>[^/]+)/[0-9]+\.log'
+        parse_from: attributes["log.file.path"]
+        on_error: send
+      - type: move
+        from: attributes.pod_name
+        to: resource["k8s.pod.name"]
+        if: 'attributes.pod_name != nil'
+      - type: move
+        from: attributes.namespace
+        to: resource["k8s.namespace.name"]
+        if: 'attributes.namespace != nil'
+      - type: move
+        from: attributes.uid
+        to: resource["k8s.pod.uid"]
+        if: 'attributes.uid != nil'
+      - type: move
+        from: attributes.container_name
+        to: resource["k8s.container.name"]
+        if: 'attributes.container_name != nil'
+
 processors:
+  # Metrics: Step 1 — copy rollout labels to OTel semantic convention attributes
+  # so they can be promoted to resource scope by groupbyattrs below.
+  # Rollout name → service.name enables correlation with APM traces and metrics.
+  transform/apm_labels:
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(attributes["service.name"], attributes["name"]) where attributes["name"] != nil
+          - set(attributes["service.namespace"], attributes["namespace"]) where attributes["namespace"] != nil
+          - set(attributes["deployment.environment"], "${DEPLOYMENT_ENVIRONMENT}")
+
+  # Metrics: Step 2 — promote service identity attributes to resource scope.
+  # Each rollout gets its own resource with service.name matching your APM service.
+  groupbyattrs/service:
+    keys:
+      - service.name
+      - service.namespace
+      - deployment.environment
+
+  # Logs: enrich with pod metadata from K8s API, including rollouts-pod-template-hash.
+  # This label distinguishes canary pods from stable pods in Last9 log queries.
+  k8sattributes:
+    auth_type: serviceAccount
+    extract:
+      metadata:
+        - k8s.pod.name
+        - k8s.namespace.name
+        - k8s.node.name
+        - k8s.deployment.name
+      labels:
+        - tag_name: k8s.pod.labels.app
+          key: app
+          from: pod
+        - tag_name: k8s.pod.labels.rollouts-pod-template-hash
+          key: rollouts-pod-template-hash
+          from: pod
+    pod_association:
+      - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+      - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+
+  resource:
+    attributes:
+      - key: k8s.cluster.name
+        value: "${K8S_CLUSTER_NAME}"
+        action: upsert
+
   batch:
     timeout: 10s
     send_batch_size: 10000
     send_batch_max_size: 10000
-  resource:
-    attributes:
-      - key: service.name
-        value: "argo-rollouts"
-        action: upsert
-      - key: k8s.cluster.name
-        value: "${K8S_CLUSTER_NAME}"
-        action: upsert
-      - key: deployment.environment
-        value: "${DEPLOYMENT_ENVIRONMENT}"
-        action: upsert
 
 exporters:
   otlp/last9:
@@ -46,12 +120,14 @@ exporters:
     headers:
       "Authorization": "${LAST9_AUTH_HEADER}"
     compression: gzip
-  debug:
-    verbosity: detailed
 
 service:
   pipelines:
     metrics:
       receivers: [prometheus]
-      processors: [resource, batch]
-      exporters: [otlp/last9, debug]
+      processors: [transform/apm_labels, groupbyattrs/service, resource, batch]
+      exporters: [otlp/last9]
+    logs:
+      receivers: [filelog]
+      processors: [k8sattributes, resource, batch]
+      exporters: [otlp/last9]

--- a/otel-collector/argo-rollouts/otel-config.yaml
+++ b/otel-collector/argo-rollouts/otel-config.yaml
@@ -1,0 +1,57 @@
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "argo-rollouts"
+          scrape_interval: 30s
+          static_configs:
+            - targets: ["argo-rollouts-metrics.argo-rollouts.svc.cluster.local:8090"]
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              regex: "rollout_.*|argo_rollouts_.*|analysis_run_.*|experiment_.*"
+              action: keep
+
+        - job_name: "kube-state-metrics-rollouts"
+          scrape_interval: 30s
+          static_configs:
+            - targets: ["kube-state-metrics.kube-system.svc.cluster.local:8080"]
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              regex: "kube_pod_labels|kube_pod_status_phase|kube_pod_container_.*"
+              action: keep
+            - source_labels: [label_rollouts_pod_template_hash]
+              regex: ".+"
+              action: keep
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 10000
+    send_batch_max_size: 10000
+  resource:
+    attributes:
+      - key: service.name
+        value: "argo-rollouts"
+        action: upsert
+      - key: k8s.cluster.name
+        value: "${K8S_CLUSTER_NAME}"
+        action: upsert
+      - key: deployment.environment
+        value: "${DEPLOYMENT_ENVIRONMENT}"
+        action: upsert
+
+exporters:
+  otlp/last9:
+    endpoint: "${LAST9_OTLP_ENDPOINT}"
+    headers:
+      "Authorization": "${LAST9_AUTH_HEADER}"
+    compression: gzip
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [resource, batch]
+      exporters: [otlp/last9, debug]

--- a/otel-collector/argo-rollouts/rollout-example.yaml
+++ b/otel-collector/argo-rollouts/rollout-example.yaml
@@ -1,0 +1,63 @@
+---
+# Example Rollout using Last9 as the canary analysis gate.
+#
+# This is a reference template — adapt the container image, port,
+# service selectors, and metric labels to match your application.
+#
+# The rollout progresses through 10% → 25% → 50% → 100% traffic,
+# running Last9 error rate and latency checks at each pause.
+# Any analysis failure triggers an automatic rollback to stable.
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      containers:
+        - name: my-app
+          image: my-app:latest
+          ports:
+            - containerPort: 8080
+  strategy:
+    canary:
+      # Run both analysis templates in parallel at each pause step
+      analysis:
+        templates:
+          - templateName: last9-http-error-rate
+          - templateName: last9-latency-p99
+        args:
+          - name: service-name
+            value: my-app
+          - name: namespace
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        # How long to wait before starting analysis after each weight change
+        startingStep: 1
+      steps:
+        # Step 1: Send 10% of traffic to canary
+        - setWeight: 10
+        # Step 2: Pause 5 minutes — analysis runs here
+        # If Last9 reports error rate > 10% or p99 > 1s: auto rollback
+        - pause:
+            duration: 5m
+        # Step 3: Promote to 25%
+        - setWeight: 25
+        # Step 4: Pause 5 minutes — analysis runs again
+        - pause:
+            duration: 5m
+        # Step 5: Promote to 50%
+        - setWeight: 50
+        # Step 6: Final pause before full promotion
+        - pause:
+            duration: 5m
+        # Step 7: 100% — stable fully replaced by new version


### PR DESCRIPTION
## Summary

- **Logs pipeline**: adds `filelog` receiver + `k8sattributes` processor to collect pod logs enriched with `rollouts-pod-template-hash`, enabling canary vs stable pod log filtering in Last9
- **APM correlation**: adds `transform/apm_labels` + `groupbyattrs/service` processors to map rollout `name` label → `service.name`, so rollout metrics correlate with APM traces and metrics for the same service
- **Namespace**: changed from `monitoring` to `last9`
- **DaemonSet**: changed from `Deployment` to `DaemonSet` (required for `/var/log/pods` host volume access)
- **Bug fixes**: filelog regex now handles both UUID and hex-hash pod UIDs (static pods like etcd); `if` guards on `move` operators prevent failures when regex doesn't match

## Test plan

- [x] Deployed collector to minikube — metrics pipeline sending to Last9 (`sent_metric_points=564`, `send_failed=0`)
- [x] Logs pipeline sending to Last9 (`sent_log_records=115`, `receiver_accepted=155`)
- [x] `service.name=test-rollout` confirmed on rollout metrics in debug output
- [x] `rollouts-pod-template-hash` label extraction verified via k8sattributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)