### PR TITLE
Add deployment.environment label to Sanic event loop metrics

### DIFF
--- a/python/sanic-event-loop-diagnostics/.env.example
+++ b/python/sanic-event-loop-diagnostics/.env.example
@@ -10,7 +10,8 @@ OTEL_SERVICE_NAME=sanic-event-loop-demo
 SERVICE_VERSION=1.0.0
 
 # Deployment environment - critical for filtering in Last9
-# Options: production, staging, development, etc.
+# This label is included in all event loop metrics to help you filter
+# metrics by environment (production, staging, development, etc.)
 DEPLOYMENT_ENVIRONMENT=development
 
 # Service namespace - logical grouping (e.g., "payments", "user-management")

--- a/python/sanic-event-loop-diagnostics/README.md
+++ b/python/sanic-event-loop-diagnostics/README.md
@@ -29,6 +29,8 @@ These metrics are crucial for diagnosing async application performance issues.
 | `asyncio.eventloop.blocking_events` | Counter | Count of detected blocking operations |
 | `asyncio.eventloop.lag_distribution` | Histogram | Distribution of lag measurements |
 
+**Metric Labels:** All metrics include `service.name` and `deployment.environment` labels, enabling you to filter metrics by service and environment (production, staging, development, etc.) in your observability platform.
+
 ### How It Works
 
 The monitoring uses the **sleep-based lag detection** technique:
@@ -185,7 +187,7 @@ cp .env.example .env
 |----------|-------------|---------|
 | `OTEL_SERVICE_NAME` | Service name shown in Last9 | `sanic-event-loop-demo` |
 | `SERVICE_VERSION` | Service version for tracking deployments | - |
