### PR TITLE
Clarify deployment.environment is an OpenTelemetry Resource attribute

### DIFF
--- a/python/sanic-event-loop-diagnostics/.env.example
+++ b/python/sanic-event-loop-diagnostics/.env.example
@@ -10,6 +10,8 @@ OTEL_SERVICE_NAME=sanic-event-loop-demo
 SERVICE_VERSION=1.0.0
 
 # Deployment environment - critical for filtering in Last9
+# This becomes the "deployment.environment" OpenTelemetry Resource attribute,
+# which is automatically added as a label to ALL metrics, traces, and logs.
 # Options: production, staging, development, etc.
 DEPLOYMENT_ENVIRONMENT=development
 

--- a/python/sanic-event-loop-diagnostics/README.md
+++ b/python/sanic-event-loop-diagnostics/README.md
@@ -29,6 +29,8 @@ These metrics are crucial for diagnosing async application performance issues.
 | `asyncio.eventloop.blocking_events` | Counter | Count of detected blocking operations |
 | `asyncio.eventloop.lag_distribution` | Histogram | Distribution of lag measurements |
 
+**Note on Metric Labels**: All metrics automatically include OpenTelemetry Resource attributes such as `service.name`, `deployment.environment`, `service.version`, and any Kubernetes/cloud-specific attributes. These are set once in the Resource configuration and propagate to all metrics, traces, and logs. See the [Configuration](#configuration) section for details.
+
 ### How It Works
 
 The monitoring uses the **sleep-based lag detection** technique:
@@ -185,14 +187,19 @@ cp .env.example .env
 |----------|-------------|---------|
 | `OTEL_SERVICE_NAME` | Service name shown in Last9 | `sanic-event-loop-demo` |
 | `SERVICE_VERSION` | Service version for tracking deployments | - |
-| `DEPLOYMENT_ENVIRONMENT` | Environment (production/staging/development) | `development` |
+| `DEPLOYMENT_ENVIRONMENT` | **OpenTelemetry Resource attribute** - automatically added as `deployment.environment` label to ALL metrics, traces, and logs | `development` |
 | `SERVICE_NAMESPACE` | Logical grouping (e.g., "payments", "user-management") | - |
 
 ```bash
 OTEL_SERVICE_NAME=my-async-service
 SERVICE_VERSION=1.0.0
-DEPLOYMENT_ENVIRONMENT=production
+DEPLOYMENT_ENVIRONMENT=production  # Becomes deployment.environment label in all telemetry
 SERVICE_NAMESPACE=backend
+```
+
+**Alternative (Standard OpenTelemetry)**: You can also set resource attributes using the standard `OTEL_RESOURCE_ATTRIBUTES` environment variable:
+```bash
+export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=production,service.namespace=backend"
 ```
 
 #### OTLP Export Configuration


### PR DESCRIPTION
## Summary

This PR clarifies that `deployment.environment` is already supported in the Sanic event loop diagnostics example through **OpenTelemetry Resource attributes** - no code changes needed!

## Problem

The documentation didn't clearly explain that `deployment.environment` automatically propagates to all metrics, traces, and logs via the OpenTelemetry Resource mechanism.

## Solution (Documentation Only)

Added clarification that:
1. `DEPLOYMENT_ENVIRONMENT` env var becomes `deployment.environment` Resource attribute
2. Resource attributes automatically propagate to ALL telemetry signals
3. No manual label addition needed - it's built into OpenTelemetry

## How It Already Works

```python
# otel_setup.py:304-310 (existing code)
deployment_env = (
    os.getenv("DEPLOYMENT_ENVIRONMENT") or
    os.getenv("ENVIRONMENT") or
    os.getenv("ENV") or
    "development"
)
service_attrs[DEPLOYMENT_ENVIRONMENT] = deployment_env

# Resource is passed to MeterProvider/TracerProvider
resource = create_resource(service_name)
meter_provider = MeterProvider(resource=resource)  # ← Resource attributes propagate!
```

## Changes Made

### README.md
- Added note explaining Resource attributes propagate to all metrics
- Clarified `DEPLOYMENT_ENVIRONMENT` → `deployment.environment` label mapping  
- Added example of using standard `OTEL_RESOURCE_ATTRIBUTES` approach

### .env.example
- Enhanced comment explaining Resource attribute behavior

## Follows Repository Standards

This approach matches other examples in the repo:
- `python/sanic/event-loop-diagnostics/otel_config_production.py:56`
  ```python
  "deployment.environment": os.getenv("ENVIRONMENT", "production")
  ```

## Example Usage

```bash
# Method 1: Using DEPLOYMENT_ENVIRONMENT (recommended for this example)
export DEPLOYMENT_ENVIRONMENT=production

# Method 2: Standard OpenTelemetry approach
export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=production"
```

Both methods result in:
```promql
asyncio_eventloop_lag_milliseconds{
  service_name="sanic-event-loop-demo",
  deployment_environment="production"  # ← Automatically included!
}
```

## Benefits

✅ No code changes needed - functionality already exists
✅ Follows OpenTelemetry standard Resource pattern
✅ Consistent with other examples in the repository  
✅ Clearer documentation for end users

## Testing

- [x] Verified `otel_setup.py` already sets `deployment.environment` in Resource
- [x] Confirmed Resource attributes propagate to MeterProvider
- [x] Documentation accurately reflects existing behavior

## Related

This clarification was requested to help end users filter metrics by environment (production, staging, development, etc.) in Last9 and other observability platforms.