### PR TITLE
docs: add MDC attribute capture to Spring Boot example

### DIFF
--- a/java/springboot/env.example
+++ b/java/springboot/env.example
@@ -41,6 +41,11 @@ OTEL_LOGS_EXPORTER=otlp
 OTEL_LOGS_SAMPLER=parentbased_always_on
 OTEL_LOGS_SAMPLER_ARG=1.0
 
+# MDC Attributes Capture (Logback/Log4j)
+# Captures MDC context (e.g., requestId, transactionId, correlationId) as log record attributes.
+# Use "*" to capture all MDC attributes, or a comma-separated list for specific ones.
+OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_MDC_ATTRIBUTES=*
+
 # Additional Resource Attributes
 # OTEL_RESOURCE_ATTRIBUTES=service.name=springboot-otel-demo,service.version=1.0.0,deployment.environment=development,host.name=localhost,process.runtime.name=OpenJDK,process.runtime.version=17
 


### PR DESCRIPTION
## Summary
- Added `OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_MDC_ATTRIBUTES=*` to `java/springboot/env.example`
- Includes documentation comment explaining the config

## Context
Without this config, the OTEL Java agent does not capture Logback MDC attributes (requestId, transactionId, correlationId) as log record attributes.

## Test plan
- [ ] Verify env.example is valid and comments are clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)