-| `DEPLOYMENT_ENVIRONMENT` | Environment (production/staging/development) | `development` |
+| `DEPLOYMENT_ENVIRONMENT` | Environment label included in all metrics (production/staging/development) | `development` |
 | `SERVICE_NAMESPACE` | Logical grouping (e.g., "payments", "user-management") | - |
 
 ```bash

--- a/python/sanic-event-loop-diagnostics/app.py
+++ b/python/sanic-event-loop-diagnostics/app.py
@@ -49,6 +49,7 @@ async def setup_otel_and_monitor(app, loop):
     global tracer, meter, event_loop_monitor
 
     service_name = os.getenv("OTEL_SERVICE_NAME", "sanic-event-loop-demo")
+    deployment_environment = os.getenv("DEPLOYMENT_ENVIRONMENT", "unknown")
 
     # Setup OpenTelemetry (tracing + metrics)
     tracer, meter = setup_opentelemetry(service_name=service_name)
@@ -59,11 +60,13 @@ async def setup_otel_and_monitor(app, loop):
         interval=0.1,  # Check every 100ms
         blocking_threshold=0.05,  # 50ms = blocking warning
         critical_threshold=0.5,  # 500ms = critical
-        service_name=service_name
+        service_name=service_name,
+        deployment_environment=deployment_environment
     )
     await event_loop_monitor.start()
 
     print(f"Event loop monitor started for {service_name}")
+    print(f"  - Deployment environment: {deployment_environment}")
     print(f"  - Monitoring interval: 100ms")
     print(f"  - Blocking threshold: 50ms")
     print(f"  - Critical threshold: 500ms")

--- a/python/sanic-event-loop-diagnostics/event_loop_monitor.py
+++ b/python/sanic-event-loop-diagnostics/event_loop_monitor.py
@@ -53,7 +53,8 @@ class EventLoopMonitor:
         interval: float = 0.1,
         blocking_threshold: float = 0.05,
         critical_threshold: float = 0.5,
-        service_name: str = "unknown"
+        service_name: str = "unknown",
+        deployment_environment: str = "unknown"
     ):
         """
         Initialize the event loop monitor.
@@ -66,12 +67,15 @@ class EventLoopMonitor:
                                Default 50ms - typical threshold for user-perceptible delay.
             critical_threshold: Lag above this is "critical" (seconds). Default 500ms.
             service_name: Service name for metric attributes.
+            deployment_environment: Deployment environment (production, staging, development, etc.)
+                                   for metric attributes. Helps filter metrics by environment.
         """
         self._meter = meter
         self._interval = interval
         self._blocking_threshold = blocking_threshold
         self._critical_threshold = critical_threshold
         self._service_name = service_name
+        self._deployment_environment = deployment_environment
 
         # Current stats (updated by monitoring task)
         self._stats = EventLoopStats()
@@ -103,6 +107,17 @@ class EventLoopMonitor:
 
         # Create OTEL metrics
         self._setup_metrics()
+
+    def _get_metric_attributes(self) -> Dict[str, str]:
+        """
+        Get common metric attributes for all metrics.
+
+        Returns a dictionary with service.name and deployment.environment.
+        """
+        return {
+            "service.name": self._service_name,
+            "deployment.environment": self._deployment_environment
+        }
 
     def _setup_metrics(self):
         """Create OpenTelemetry metric instruments."""
@@ -176,28 +191,28 @@ class EventLoopMonitor:
         """Callback for lag gauge."""
         yield Observation(
             self._stats.lag_ms,
-            {"service.name": self._service_name}
+            self._get_metric_attributes()
         )
 
     def _observe_active_tasks(self, options: CallbackOptions):
         """Callback for active tasks gauge."""
         yield Observation(
             self._stats.active_tasks,
-            {"service.name": self._service_name}
+            self._get_metric_attributes()
         )
 
     def _observe_utilization(self, options: CallbackOptions):
         """Callback for utilization gauge."""
         yield Observation(
             self._stats.utilization_percent,
-            {"service.name": self._service_name}
+            self._get_metric_attributes()
         )
 
     def _observe_max_lag(self, options: CallbackOptions):
         """Callback for max lag gauge."""
         yield Observation(
             self._stats.max_lag_ms,
-            {"service.name": self._service_name}
+            self._get_metric_attributes()
         )
 
     def _observe_task_breakdown(self, options: CallbackOptions):
@@ -210,13 +225,9 @@ class EventLoopMonitor:
         trend analysis of which tasks are active over time.
         """
         for coro_name, count in self._stats.task_breakdown.items():
-            yield Observation(
-                count,
-                {
-                    "service.name": self._service_name,
-                    "task.coroutine": coro_name,
-                }
-            )
+            attributes = self._get_metric_attributes()
+            attributes["task.coroutine"] = coro_name
+            yield Observation(count, attributes)
 
     async def start(self):
         """Start the monitoring task."""
@@ -307,7 +318,7 @@ class EventLoopMonitor:
                 # Record lag in histogram for distribution analysis (in milliseconds)
                 self._lag_histogram.record(
                     lag_ms,
-                    {"service.name": self._service_name}
+                    self._get_metric_attributes()
                 )
 
                 # Detect blocking events and attribute lag to contributing tasks
@@ -320,14 +331,10 @@ class EventLoopMonitor:
                     else:
                         severity = "warning"
 
-                    self._blocking_counter.add(
-                        1,
-                        {
-                            "service.name": self._service_name,
-                            "blocking.severity": severity,
-                            "blocking.lag_ms": str(round(lag_ms, 3))
-                        }
-                    )
+                    blocking_attributes = self._get_metric_attributes()
+                    blocking_attributes["blocking.severity"] = severity
+                    blocking_attributes["blocking.lag_ms"] = str(round(lag_ms, 3))
+                    self._blocking_counter.add(1, blocking_attributes)
 
                     # Record the interval [start, now] during which the block
                     # occurred. The block happened somewhere between 'start'
@@ -344,14 +351,10 @@ class EventLoopMonitor:
                     # metric is still emitted.
                     contributing_tasks = task_breakdown if task_breakdown else {"unknown": 1}
                     for coro_name in contributing_tasks:
-                        self._task_lag_histogram.record(
-                            lag_ms,
-                            {
-                                "service.name": self._service_name,
-                                "task.coroutine": coro_name,
-                                "blocking.severity": severity,
-                            }
-                        )
+                        task_lag_attributes = self._get_metric_attributes()
+                        task_lag_attributes["task.coroutine"] = coro_name
+                        task_lag_attributes["blocking.severity"] = severity
+                        self._task_lag_histogram.record(lag_ms, task_lag_attributes)
 
             except asyncio.CancelledError:
                 break


### PR DESCRIPTION
## Summary

Adds `deployment.environment` label to all asyncio event loop metrics in the Sanic example, enabling users to filter and compare metrics across different deployment environments.

## Changes

### Code Changes

1. **event_loop_monitor.py**
   - Added `deployment_environment` parameter to `__init__`
   - Created `_get_metric_attributes()` helper method that returns both `service.name` and `deployment.environment` labels
   - Updated all metric observation callbacks to use the helper method
   - Updated histogram and counter recordings to include environment label

2. **app.py**
   - Read `DEPLOYMENT_ENVIRONMENT` from environment variables
   - Pass `deployment_environment` parameter to `EventLoopMonitor`
   - Added environment to startup log output

3. **.env.example**
   - Enhanced documentation for `DEPLOYMENT_ENVIRONMENT` variable
   - Added note that it's included in all event loop metrics

4. **README.md**
   - Documented that all metrics include `service.name` and `deployment.environment` labels
   - Updated configuration section to clarify environment label usage

## Affected Metrics

All event loop metrics now include both labels:

- `asyncio.eventloop.lag`
- `asyncio.eventloop.active_tasks`
- `asyncio.eventloop.utilization`
- `asyncio.eventloop.max_lag`
- `asyncio.eventloop.blocking_events`
- `asyncio.eventloop.lag_distribution`
- `asyncio.eventloop.task.active_count`
- `asyncio.eventloop.task.lag_contribution`

## Benefits

✅ Filter metrics by environment (production, staging, development)
✅ Compare metrics across environments side-by-side
✅ Set up environment-specific alerts
✅ Track metrics separately for each deployment environment

## Example Queries

```promql
# Filter by production environment only
asyncio_eventloop_lag_milliseconds{deployment_environment="production"}

# Compare production vs staging
asyncio_eventloop_lag_milliseconds{deployment_environment=~"production|staging"}

# P95 lag by environment
histogram_quantile(0.95, 
  rate(asyncio_eventloop_lag_distribution_milliseconds_bucket[5m])
) by (deployment_environment)
```

## Testing

- [x] Code changes verified manually
- [x] All metric recording calls updated to use `_get_metric_attributes()`
- [x] Documentation updated

## Deployment Notes

After deployment, users can set `DEPLOYMENT_ENVIRONMENT` in their `.env` file:

```bash
DEPLOYMENT_ENVIRONMENT=production  # or staging, development, etc.
```

The environment label will be automatically included in all event loop metrics exported to Last9.