### PR TITLE
feat(ruby/rails5.2): add OtelFilterSpanProcessor and Sidekiq OTel fixes

### DIFF
--- a/ruby/rails5.2/README.md
+++ b/ruby/rails5.2/README.md
@@ -1,11 +1,10 @@
 # Rails 5.2 OpenTelemetry Example
 
-This example demonstrates OpenTelemetry instrumentation for a Rails 5.2 API application, sending traces to [Last9](https://last9.io).
+OpenTelemetry instrumentation for a Rails 5.2 API application with built-in span noise reduction, sending traces to [Last9](https://last9.io).
 
-## Requirements
+## Prerequisites
 
 - Ruby 2.7.x
-- Rails 5.2.x
 - Bundler
 
 ## Quick Start
@@ -15,12 +14,10 @@ This example demonstrates OpenTelemetry instrumentation for a Rails 5.2 API appl
    bundle install
    ```
 
-2. **Configure environment variables:**
+2. **Configure environment:**
    ```bash
-   export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <your-credentials>"
-   export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp.last9.io:443"
-   export OTEL_TRACES_SAMPLER="always_on"
-   export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=local"
+   cp .env.example .env
+   # Fill in your Last9 OTLP endpoint and credentials
    ```
 
 3. **Start the server:**
@@ -28,102 +25,122 @@ This example demonstrates OpenTelemetry instrumentation for a Rails 5.2 API appl
    bundle exec rails server
    ```
 
-4. **Test the endpoints:**
+4. **Send test requests:**
    ```bash
    curl http://localhost:3000/health
    curl http://localhost:3000/users
-   curl http://localhost:3000/error
+   curl http://localhost:3000/calculate?n=10
+   curl -X POST http://localhost:3000/process_order
    ```
+
+## Configuration
+
+| Variable | Description |
+|---|---|
+| `OTEL_SERVICE_NAME` | Service name shown in traces |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Last9 OTLP endpoint |
+| `OTEL_EXPORTER_OTLP_HEADERS` | `Authorization=Basic <base64-credentials>` |
+| `OTEL_TRACES_EXPORTER` | Set to `otlp` |
+
+## Reducing Trace Volume
+
+Ruby's `opentelemetry-instrumentation-all` + `use_all()` generates a large number of spans by default. This example includes several mechanisms to reduce noise.
+
+### What's disabled
+
+`ActionView` instrumentation is disabled — it creates a span per template and partial render, which is very high volume in full-stack apps and irrelevant for JSON APIs:
+
+```ruby
+c.use_all('OpenTelemetry::Instrumentation::ActionView' => { enabled: false })
+```
+
+### FilterSpanProcessor
+
+A custom `OtelFilterSpanProcessor` wraps the `BatchSpanProcessor` and drops spans before export. The following are dropped by default:
+
+| Category | Examples | Reason |
+|---|---|---|
+| DB transaction boundaries | `BEGIN`, `COMMIT`, `ROLLBACK` | 2 extra spans per transaction, no debug value |
+| Health check paths | `/health`, `/healthz`, `/ping`, `/readyz`, `/livez` | Load balancer polling noise |
+| OTLP exporter calls | Calls to your Last9 endpoint | Prevents Net::HTTP meta-tracing feedback loop |
+| Noisy Redis commands | `HGET`, `HSET`, `HMGET`, `PIPELINED`, `EXPIRE`, `TTL`, etc. | High-frequency cache ops with no actionable signal |
+
+### Tuning via environment variables
+
+```bash
+# Drop additional URL paths (comma-separated)
+OTEL_FILTER_PATHS=/admin,/metrics,/internal
+
+# Drop spans by peer hostname
+OTEL_FILTER_HOSTS=internal.svc,cache.local
+
+# Drop spans whose name contains any substring
+OTEL_FILTER_SPAN_NAMES=render_partial,render_template
+
+# Override which Redis commands to drop
+OTEL_FILTER_REDIS_COMMANDS=GET,SET,DEL,EXPIRE
+
+# Drop all spans from specific Sidekiq queues
+OTEL_FILTER_SIDEKIQ_QUEUES=mailers,low
+
+# Drop all spans from specific Sidekiq job classes
+OTEL_FILTER_SIDEKIQ_JOBS=HeartbeatJob,MetricsSyncJob
+```
+
+### Sidekiq
+
+`opentelemetry-instrumentation-sidekiq` (included via `opentelemetry-instrumentation-all`) auto-instruments Sidekiq at Rails boot — no extra setup needed for basic tracing.
+
+`config/initializers/sidekiq.rb` adds one critical hook: it calls `OpenTelemetry.tracer_provider.shutdown` on Sidekiq stop. Without this, spans buffered in the `BatchSpanProcessor` are lost when the process receives a stop signal.
+
+### Probabilistic sampling
+
+Sample a percentage of traces instead of sending everything:
+
+```bash
+OTEL_SAMPLE_RATE=0.1   # 10% of traces
+OTEL_SAMPLE_RATE=0.25  # 25% of traces
+```
+
+Uses `parentbased_traceidratio` — downstream services respect the parent's sampling decision, so traces are never split mid-way.
 
 ## Available Endpoints
 
 | Endpoint | Description |
-|----------|-------------|
+|---|---|
 | `GET /health` | Health check |
 | `GET /users` | Returns mock user data |
-| `GET /calculate?n=10` | Fibonacci calculation with custom spans |
-| `GET /error` | Triggers an exception (for testing error traces) |
+| `GET /calculate?n=10` | Fibonacci with a custom span |
+| `GET /error` | Triggers an exception (tests error trace recording) |
 | `POST /process_order` | Nested spans example |
-| `GET /external_api` | Simulated external API call |
+| `GET /external_api` | Simulated external HTTP call |
 
-## OpenTelemetry Configuration
+## Exception Tracking Fix (Rails 5.x)
 
-The OTel configuration is in `config/initializers/opentelemetry.rb`:
+`config/initializers/otel_exception_tracking.rb` fixes two known issues:
 
-- Uses OTLP exporter to send traces to Last9
-- Batch span processor for efficient export
-- Auto-instrumentation for Rails, ActiveRecord, Rack, and more
+**1. Controller exceptions not recorded ([opentelemetry-ruby-contrib #635](https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/635))**
 
-## Exception Tracking Fix for Rails 5.x
+`opentelemetry-instrumentation-action_pack` v0.4.x doesn't record controller exceptions as span events. The fix requires Rails 6.1+ to land upstream. This workaround uses Rack middleware + `ActiveSupport::Notifications` to capture both unhandled exceptions and those handled via `rescue_from`.
 
-Rails 5.x users may encounter a known bug where **controller exceptions are not recorded as span events**. This is due to a bug in `opentelemetry-instrumentation-action_pack` v0.4.x ([GitHub Issue #635](https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/635)).
+**2. Sidekiq job exceptions silently dropped**
 
-The fix exists in action_pack v0.9.0+, but that version requires Rails 6.1+.
+`opentelemetry-instrumentation-sidekiq` wraps `process_one` in `untraced` to suppress Sidekiq's internal polling spans. When a job has no propagated trace context (no `traceparent` header — the common case for jobs enqueued without HTTP context), the `tracer_middleware` inherits the suppressed context and creates a `NonRecordingSpan`. Exceptions on those spans are silently dropped.
 
-### Solution
+The fix is `SidekiqClearUntraced`, a Sidekiq server middleware inserted before the OTel `TracerMiddleware` that replaces the suppressed context with `Context::ROOT`, ensuring job spans are always recording.
 
-This example includes a drop-in fix: `config/initializers/otel_exception_tracking.rb`
+**To use in your own app:** copy `config/initializers/otel_exception_tracking.rb` into your app. No other changes needed.
 
-**For your own Rails 5.x application:**
-
-1. Copy `config/initializers/otel_exception_tracking.rb` to your app
-2. No other code changes required
-3. Exceptions will automatically be captured with:
-   - `exception.type`
-   - `exception.message`
-   - `exception.stacktrace`
-   - Span status set to `ERROR`
-
-### How It Works
-
-The fix uses two mechanisms:
-
-1. **Rack Middleware** - Catches unhandled exceptions that bubble up
-2. **ActiveSupport::Notifications** - Catches exceptions handled by `rescue_from`
-
-### Manual Recording (Optional)
-
-You can also manually record exceptions anywhere in your code:
+To record exceptions manually anywhere in your code:
 
 ```ruby
-begin
-  # risky operation
 rescue => e
   OtelExceptionTracking.record(e)
   raise
 end
 ```
 
-## Gem Versions
-
-Key OpenTelemetry gems used:
-
-- `opentelemetry-sdk` ~> 1.2
-- `opentelemetry-exporter-otlp` ~> 0.24
-- `opentelemetry-instrumentation-rails` = 0.24.1
-- `opentelemetry-instrumentation-all` ~> 0.30
-
-## Troubleshooting
-
-### Exceptions not appearing in traces?
-
-1. Ensure `otel_exception_tracking.rb` is loaded AFTER `opentelemetry.rb`
-   - Rename to `z_otel_exception_tracking.rb` if needed for alphabetical load order
-2. Check that OpenTelemetry is properly configured
-3. Verify your OTLP endpoint and credentials
-
-### Middleware load order
-
-You can verify the middleware is installed:
-
-```bash
-bundle exec rails middleware
-```
-
-Look for `OpenTelemetry::Instrumentation::ExceptionTracking::Middleware` before `ActionDispatch::ShowExceptions`.
-
 ## References
 
-- [OpenTelemetry Ruby](https://opentelemetry.io/docs/languages/ruby/)
-- [Last9 Documentation](https://docs.last9.io/)
-- [Exception Recording Bug #635](https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/635)
+- [OpenTelemetry Ruby docs](https://opentelemetry.io/docs/languages/ruby/)
+- [Last9 documentation](https://last9.io/docs)

--- a/ruby/rails5.2/config/initializers/opentelemetry.rb
+++ b/ruby/rails5.2/config/initializers/opentelemetry.rb
@@ -6,32 +6,177 @@ require 'opentelemetry/sdk'
 require 'opentelemetry/exporter/otlp'
 require 'opentelemetry/instrumentation/all'
 
+# Reduces trace volume by dropping high-cardinality, low-value spans before export.
+#
+# Drops by default:
+#   - DB transaction boundary spans (BEGIN / COMMIT / ROLLBACK) — high volume, no debug value
+#   - HTTP health check paths (/health, /healthz, /ping, /readyz, /livez)
+#   - OTLP exporter's own HTTP calls (prevents meta-tracing feedback loop)
+#   - Noisy Redis commands (HGET, HSET, HMGET, HMSET, EXPIRE, TTL, EXISTS, PIPELINED)
+#
+# Configurable via env vars:
+#   OTEL_FILTER_PATHS          — comma-separated URL paths to drop (e.g. /admin,/metrics)
+#   OTEL_FILTER_HOSTS          — comma-separated hostnames to drop (e.g. internal.svc)
+#   OTEL_FILTER_SPAN_NAMES     — comma-separated span name substrings to drop
+#   OTEL_FILTER_REDIS_COMMANDS — override Redis commands to drop (e.g. GET,SET,DEL)
+#   OTEL_FILTER_SIDEKIQ_QUEUES — drop all spans from these Sidekiq queues (e.g. mailers,low)
+#   OTEL_FILTER_SIDEKIQ_JOBS   — drop all spans from these Sidekiq job classes (e.g. HeartbeatJob)
+class OtelFilterSpanProcessor
+  DB_TRANSACTION_PATTERN = /\A(BEGIN|COMMIT|ROLLBACK)/i
+
+  DEFAULT_DROP_PATHS = %w[
+    /health /healthz /ping /readyz /livez /metrics /favicon.ico
+  ].freeze
+
+  # High-frequency Redis commands that are too granular to be useful in traces.
+  # These are infrastructure-level ops (cache reads/writes, expiry checks) that
+  # generate millions of spans without adding debugging value.
+  DEFAULT_REDIS_NOISE_COMMANDS = %w[
+    HGET HSET HMGET HMSET HGETALL HDEL
+    GET SET SETEX SETNX GETEX
+    EXPIRE TTL PEXPIRE PTTL EXISTS DEL
+    PIPELINED MULTI EXEC
+  ].freeze
+
+  def initialize(delegate_processor)
+    @delegate        = delegate_processor
+    @drop_paths      = build_drop_paths
+    @drop_hosts      = build_drop_hosts
+    @drop_names      = build_drop_names
+    @redis_commands  = build_redis_commands
+    @sidekiq_queues  = build_sidekiq_queues
+    @sidekiq_jobs    = build_sidekiq_jobs
+  end
+
+  def on_start(span, parent_context)
+    @delegate.on_start(span, parent_context)
+  end
+
+  def on_finish(span)
+    @delegate.on_finish(span) unless drop?(span)
+  end
+
+  def force_flush(timeout: nil)
+    @delegate.force_flush(timeout: timeout)
+  end
+
+  def shutdown(timeout: nil)
+    @delegate.shutdown(timeout: timeout)
+  end
+
+  private
+
+  def drop?(span)
+    drop_by_span_name?(span.name) ||
+      drop_by_http_path?(span.attributes) ||
+      drop_by_peer_host?(span.attributes) ||
+      drop_redis_noise?(span) ||
+      drop_sidekiq_noise?(span)
+  end
+
+  # BEGIN/COMMIT/ROLLBACK spans wrap every transaction block — 2 extra spans per transaction
+  def drop_by_span_name?(name)
+    return true if name.match?(DB_TRANSACTION_PATTERN)
+    @drop_names.any? { |pattern| name.include?(pattern) }
+  end
+
+  # Load balancers poll health check paths every few seconds — filter them out
+  def drop_by_http_path?(attrs)
+    target = attrs['http.target'] || attrs['url.path'] || ''
+    return false if target.empty?
+    @drop_paths.any? { |p| target == p || target.start_with?("#{p}/") }
+  end
+
+  # The OTLP exporter uses Net::HTTP — without this filter, each export batch
+  # creates a new Net::HTTP span that gets included in the next batch (feedback loop)
+  def drop_by_peer_host?(attrs)
+    host = attrs['net.peer.name'] || attrs['server.address'] || ''
+    return false if host.empty?
+    @drop_hosts.any? { |h| host == h || host.end_with?(".#{h}") }
+  end
+
+  # Redis commands like HGET/PIPELINED are called millions of times for cache ops.
+  # Identified by db.system=redis so we don't accidentally drop non-Redis spans
+  # whose names happen to match (e.g. a span named "GET" in a different context).
+  def drop_redis_noise?(span)
+    return false unless span.attributes['db.system'] == 'redis'
+    @redis_commands.include?(span.name.upcase)
+  end
+
+  # Drop Sidekiq spans by queue name or job class.
+  # Useful for high-frequency polling/heartbeat jobs that add noise without value.
+  # messaging.destination = queue name (e.g. "default", "mailers")
+  # messaging.sidekiq.job_class = job class name (e.g. "HeartbeatJob")
+  def drop_sidekiq_noise?(span)
+    return false unless span.attributes['messaging.system'] == 'sidekiq'
+    queue = span.attributes['messaging.destination'] || ''
+    job   = span.attributes['messaging.sidekiq.job_class'] || ''
+    @sidekiq_queues.include?(queue) || @sidekiq_jobs.include?(job)
+  end
+
+  def build_drop_paths
+    env = ENV.fetch('OTEL_FILTER_PATHS', '').split(',').map(&:strip).reject(&:empty?)
+    (DEFAULT_DROP_PATHS + env).uniq
+  end
+
+  def build_drop_hosts
+    hosts = []
+    if (endpoint = ENV['OTEL_EXPORTER_OTLP_ENDPOINT'])
+      uri = URI.parse(endpoint) rescue nil
+      hosts << uri.host if uri&.host
+    end
+    env = ENV.fetch('OTEL_FILTER_HOSTS', '').split(',').map(&:strip).reject(&:empty?)
+    (hosts + env).uniq
+  end
+
+  def build_drop_names
+    ENV.fetch('OTEL_FILTER_SPAN_NAMES', '').split(',').map(&:strip).reject(&:empty?)
+  end
+
+  def build_redis_commands
+    env = ENV.fetch('OTEL_FILTER_REDIS_COMMANDS', '')
+    return DEFAULT_REDIS_NOISE_COMMANDS.to_set if env.empty?
+    env.split(',').map { |c| c.strip.upcase }.reject(&:empty?).to_set
+  end
+
+  def build_sidekiq_queues
+    ENV.fetch('OTEL_FILTER_SIDEKIQ_QUEUES', '').split(',').map(&:strip).reject(&:empty?).to_set
+  end
+
+  def build_sidekiq_jobs
+    ENV.fetch('OTEL_FILTER_SIDEKIQ_JOBS', '').split(',').map(&:strip).reject(&:empty?).to_set
+  end
+end
+
 # Configure OTLP exporter to send traces to Last9
 otel_exporter = OpenTelemetry::Exporter::OTLP::Exporter.new
 
-# Set up batch processing for efficient trace export
-processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(otel_exporter)
+# Wrap batch processor with filter to drop noisy spans before export
+batch_processor  = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(otel_exporter)
+filter_processor = OtelFilterSpanProcessor.new(batch_processor)
 
 # Configure OpenTelemetry SDK
 OpenTelemetry::SDK.configure do |c|
-  # Add the span processor for exporting traces
-  c.add_span_processor(processor)
+  c.add_span_processor(filter_processor)
 
-  # Configure resource attributes for better trace identification
+  # Probabilistic sampling via OTEL_SAMPLE_RATE (0.0–1.0).
+  # Uses parentbased_traceidratio so downstream services respect the parent's sampling decision.
+  # Example: OTEL_SAMPLE_RATE=0.1 samples 10% of traces.
+  if (rate = ENV['OTEL_SAMPLE_RATE']&.to_f) && rate < 1.0
+    c.sampler = OpenTelemetry::SDK::Trace::Samplers.parent_based(
+      root: OpenTelemetry::SDK::Trace::Samplers.trace_id_ratio_based(rate.clamp(0.0, 1.0))
+    )
+  end
+
   c.resource = OpenTelemetry::SDK::Resources::Resource.create({
-    # Service name from environment variable or default
     OpenTelemetry::SemanticConventions::Resource::SERVICE_NAME => ENV['OTEL_SERVICE_NAME'] || 'ruby-on-rails-api-service',
-
-    # Version of your service (update this with your app version)
     OpenTelemetry::SemanticConventions::Resource::SERVICE_VERSION => "0.0.0",
-
-    # Deployment environment (development, staging, production)
     OpenTelemetry::SemanticConventions::Resource::DEPLOYMENT_ENVIRONMENT => Rails.env.to_s
   })
 
-  # Enable all available instrumentations
-  # This includes Rails, ActiveRecord, ActiveJob, ActionPack, and more
-  c.use_all()
+  # ActionView creates a span per template and partial render — very high volume in
+  # full-stack apps. Disabled here since this app renders JSON, not HTML views.
+  c.use_all('OpenTelemetry::Instrumentation::ActionView' => { enabled: false })
 end
 
 Rails.logger.info "OpenTelemetry initialized for #{Rails.env} environment"

--- a/ruby/rails5.2/config/initializers/otel_exception_tracking.rb
+++ b/ruby/rails5.2/config/initializers/otel_exception_tracking.rb
@@ -1,9 +1,15 @@
 # OpenTelemetry Exception Tracking for Rails 5.x
 #
-# This file fixes a known bug in opentelemetry-instrumentation-action_pack v0.4.x
-# where controller exceptions are not recorded as span events.
+# This file fixes two known issues:
 #
-# Bug reference: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/635
+# 1. opentelemetry-instrumentation-action_pack v0.4.x doesn't record controller
+#    exceptions as span events.
+#    Bug: https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/635
+#
+# 2. opentelemetry-instrumentation-sidekiq's process_one patch wraps job execution
+#    in `untraced`, which suppresses span recording when jobs lack propagated trace
+#    context (no traceparent header). This causes NonRecordingSpan to be created,
+#    so exceptions are silently dropped.
 #
 # INSTALLATION:
 #   1. Copy this file to config/initializers/otel_exception_tracking.rb
@@ -11,18 +17,11 @@
 #      (rename to z_otel_exception_tracking.rb if needed for load order)
 #   3. No other code changes required - exceptions are automatically captured
 #
-# WHAT IT DOES:
-#   - Records exception details on the current OTel span when errors occur
-#   - Adds exception.type, exception.message, exception.stacktrace as span event
-#   - Sets span status to ERROR
-#   - Captures BOTH:
-#     * Unhandled exceptions (via Rack middleware)
-#     * Handled exceptions via rescue_from (via ActiveSupport::Notifications)
-#
 # COMPATIBILITY:
 #   - Rails 5.0+ (tested with 5.2)
 #   - Ruby 2.5+
 #   - opentelemetry-sdk 1.0+
+#   - opentelemetry-instrumentation-sidekiq 0.22+
 
 module OtelExceptionTracking
   class << self
@@ -55,7 +54,35 @@ module OtelExceptionTracking
       raise
     end
   end
+
+  # Sidekiq server middleware that clears the untraced suppression flag.
+  #
+  # The sidekiq instrumentation gem wraps process_one in `untraced` to suppress
+  # spans from Sidekiq's internal polling. But when a job has no propagated trace
+  # context, the tracer_middleware inherits the suppressed context and creates a
+  # NonRecordingSpan. This middleware clears that flag so job spans are always
+  # recorded and exported.
+  #
+  # Must be inserted BEFORE the OTel TracerMiddleware in the Sidekiq server
+  # middleware chain.
+  class SidekiqClearUntraced
+    def call(worker, msg, queue)
+      if ::OpenTelemetry::Common::Utilities.untraced?
+        # Replace the current context (which has the untraced suppression flag)
+        # with an empty root context. This is safe because the OTel
+        # tracer_middleware (which runs after us) replaces the context anyway
+        # via Context.with_current(extracted_context).
+        ::OpenTelemetry::Context.with_current(::OpenTelemetry::Context::ROOT) do
+          yield
+        end
+      else
+        yield
+      end
+    end
+  end
 end
+
+# --- Rails / Rack setup ---
 
 # Insert middleware directly (runs during initializer load)
 Rails.application.config.middleware.insert_before(
@@ -68,6 +95,25 @@ ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*
   event = ActiveSupport::Notifications::Event.new(*args)
   exception = event.payload[:exception_object]
   OtelExceptionTracking.record(exception) if exception
+end
+
+# --- Sidekiq setup ---
+
+# Clear the untraced flag before the OTel tracer middleware runs, so Sidekiq
+# job spans are always recording (and exceptions are exported).
+if defined?(::Sidekiq)
+  ::Sidekiq.configure_server do |config|
+    config.server_middleware do |chain|
+      if defined?(::OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMiddleware)
+        chain.insert_before(
+          ::OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMiddleware,
+          OtelExceptionTracking::SidekiqClearUntraced
+        )
+      else
+        chain.prepend(OtelExceptionTracking::SidekiqClearUntraced)
+      end
+    end
+  end
 end
 
 Rails.logger.info('[OTel Exception Tracking] Installed for Rails 5.x')

--- a/ruby/rails5.2/config/initializers/sidekiq.rb
+++ b/ruby/rails5.2/config/initializers/sidekiq.rb
@@ -1,0 +1,21 @@
+# Sidekiq + OpenTelemetry initialization
+#
+# opentelemetry-instrumentation-sidekiq (included via opentelemetry-instrumentation-all)
+# auto-instruments Sidekiq via middleware when use_all() runs at Rails boot.
+#
+# This file handles two concerns:
+#   1. Ensuring the OTel SDK shuts down cleanly when Sidekiq stops (flushes pending spans)
+#   2. Providing a place to configure queue/job-level filtering via env vars:
+#
+#      OTEL_FILTER_SIDEKIQ_QUEUES — drop all spans from these queues (e.g. mailers,low)
+#      OTEL_FILTER_SIDEKIQ_JOBS   — drop all spans from these job classes (e.g. HeartbeatJob)
+
+if defined?(Sidekiq)
+  Sidekiq.configure_server do |config|
+    # Flush and shut down the OTel SDK when Sidekiq receives a stop signal.
+    # Without this, spans buffered in the BatchSpanProcessor may be lost on shutdown.
+    config.on(:shutdown) do
+      OpenTelemetry.tracer_provider.shutdown
+    end
+  end
+end


### PR DESCRIPTION
- Add OtelFilterSpanProcessor wrapping BatchSpanProcessor to drop high-volume, low-value spans before export:
  - DB transaction boundaries (BEGIN/COMMIT/ROLLBACK)
  - HTTP health check paths (/health, /healthz, /ping, /readyz, /livez)
  - OTLP exporter's own Net::HTTP calls (prevents meta-tracing loop)
  - Noisy Redis commands (HGET, HSET, HMGET, PIPELINED, EXPIRE, etc.)
  - Sidekiq spans by queue or job class (opt-in via env vars)
- Add probabilistic sampling via OTEL_SAMPLE_RATE env var using parentbased_traceidratio sampler
- Disable ActionView instrumentation (high span volume, irrelevant for JSON API apps)
- Add config/initializers/sidekiq.rb with shutdown hook to flush BatchSpanProcessor on Sidekiq stop
- Fix otel_exception_tracking.rb: add SidekiqClearUntraced middleware to fix silent exception drops when jobs lack traceparent context
- Update README with noise reduction guide and Sidekiq documentation

Configurable via: OTEL_FILTER_PATHS, OTEL_FILTER_HOSTS, OTEL_FILTER_SPAN_NAMES, OTEL_FILTER_REDIS_COMMANDS, OTEL_FILTER_SIDEKIQ_QUEUES, OTEL_FILTER_SIDEKIQ_JOBS, OTEL_SAMPLE_RATE