### PR TITLE
Add AWS Lambda trace-log correlation example

### DIFF
--- a/python/lambda-trace-log-correlation/.env.example
+++ b/python/lambda-trace-log-correlation/.env.example
@@ -1,0 +1,8 @@
+# Lambda Function Environment Variables
+# Configure these in your AWS Lambda function settings
+
+# OpenTelemetry Configuration
+OTEL_SERVICE_NAME=lambda-trace-correlation
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.example.com:443
+OTEL_EXPORTER_OTLP_HEADERS_AUTHORIZATION=Basic <your-base64-credentials>
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment=local

--- a/python/lambda-trace-log-correlation/.gitignore
+++ b/python/lambda-trace-log-correlation/.gitignore
@@ -1,0 +1,35 @@
+# Environment/secrets
+.env
+.env.local
+.env.*.local
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+.venv/
+venv/
+ENV/
+env/
+
+# Lambda deployment package
+lambda-package.zip
+package/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# AWS
+response.json

--- a/python/lambda-trace-log-correlation/README.md
+++ b/python/lambda-trace-log-correlation/README.md
@@ -1,0 +1,248 @@
+# AWS Lambda Trace-Log Correlation with OpenTelemetry
+
+This example demonstrates how to achieve complete traces-log-traces correlation in AWS Lambda using OpenTelemetry, with logs collected via CloudWatch and correlated with traces in your observability platform.
+
+## Architecture
+
+```
+┌─────────────┐         ┌──────────────┐         ┌─────────────┐
+│   Lambda    │ ──────> │  OTLP        │ ──────> │ Observability│
+│  Function   │ traces  │  Endpoint    │         │  Platform   │
+└─────────────┘         └──────────────┘         └─────────────┘
+       │                                                  ▲
+       │ logs                                             │
+       ▼                                                  │
+┌─────────────┐         ┌──────────────┐                │
+│ CloudWatch  │ ──────> │ OTel         │ ────────────────┘
+│    Logs     │         │ Collector    │    logs with
+└─────────────┘         └──────────────┘    trace_id
+
+```
+
+## Key Features
+
+- **Custom Trace Logging**: Uses a custom `TraceContextFormatter` to inject `trace_id` and `span_id` into every log message
+- **Manual OTLP Export**: Direct trace export to observability platform without Lambda Layer conflicts
+- **CloudWatch Log Collection**: OTel Collector polls CloudWatch logs and extracts trace context
+- **Trace ID Extraction**: Automatic extraction of trace_id and span_id as separate log attributes for correlation
+
+## Prerequisites
+
+- AWS account with Lambda and CloudWatch access
+- EC2 instance for running OTel Collector (with IAM role for CloudWatch Logs read access)
+- Observability platform with OTLP endpoint supporting traces and logs
+
+## Setup
+
+### 1. Lambda Function
+
+**Dependencies** (`requirements.txt`):
+```txt
+opentelemetry-api==1.21.0
+opentelemetry-sdk==1.21.0
+opentelemetry-exporter-otlp-proto-http==1.21.0
+```
+
+**Lambda Configuration**:
+- Runtime: Python 3.11
+- Handler: `lambda_function.lambda_handler`
+- Environment Variables:
+  - `OTEL_EXPORTER_OTLP_ENDPOINT`: Your OTLP endpoint (e.g., `https://otlp-region.example.com:443`)
+  - `OTEL_SERVICE_NAME`: Service name for traces (e.g., `lambda-trace-correlation`)
+
+**Deployment**:
+```bash
+# Create deployment package
+zip -r lambda-package.zip lambda_function.py
+cd venv/lib/python3.11/site-packages
+zip -r ../../../../lambda-package.zip .
+cd ../../../../
+
+# Deploy to Lambda
+aws lambda update-function-code \
+  --function-name your-lambda-function \
+  --zip-file fileb://lambda-package.zip
+```
+
+### 2. OTel Collector Setup
+
+**Install OTel Collector** on EC2 instance:
+```bash
+# Download and install
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.114.0/otelcol-contrib_0.114.0_linux_amd64.tar.gz
+tar -xzf otelcol-contrib_0.114.0_linux_amd64.tar.gz
+sudo mv otelcol-contrib /usr/local/bin/
+```
+
+**IAM Role** for EC2 instance:
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+        "logs:GetLogEvents",
+        "logs:FilterLogEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+**Configure OTel Collector**:
+Copy `otel-collector-config.yaml` to your EC2 instance and update:
+- `region`: Your AWS region
+- `named`: Your Lambda log group name (e.g., `/aws/lambda/your-function-name`)
+- `endpoint`: Your OTLP endpoint
+- `Authorization`: Your OTLP authorization header
+
+**Start Collector**:
+```bash
+nohup /usr/local/bin/otelcol-contrib --config /path/to/otel-collector-config.yaml > otel.log 2>&1 &
+```
+
+## How It Works
+
+### 1. Trace Context Injection
+
+The Lambda function uses a custom logging formatter to inject trace context:
+
+```python
+class TraceContextFormatter(logging.Formatter):
+    def format(self, record):
+        span = trace.get_current_span()
+        if span:
+            span_context = span.get_span_context()
+            if span_context.is_valid:
+                record.trace_id = format(span_context.trace_id, '032x')
+                record.span_id = format(span_context.span_id, '016x')
+        return super().format(record)
+```
+
+This produces logs like:
+```
+[INFO] [trace_id=38372e92ab741e4f1033d84c4de56ee9 span_id=06199b7a707b3ae7] Lambda invocation started
+```
+
+### 2. Trace Export
+
+Traces are exported directly to the OTLP endpoint using manual initialization:
+
+```python
+def init_tracer():
+    resource = Resource.create({
+        "service.name": os.environ.get("OTEL_SERVICE_NAME", "lambda-service"),
+        "deployment.environment": "production"
+    })
+
+    provider = TracerProvider(resource=resource)
+
+    otlp_exporter = OTLPSpanExporter(
+        endpoint=os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") + "/v1/traces",
+        headers={"authorization": "..."}
+    )
+
+    _span_processor = BatchSpanProcessor(otlp_exporter)
+    provider.add_span_processor(_span_processor)
+    trace.set_tracer_provider(provider)
+```
+
+### 3. Log Collection and Correlation
+
+The OTel Collector:
+1. Polls CloudWatch logs every 2 minutes (configurable)
+2. Extracts `trace_id` and `span_id` from log body using regex:
+   ```yaml
+   transform/extract_trace_id:
+     log_statements:
+       - context: log
+         statements:
+           - set(attributes["trace_id"], ExtractPatterns(body, "trace_id=(?P<trace_id>[a-f0-9]{32})")["trace_id"])
+           - set(attributes["span_id"], ExtractPatterns(body, "span_id=(?P<span_id>[a-f0-9]{16})")["span_id"])
+   ```
+3. Exports logs with trace_id as separate attributes to observability platform
+
+## Verification
+
+### Test Lambda Function
+
+```bash
+aws lambda invoke \
+  --function-name your-lambda-function \
+  --payload '{"test":"trace-correlation"}' \
+  response.json
+```
+
+### Check CloudWatch Logs
+
+Look for logs with trace context:
+```
+[INFO] [trace_id=38372e92ab741e4f1033d84c4de56ee9 span_id=06199b7a707b3ae7] Processing test event
+```
+
+### Verify OTel Collector
+
+Check collector logs to confirm trace_id extraction:
+```bash
+tail -f otel.log | grep trace_id
+```
+
+You should see:
+```
+Attributes:
+     -> trace_id: Str(38372e92ab741e4f1033d84c4de56ee9)
+     -> span_id: Str(06199b7a707b3ae7)
+```
+
+### Check Observability Platform
+
+In your observability platform:
+1. Find a trace by trace_id
+2. Navigate to logs view
+3. Filter by `trace_id` attribute
+4. Verify logs from the same trace appear
+
+## Important Notes
+
+### Force Flush Pattern
+
+Lambda containers can be frozen after execution, so we force flush traces:
+
+```python
+if _span_processor:
+    _span_processor.force_flush(timeout_millis=5000)
+```
+
+This ensures all traces are sent before the Lambda execution completes.
+
+### Why Manual Initialization?
+
+We use manual OTLP initialization instead of AWS Lambda Layer because:
+- Avoids TracerProvider override conflicts
+- Full control over trace export configuration
+- No dependency on Lambda Layer version compatibility
+
+### Log Format Requirements
+
+The regex pattern in OTel Collector expects exact format:
+```
+trace_id=<32-hex-chars> span_id=<16-hex-chars>
+```
+
+If you change the log format in Lambda, update the regex in `otel-collector-config.yaml`.
+
+## Related Examples
+
+- [AWS SQS Lambda](../aws-sqs-lambda/): Lambda with SQS integration
+- [AWS Lambda Go](../../aws/lambda-go/): Lambda trace export in Go
+
+## References
+
+- [OpenTelemetry Python SDK](https://opentelemetry-python.readthedocs.io/)
+- [OTLP Specification](https://opentelemetry.io/docs/specs/otlp/)
+- [OpenTelemetry Transformation Language (OTTL)](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl)
+- [AWS CloudWatch Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscloudwatchreceiver)

--- a/python/lambda-trace-log-correlation/lambda_function.py
+++ b/python/lambda-trace-log-correlation/lambda_function.py
@@ -1,0 +1,134 @@
+import logging
+import json
+import os
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+
+# Custom formatter to add trace_id and span_id to logs
+class TraceContextFormatter(logging.Formatter):
+    def format(self, record):
+        span = trace.get_current_span()
+        if span:
+            span_context = span.get_span_context()
+            if span_context.is_valid:
+                record.trace_id = format(span_context.trace_id, '032x')
+                record.span_id = format(span_context.span_id, '016x')
+            else:
+                record.trace_id = '0' * 32
+                record.span_id = '0' * 16
+        else:
+            record.trace_id = '0' * 32
+            record.span_id = '0' * 16
+        return super().format(record)
+
+# Configure logger with custom formatter
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# Add trace context to log format
+handler = logging.StreamHandler()
+formatter = TraceContextFormatter(
+    '[%(levelname)s] [trace_id=%(trace_id)s span_id=%(span_id)s] %(message)s'
+)
+handler.setFormatter(formatter)
+logger.handlers = [handler]
+
+_tracer_initialized = False
+_span_processor = None
+
+def init_tracer():
+    """Initialize OpenTelemetry tracer with OTLP exporter"""
+    global _tracer_initialized, _span_processor
+    if _tracer_initialized:
+        return
+
+    # Create resource with service name and parse deployment.environment from OTEL_RESOURCE_ATTRIBUTES
+    resource_attrs = {
+        "service.name": os.environ.get("OTEL_SERVICE_NAME", "lambda-service"),
+    }
+
+    # Parse OTEL_RESOURCE_ATTRIBUTES if provided (format: key1=value1,key2=value2)
+    otel_resource_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
+    if otel_resource_attrs:
+        for pair in otel_resource_attrs.split(","):
+            if "=" in pair:
+                key, value = pair.split("=", 1)
+                resource_attrs[key.strip()] = value.strip()
+
+    resource = Resource.create(resource_attrs)
+
+    # Create tracer provider
+    provider = TracerProvider(resource=resource)
+
+    # Configure OTLP exporter
+    otlp_exporter = OTLPSpanExporter(
+        endpoint=os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") + "/v1/traces",
+        headers={
+            "authorization": os.environ.get("OTEL_EXPORTER_OTLP_HEADERS_AUTHORIZATION", "")
+        }
+    )
+
+    # Add span processor and keep reference for flushing
+    _span_processor = BatchSpanProcessor(otlp_exporter)
+    provider.add_span_processor(_span_processor)
+
+    # Set as global tracer provider
+    trace.set_tracer_provider(provider)
+
+    _tracer_initialized = True
+    logger.info("OpenTelemetry tracer initialized manually with OTLP exporter")
+
+def lambda_handler(event, context):
+    global _span_processor
+
+    # Initialize tracer first
+    init_tracer()
+
+    # Get tracer after initialization
+    tracer = trace.get_tracer(__name__)
+
+    # Create an explicit span for this Lambda invocation
+    with tracer.start_as_current_span("lambda_handler") as span:
+        span.set_attribute("faas.execution", context.aws_request_id)
+        span.set_attribute("faas.name", context.function_name)
+
+        logger.info("Lambda invocation started")
+        logger.info(f"Request ID: {context.aws_request_id}")
+        logger.info(f"Processing test event: {json.dumps(event)}")
+
+        # Simulate some work with child spans
+        with tracer.start_as_current_span("validate_input") as validate_span:
+            logger.info("Step 1: Validating input")
+            validate_span.set_attribute("validation.result", "success")
+
+        with tracer.start_as_current_span("process_data") as process_span:
+            logger.info("Step 2: Processing data")
+            process_span.set_attribute("processing.items", 1)
+
+        with tracer.start_as_current_span("prepare_response") as response_span:
+            logger.info("Step 3: Preparing response")
+            response_span.set_attribute("response.status", "success")
+
+        result = {
+            "statusCode": 200,
+            "body": {
+                "status": "success",
+                "message": "Manual OTLP trace export test with trace_id in logs",
+                "trace_id": format(span.get_span_context().trace_id, '032x'),
+                "span_id": format(span.get_span_context().span_id, '016x')
+            }
+        }
+
+        logger.info("Processing completed successfully")
+        logger.warning("This is a test warning - should have trace context")
+
+    # Force flush spans before Lambda terminates
+    if _span_processor:
+        logger.info("Forcing span processor flush...")
+        _span_processor.force_flush(timeout_millis=5000)
+        logger.info("Span processor flush completed")
+
+    return result

--- a/python/lambda-trace-log-correlation/otel-collector-config.yaml
+++ b/python/lambda-trace-log-correlation/otel-collector-config.yaml
@@ -1,0 +1,69 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+  awscloudwatch:
+    # Region of your AWS account
+    region: <your-aws-region>  # e.g., us-east-1, ap-south-1
+    logs:
+      poll_interval: 2m
+      groups:
+        # Configure your Lambda log group name
+        named:
+          /aws/lambda/<your-lambda-function-name>:
+
+processors:
+  batch:
+    timeout: 40s
+    send_batch_size: 100000
+    send_batch_max_size: 100000
+
+  transform/extract_trace_id:
+    error_mode: ignore
+    log_statements:
+      - context: log
+        statements:
+          # Extract trace_id from log body using regex with named capture groups
+          - set(attributes["trace_id"], ExtractPatterns(body, "trace_id=(?P<trace_id>[a-f0-9]{32})")["trace_id"])
+          - set(attributes["span_id"], ExtractPatterns(body, "span_id=(?P<span_id>[a-f0-9]{16})")["span_id"])
+
+  transform/add_timestamp:
+    error_mode: ignore
+    log_statements:
+      - context: log
+        conditions:
+        - time_unix_nano == 0
+        statements:
+          - set(observed_time, Now())
+          - set(time_unix_nano, observed_time_unix_nano)
+
+  transform/logs:
+    error_mode: ignore
+    log_statements:
+      - context: log
+        statements:
+          - set(resource.attributes["service.name"], "cloudwatch-logs")
+          - set(attributes["source"], "cloudwatch")
+
+  resourcedetection/ec2:
+    detectors: [env, ec2]
+    timeout: 2s
+    override: false
+
+exporters:
+  debug:
+    verbosity: detailed
+  otlp:
+    endpoint: "<your-otlp-endpoint>"  # e.g., https://otlp.example.com:443
+    headers:
+      Authorization: "<your-authorization-header>"  # e.g., Basic <base64-encoded-credentials>
+
+service:
+  pipelines:
+    logs:
+      receivers: [awscloudwatch]
+      processors: [batch, resourcedetection/ec2, transform/add_timestamp, transform/extract_trace_id, transform/logs]
+      exporters: [otlp, debug]

--- a/python/lambda-trace-log-correlation/requirements.txt
+++ b/python/lambda-trace-log-correlation/requirements.txt
@@ -1,0 +1,3 @@
+opentelemetry-api==1.21.0
+opentelemetry-sdk==1.21.0
+opentelemetry-exporter-otlp-proto-http==1.21.0


### PR DESCRIPTION
## Summary
Adds a production-ready example demonstrating complete trace-log correlation in AWS Lambda using OpenTelemetry.

## What's included
- **Lambda function** with custom TraceContextFormatter that injects trace_id and span_id into every log message
- **OTel Collector config** for CloudWatch log collection with automatic trace_id/span_id extraction
- **Complete documentation** including architecture, setup instructions, verification steps, and troubleshooting

## Key features
- Custom logging formatter for trace context injection
- Manual OTLP trace export (avoids Lambda Layer conflicts)
- CloudWatch log collection via OTel Collector
- OTTL-based trace_id/span_id extraction as separate log attributes
- Complete trace-log correlation in observability platform

## Open-source ready
- No hardcoded credentials or endpoints
- Generic placeholders for all configuration
- Follows repository conventions (OTEL_RESOURCE_ATTRIBUTES pattern)
- Includes .gitignore and .env.example
- Customer-friendly documentation

## Testing
Successfully tested with:
- Lambda function sending traces to OTLP endpoint
- CloudWatch logs containing trace_id/span_id
- OTel Collector extracting trace IDs as string attributes
- Full correlation verified in observability platform