### PR TITLE
Add iOS OpenTelemetry example

### DIFF
--- a/ios/.env.example
+++ b/ios/.env.example
@@ -1,0 +1,5 @@
+# Last9 Client Monitoring credentials
+# Create a client token at https://app.last9.io/control-plane/ingestion-tokens
+# Set allowed origin to: ios://com.yourcompany.yourapp (your bundle ID)
+LAST9_OTLP_ENDPOINT=<your-base-url>/v1/otlp/organizations/<your-org-slug>/telemetry/client_monitoring
+LAST9_CLIENT_TOKEN=<your-client-token>

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,0 +1,28 @@
+# Environment/secrets
+.env
+.env.local
+
+# Xcode
+*.xcodeproj/xcuserdata/
+*.xcworkspace/xcuserdata/
+DerivedData/
+*.xccheckout
+*.moved-aside
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# Swift Package Manager
+.build/
+.swiftpm/
+Packages/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "Last9OTelExample",
+    platforms: [.iOS(.v13)],
+    dependencies: [
+        .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.3.0"),
+        .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", from: "2.3.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "Last9OTelExample",
+            dependencies: [
+                .product(name: "OpenTelemetryApi", package: "opentelemetry-swift-core"),
+                .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core"),
+                .product(name: "OpenTelemetryProtocolExporterHTTP", package: "opentelemetry-swift"),
+                .product(name: "URLSessionInstrumentation", package: "opentelemetry-swift"),
+                .product(name: "ResourceExtension", package: "opentelemetry-swift"),
+                .product(name: "NetworkStatus", package: "opentelemetry-swift"),
+            ],
+            path: "Sources"
+        )
+    ]
+)

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,143 @@
+# iOS OpenTelemetry - Last9 Integration
+
+Send distributed traces from an iOS app to Last9 using OpenTelemetry Swift SDK. Auto-instruments all URLSession network calls and injects W3C `traceparent` for backend correlation.
+
+Uses **client monitoring tokens** (write-only, safe for mobile apps) with synthetic origins (`ios://com.yourcompany.yourapp`).
+
+## Prerequisites
+
+- Xcode 15+ / Swift 5.9+
+- iOS 13+ deployment target
+- A Last9 client monitoring token from [Ingestion Tokens](https://app.last9.io/control-plane/ingestion-tokens)
+
+## Quick Start
+
+### 1. Add SPM Dependencies
+
+In Xcode: **File → Add Package Dependencies**, add these two packages:
+
+```
+https://github.com/open-telemetry/opentelemetry-swift-core.git  (from: 2.3.0)
+https://github.com/open-telemetry/opentelemetry-swift.git       (from: 2.3.0)
+```
+
+Select these products for your target:
+
+| Package | Product |
+|---------|---------|
+| opentelemetry-swift-core | `OpenTelemetryApi`, `OpenTelemetrySdk` |
+| opentelemetry-swift | `OpenTelemetryProtocolExporterHTTP`, `URLSessionInstrumentation`, `ResourceExtension`, `NetworkStatus` |
+
+### 2. Create a Client Monitoring Token
+
+1. Go to [Ingestion Tokens](https://app.last9.io/control-plane/ingestion-tokens)
+2. Click **Create New Token** → select **Client**
+3. Set allowed origin to `ios://com.yourcompany.yourapp` (your app's bundle ID)
+4. Copy the token and the endpoint URL
+
+### 3. Copy `Last9OTel.swift` into your project
+
+Copy `Sources/Last9OTel.swift` into your Xcode project.
+
+### 4. Initialize in AppDelegate
+
+```swift
+func application(_ application: UIApplication,
+                 didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+    Last9OTel.initialize(
+        endpoint: "<your-base-url>/v1/otlp/organizations/<your-org-slug>/telemetry/client_monitoring",
+        clientToken: "<your-client-token>",
+        serviceName: "my-ios-app"
+    )
+
+    return true
+}
+```
+
+Or for SwiftUI:
+
+```swift
+@main
+struct YourApp: App {
+    init() {
+        Last9OTel.initialize(
+            endpoint: "<your-base-url>/v1/otlp/organizations/<your-org-slug>/telemetry/client_monitoring",
+            clientToken: "<your-client-token>",
+            serviceName: "my-ios-app"
+        )
+    }
+    var body: some Scene {
+        WindowGroup { ContentView() }
+    }
+}
+```
+
+### 5. That's it — network calls are auto-traced
+
+Every `URLSession` request is now automatically traced with:
+- HTTP method, URL, status code, latency
+- W3C `traceparent` header injected (links to backend traces)
+- Device model, OS version, app version attached
+
+## Configuration
+
+| Environment Variable | Description |
+|---------------------|-------------|
+| `LAST9_OTLP_ENDPOINT` | Last9 client monitoring endpoint |
+| `LAST9_CLIENT_TOKEN` | Client token from [Ingestion Tokens](https://app.last9.io/control-plane/ingestion-tokens) |
+
+## What's Auto-Instrumented
+
+| Signal | Details |
+|--------|---------|
+| URLSession requests | Every `dataTask`, `data(from:)`, `download` call — latency, status, URL |
+| W3C trace propagation | `traceparent` + `tracestate` headers injected into outgoing requests |
+| Resource attributes | `device.model.identifier`, `os.name`, `os.version`, `service.version` |
+| Network type | WiFi vs Cellular (iOS only) |
+
+## Custom Spans
+
+Track business-specific events:
+
+```swift
+let tracer = Last9OTel.tracer("auth")
+let span = tracer.spanBuilder(spanName: "user.login")
+    .setAttribute(key: "auth.method", value: "otp")
+    .startSpan()
+
+// ... your logic ...
+
+span.setAttribute(key: "auth.success", value: true)
+span.end()
+```
+
+See `Sources/ExampleUsage.swift` for more patterns (screen tracking, video playback, error handling).
+
+## Verification
+
+1. Run the app and trigger a network request
+2. Open [Last9 Traces](https://app.last9.io) and search for your service name
+3. You should see HTTP spans with `url.full`, `http.response.status_code`, `http.request.method`
+
+## Security
+
+This integration uses **client monitoring tokens** which are:
+- **Write-only** — can send telemetry, cannot read or query data
+- **Origin-scoped** — tied to your app's bundle ID (`ios://com.yourcompany.yourapp`)
+- **Rate-limited** — server-side rate limiting prevents abuse
+
+The token is safe to ship in your app binary.
+
+## Project Structure
+
+```
+ios/
+├── Package.swift              # SPM dependencies
+├── Sources/
+│   ├── Last9OTel.swift        # Core setup — copy this to your project
+│   ├── AppDelegate.swift      # Example initialization
+│   └── ExampleUsage.swift     # Custom span patterns
+├── .env.example               # Credential template
+└── README.md
+```

--- a/ios/Sources/AppDelegate.swift
+++ b/ios/Sources/AppDelegate.swift
@@ -1,0 +1,40 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+
+        // Initialize Last9 OpenTelemetry.
+        //
+        // After this call:
+        //   - Every URLSession request is auto-traced (latency, status, URL)
+        //   - W3C traceparent is auto-injected (links to backend traces)
+        //   - Device, OS, app version are auto-attached to every span
+        //
+        // Uses a client monitoring token (write-only, safe for mobile apps).
+        // Create the token at https://app.last9.io/control-plane/ingestion-tokens
+        // with allowed origin: ios://com.yourcompany.yourapp
+        Last9OTel.initialize(
+            endpoint: ProcessInfo.processInfo.environment["LAST9_OTLP_ENDPOINT"]
+                ?? "<your-base-url>/v1/otlp/organizations/<your-org-slug>/telemetry/client_monitoring",
+            clientToken: ProcessInfo.processInfo.environment["LAST9_CLIENT_TOKEN"]
+                ?? "<your-client-token>",
+            serviceName: "my-ios-app",
+            environment: "staging"
+        )
+
+        return true
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        Last9OTel.shared?.flush()
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        Last9OTel.shared?.shutdown()
+    }
+}

--- a/ios/Sources/AppDelegate.swift
+++ b/ios/Sources/AppDelegate.swift
@@ -10,14 +10,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Initialize Last9 OpenTelemetry.
         //
-        // After this call:
-        //   - Every URLSession request is auto-traced (latency, status, URL)
-        //   - W3C traceparent is auto-injected (links to backend traces)
-        //   - Device, OS, app version are auto-attached to every span
-        //
-        // Uses a client monitoring token (write-only, safe for mobile apps).
-        // Create the token at https://app.last9.io/control-plane/ingestion-tokens
-        // with allowed origin: ios://com.yourcompany.yourapp
+        // After this call, automatically:
+        //   - Every URLSession request is traced (latency, status, URL)
+        //   - W3C traceparent is injected (links to backend traces)
+        //   - Device, OS, app version attached per OTel semantic conventions
+        //   - App lifecycle events emitted (active, inactive, background, foreground, terminate)
+        //   - NSException crashes captured with stack traces
+        //   - Flush on background + shutdown on terminate handled automatically
         Last9OTel.initialize(
             endpoint: ProcessInfo.processInfo.environment["LAST9_OTLP_ENDPOINT"]
                 ?? "<your-base-url>/v1/otlp/organizations/<your-org-slug>/telemetry/client_monitoring",
@@ -30,11 +29,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        Last9OTel.shared?.flush()
-    }
-
-    func applicationWillTerminate(_ application: UIApplication) {
-        Last9OTel.shared?.shutdown()
-    }
+    // No need for applicationDidEnterBackground / applicationWillTerminate —
+    // Last9OTel handles lifecycle automatically via NotificationCenter observers.
 }

--- a/ios/Sources/ExampleUsage.swift
+++ b/ios/Sources/ExampleUsage.swift
@@ -1,0 +1,90 @@
+import Foundation
+import OpenTelemetryApi
+
+// MARK: - Example 1: Network calls are automatic
+
+/// Every URLSession call is auto-traced. No code changes needed.
+/// The span captures: HTTP method, URL, status code, latency.
+/// W3C traceparent is injected so backend traces link to this request.
+func fetchContent(id: String) async throws -> Data {
+    let url = URL(string: "https://api.example.com/v1/content/\(id)")!
+    let (data, _) = try await URLSession.shared.data(from: url)
+    return data
+    // That's it — this request is already traced in Last9.
+}
+
+// MARK: - Example 2: Custom span for business logic
+
+/// Track a login flow as a single span with attributes.
+func handleLogin(phone: String, otp: String) async throws {
+    let tracer = Last9OTel.tracer("auth")
+    let span = tracer.spanBuilder(spanName: "user.login")
+        .setAttribute(key: "auth.method", value: "otp")
+        .startSpan()
+
+    defer { span.end() }
+
+    do {
+        let url = URL(string: "https://api.example.com/v1/auth/verify-otp")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = try JSONEncoder().encode(["phone": phone, "otp": otp])
+        let (_, response) = try await URLSession.shared.data(for: request)
+
+        let httpResponse = response as! HTTPURLResponse
+        span.setAttribute(key: "auth.success", value: httpResponse.statusCode == 200)
+        span.setAttribute(key: "http.status_code", value: httpResponse.statusCode)
+    } catch {
+        span.setAttribute(key: "auth.success", value: false)
+        span.addEvent(name: "exception", attributes: [
+            "exception.message": .string(error.localizedDescription)
+        ])
+        throw error
+    }
+}
+
+// MARK: - Example 3: Track screen views (UIKit)
+
+import UIKit
+
+class HomeViewController: UIViewController {
+    private var screenSpan: Span?
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        let tracer = Last9OTel.tracer("navigation")
+        screenSpan = tracer.spanBuilder(spanName: "screen.view")
+            .setAttribute(key: "screen.name", value: "HomeScreen")
+            .setAttribute(key: "screen.class", value: String(describing: type(of: self)))
+            .startSpan()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        screenSpan?.end()
+        screenSpan = nil
+    }
+}
+
+// MARK: - Example 4: Track video playback events
+
+func trackPlaybackStart(contentId: String, contentTitle: String) {
+    let tracer = Last9OTel.tracer("player")
+    let span = tracer.spanBuilder(spanName: "playback.start")
+        .setAttribute(key: "content.id", value: contentId)
+        .setAttribute(key: "content.title", value: contentTitle)
+        .setAttribute(key: "player.type", value: "avplayer")
+        .startSpan()
+    span.end()
+}
+
+func trackPlaybackError(contentId: String, error: Error, bufferDuration: Double) {
+    let tracer = Last9OTel.tracer("player")
+    let span = tracer.spanBuilder(spanName: "playback.error")
+        .setAttribute(key: "content.id", value: contentId)
+        .setAttribute(key: "error.message", value: error.localizedDescription)
+        .setAttribute(key: "player.buffer_duration_ms", value: Int(bufferDuration * 1000))
+        .startSpan()
+    span.setStatus(.error(description: error.localizedDescription))
+    span.end()
+}

--- a/ios/Sources/Last9OTel.swift
+++ b/ios/Sources/Last9OTel.swift
@@ -5,28 +5,29 @@ import OpenTelemetryProtocolExporterHttp
 import URLSessionInstrumentation
 import ResourceExtension
 
+#if canImport(UIKit)
+import UIKit
+#endif
+
 /// Last9 OpenTelemetry setup for iOS.
 ///
 /// Uses the client monitoring token flow (same as Browser RUM SDK) with a
 /// synthetic origin (`ios://com.your.bundleid`). Auto-instruments URLSession
 /// and injects W3C traceparent for backend correlation.
+///
+/// Resource attributes follow OTel semantic conventions:
+/// - service.*, device.*, os.*, app.*, telemetry.sdk.*, host.*
 final class Last9OTel {
     static var shared: Last9OTel?
 
     private let tracerProvider: TracerProviderSdk
+    private let loggerProvider: LoggerProviderSdk?
     private let urlSessionInstrumentation: URLSessionInstrumentation
+    private var lifecycleLogger: Logger?
 
     // MARK: - Initialization
 
     /// Call once in `application(_:didFinishLaunchingWithOptions:)` or SwiftUI `App.init()`.
-    ///
-    /// ```swift
-    /// Last9OTel.initialize(
-    ///     endpoint: "<your-base-url>/v1/otlp/organizations/<your-org-slug>/telemetry/client_monitoring",
-    ///     clientToken: "<your-client-token>",
-    ///     serviceName: "my-ios-app"
-    /// )
-    /// ```
     @discardableResult
     static func initialize(
         endpoint: String,
@@ -41,6 +42,7 @@ final class Last9OTel {
             environment: environment
         )
         shared = instance
+        instance.startLifecycleObserver()
         return instance
     }
 
@@ -50,25 +52,15 @@ final class Last9OTel {
         serviceName: String,
         environment: String
     ) {
-        // 1. Resource — auto-detected device/OS + custom service attributes
-        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
-        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
         let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
 
-        var resource = DefaultResources().get()
-        resource.merge(other: Resource(attributes: [
-            "service.name": .string(serviceName),
-            "service.version": .string("\(appVersion)+\(buildNumber)"),
-            "deployment.environment": .string(environment),
-            "service.namespace": .string("mobile"),
-        ]))
+        // 1. Resource — OTel semantic conventions for mobile
+        let resource = Self.buildResource(serviceName: serviceName, environment: environment)
 
         // 2. Synthetic origin — ios://com.your.bundleid
-        //    Register this value as the allowed origin when creating the
-        //    client monitoring token in the Last9 dashboard.
         let origin = "ios://\(bundleId)"
 
-        // 3. Device ID for client identification (stable per vendor, resets on uninstall)
+        // 3. Device ID for client identification
         let clientId: String
         #if canImport(UIKit)
         clientId = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
@@ -87,13 +79,12 @@ final class Last9OTel {
             ]
         )
 
+        // 5. Trace exporter + processor
         let traceExporter = OtlpHttpTraceExporter(
             endpoint: URL(string: "\(endpoint)/v1/traces")!,
             config: otlpConfig,
             envVarHeaders: nil
         )
-
-        // 5. Batch span processor (flushes every 5s, max 512 spans per batch)
         let spanProcessor = BatchSpanProcessor(
             spanExporter: traceExporter,
             scheduleDelay: 5,
@@ -101,17 +92,33 @@ final class Last9OTel {
             maxExportBatchSize: 512
         )
 
-        // 6. Register tracer provider globally
+        // 6. Register tracer provider
         self.tracerProvider = TracerProviderBuilder()
             .with(resource: resource)
             .add(spanProcessor: spanProcessor)
             .build()
         OpenTelemetry.registerTracerProvider(tracerProvider: self.tracerProvider)
 
-        // 7. URLSession auto-instrumentation
-        //    - ALL URLSession calls are traced automatically (method swizzling)
-        //    - W3C traceparent header injected into every outgoing request
-        //    - Captures: HTTP method, URL, status code, latency
+        // 7. Log exporter for lifecycle events + crash reporting
+        let logExporter = OtlpHttpLogExporter(
+            endpoint: URL(string: "\(endpoint)/v1/logs")!,
+            config: otlpConfig,
+            envVarHeaders: nil
+        )
+        let logProcessor = BatchLogRecordProcessor(
+            logRecordExporter: logExporter,
+            scheduleDelay: 5,
+            maxQueueSize: 2048,
+            maxExportBatchSize: 512
+        )
+        self.loggerProvider = LoggerProviderBuilder()
+            .with(resource: resource)
+            .with(processors: [logProcessor])
+            .build()
+        OpenTelemetry.registerLoggerProvider(loggerProvider: self.loggerProvider!)
+        self.lifecycleLogger = OpenTelemetry.instance.loggerProvider.loggerBuilder(instrumentationScopeName: "device").build()
+
+        // 8. URLSession auto-instrumentation
         self.urlSessionInstrumentation = URLSessionInstrumentation(
             configuration: URLSessionInstrumentationConfiguration(
                 shouldInstrument: { request in
@@ -122,19 +129,185 @@ final class Last9OTel {
             )
         )
 
+        // 9. Install crash handler
+        Self.installCrashHandler()
+
         print("[Last9] OTel initialized — \(serviceName) (\(environment)) origin=\(origin)")
+    }
+
+    // MARK: - Resource Builder
+
+    /// Builds a Resource with all OTel semantic convention attributes for mobile.
+    private static func buildResource(serviceName: String, environment: String) -> Resource {
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+
+        // Start with auto-detected attributes (telemetry.sdk.*, os.type, device.model.identifier)
+        var resource = DefaultResources().get()
+
+        // service.*
+        var attrs: [String: AttributeValue] = [
+            "service.name": .string(serviceName),
+            "service.version": .string("\(appVersion)+\(buildNumber)"),
+            "deployment.environment": .string(environment),
+            "service.namespace": .string("mobile"),
+        ]
+
+        // device.*
+        attrs["device.manufacturer"] = .string("Apple")
+        attrs["device.model.identifier"] = .string(Self.machineIdentifier())
+        attrs["device.model.name"] = .string(Self.deviceModelName())
+
+        // os.*
+        #if canImport(UIKit)
+        let device = UIDevice.current
+        attrs["os.name"] = .string(device.systemName)
+        attrs["os.version"] = .string(device.systemVersion)
+        #endif
+        attrs["os.type"] = .string("darwin")
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+        attrs["os.build_id"] = .string("\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)")
+
+        // app.*
+        attrs["app.build_id"] = .string(buildNumber)
+        #if canImport(UIKit)
+        attrs["app.installation.id"] = .string(
+            UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
+        )
+        #endif
+
+        // host.*
+        #if arch(arm64)
+        attrs["host.arch"] = .string("arm64")
+        #elseif arch(x86_64)
+        attrs["host.arch"] = .string("x86_64")
+        #endif
+
+        resource.merge(other: Resource(attributes: attrs))
+        return resource
+    }
+
+    // MARK: - Device Model Mapping
+
+    /// Returns the raw machine identifier (e.g. "iPhone15,2").
+    private static func machineIdentifier() -> String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        return withUnsafePointer(to: &systemInfo.machine) {
+            $0.withMemoryRebound(to: CChar.self, capacity: 1) {
+                String(validatingUTF8: $0) ?? "unknown"
+            }
+        }
+    }
+
+    /// Maps machine identifier to human-readable model name.
+    private static func deviceModelName() -> String {
+        let id = machineIdentifier()
+        #if targetEnvironment(simulator)
+        return "Simulator"
+        #else
+        let models: [String: String] = [
+            // iPhone 13
+            "iPhone14,4": "iPhone 13 mini", "iPhone14,5": "iPhone 13",
+            "iPhone14,2": "iPhone 13 Pro", "iPhone14,3": "iPhone 13 Pro Max",
+            // iPhone 14
+            "iPhone14,7": "iPhone 14", "iPhone14,8": "iPhone 14 Plus",
+            "iPhone15,2": "iPhone 14 Pro", "iPhone15,3": "iPhone 14 Pro Max",
+            // iPhone 15
+            "iPhone15,4": "iPhone 15", "iPhone15,5": "iPhone 15 Plus",
+            "iPhone16,1": "iPhone 15 Pro", "iPhone16,2": "iPhone 15 Pro Max",
+            // iPhone 16
+            "iPhone17,1": "iPhone 16 Pro", "iPhone17,2": "iPhone 16 Pro Max",
+            "iPhone17,3": "iPhone 16", "iPhone17,4": "iPhone 16 Plus",
+            // iPad
+            "iPad13,18": "iPad 10th gen", "iPad13,19": "iPad 10th gen",
+            "iPad14,3": "iPad Pro 11-inch 4th gen", "iPad14,4": "iPad Pro 11-inch 4th gen",
+            "iPad14,5": "iPad Pro 12.9-inch 6th gen", "iPad14,6": "iPad Pro 12.9-inch 6th gen",
+            // Apple TV
+            "AppleTV11,1": "Apple TV 4K 2nd gen", "AppleTV14,1": "Apple TV 4K 3rd gen",
+        ]
+        return models[id] ?? id
+        #endif
+    }
+
+    // MARK: - App Lifecycle Events (OTel semantic convention: device.app.lifecycle)
+
+    private func startLifecycleObserver() {
+        #if canImport(UIKit)
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+        nc.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
+        nc.addObserver(self, selector: #selector(appDidEnterBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        nc.addObserver(self, selector: #selector(appWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
+        nc.addObserver(self, selector: #selector(appWillTerminate), name: UIApplication.willTerminateNotification, object: nil)
+        #endif
+    }
+
+    #if canImport(UIKit)
+    @objc private func appDidBecomeActive() { emitLifecycleEvent(state: "active") }
+    @objc private func appWillResignActive() { emitLifecycleEvent(state: "inactive") }
+    @objc private func appDidEnterBackground() {
+        emitLifecycleEvent(state: "background")
+        flush()
+    }
+    @objc private func appWillEnterForeground() { emitLifecycleEvent(state: "foreground") }
+    @objc private func appWillTerminate() {
+        emitLifecycleEvent(state: "terminate")
+        shutdown()
+    }
+    #endif
+
+    /// Emits a `device.app.lifecycle` log event per OTel semantic conventions.
+    private func emitLifecycleEvent(state: String) {
+        lifecycleLogger?.logRecordBuilder()
+            .setBody(.string("device.app.lifecycle"))
+            .setSeverity(.info)
+            .setAttributes([
+                "event.name": .string("device.app.lifecycle"),
+                "ios.app.state": .string(state),
+            ])
+            .emit()
+    }
+
+    // MARK: - Crash Handler (exception events with FATAL severity)
+
+    private static func installCrashHandler() {
+        NSSetUncaughtExceptionHandler { exception in
+            let logger = OpenTelemetry.instance.loggerProvider
+                .loggerBuilder(instrumentationScopeName: "crash")
+                .build()
+
+            logger.logRecordBuilder()
+                .setBody(.string("exception"))
+                .setSeverity(.fatal)
+                .setAttributes([
+                    "event.name": .string("exception"),
+                    "exception.type": .string(exception.name.rawValue),
+                    "exception.message": .string(exception.reason ?? ""),
+                    "exception.stacktrace": .string(exception.callStackSymbols.joined(separator: "\n")),
+                ])
+                .emit()
+
+            // Force flush before crash terminates the process
+            Last9OTel.shared?.tracerProvider.forceFlush()
+            Last9OTel.shared?.loggerProvider?.forceFlush()
+            // Give the exporter time to send
+            Thread.sleep(forTimeInterval: 2)
+        }
     }
 
     // MARK: - Lifecycle
 
-    /// Flush pending spans. Call in `applicationDidEnterBackground`.
+    /// Flush pending spans and logs. Call in `applicationDidEnterBackground`.
     func flush() {
         tracerProvider.forceFlush()
+        loggerProvider?.forceFlush()
     }
 
-    /// Shutdown. Call in `applicationWillTerminate`.
+    /// Shutdown all providers. Call in `applicationWillTerminate`.
     func shutdown() {
         tracerProvider.shutdown()
+        loggerProvider?.shutdown()
     }
 
     // MARK: - Convenience

--- a/ios/Sources/Last9OTel.swift
+++ b/ios/Sources/Last9OTel.swift
@@ -1,0 +1,149 @@
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import OpenTelemetryProtocolExporterHttp
+import URLSessionInstrumentation
+import ResourceExtension
+
+/// Last9 OpenTelemetry setup for iOS.
+///
+/// Uses the client monitoring token flow (same as Browser RUM SDK) with a
+/// synthetic origin (`ios://com.your.bundleid`). Auto-instruments URLSession
+/// and injects W3C traceparent for backend correlation.
+final class Last9OTel {
+    static var shared: Last9OTel?
+
+    private let tracerProvider: TracerProviderSdk
+    private let urlSessionInstrumentation: URLSessionInstrumentation
+
+    // MARK: - Initialization
+
+    /// Call once in `application(_:didFinishLaunchingWithOptions:)` or SwiftUI `App.init()`.
+    ///
+    /// ```swift
+    /// Last9OTel.initialize(
+    ///     endpoint: "<your-base-url>/v1/otlp/organizations/<your-org-slug>/telemetry/client_monitoring",
+    ///     clientToken: "<your-client-token>",
+    ///     serviceName: "my-ios-app"
+    /// )
+    /// ```
+    @discardableResult
+    static func initialize(
+        endpoint: String,
+        clientToken: String,
+        serviceName: String,
+        environment: String = "production"
+    ) -> Last9OTel {
+        let instance = Last9OTel(
+            endpoint: endpoint,
+            clientToken: clientToken,
+            serviceName: serviceName,
+            environment: environment
+        )
+        shared = instance
+        return instance
+    }
+
+    private init(
+        endpoint: String,
+        clientToken: String,
+        serviceName: String,
+        environment: String
+    ) {
+        // 1. Resource — auto-detected device/OS + custom service attributes
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+        let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
+
+        var resource = DefaultResources().get()
+        resource.merge(other: Resource(attributes: [
+            "service.name": .string(serviceName),
+            "service.version": .string("\(appVersion)+\(buildNumber)"),
+            "deployment.environment": .string(environment),
+            "service.namespace": .string("mobile"),
+        ]))
+
+        // 2. Synthetic origin — ios://com.your.bundleid
+        //    Register this value as the allowed origin when creating the
+        //    client monitoring token in the Last9 dashboard.
+        let origin = "ios://\(bundleId)"
+
+        // 3. Device ID for client identification (stable per vendor, resets on uninstall)
+        let clientId: String
+        #if canImport(UIKit)
+        clientId = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
+        #else
+        clientId = UUID().uuidString
+        #endif
+
+        // 4. OTLP HTTP exporter → Last9 client monitoring endpoint
+        let otlpConfig = OtlpConfiguration(
+            timeout: 30,
+            compression: .gzip,
+            headers: [
+                ("X-LAST9-API-TOKEN", "Bearer \(clientToken)"),
+                ("X-LAST9-ORIGIN", origin),
+                ("Client-ID", clientId),
+            ]
+        )
+
+        let traceExporter = OtlpHttpTraceExporter(
+            endpoint: URL(string: "\(endpoint)/v1/traces")!,
+            config: otlpConfig,
+            envVarHeaders: nil
+        )
+
+        // 5. Batch span processor (flushes every 5s, max 512 spans per batch)
+        let spanProcessor = BatchSpanProcessor(
+            spanExporter: traceExporter,
+            scheduleDelay: 5,
+            maxQueueSize: 2048,
+            maxExportBatchSize: 512
+        )
+
+        // 6. Register tracer provider globally
+        self.tracerProvider = TracerProviderBuilder()
+            .with(resource: resource)
+            .add(spanProcessor: spanProcessor)
+            .build()
+        OpenTelemetry.registerTracerProvider(tracerProvider: self.tracerProvider)
+
+        // 7. URLSession auto-instrumentation
+        //    - ALL URLSession calls are traced automatically (method swizzling)
+        //    - W3C traceparent header injected into every outgoing request
+        //    - Captures: HTTP method, URL, status code, latency
+        self.urlSessionInstrumentation = URLSessionInstrumentation(
+            configuration: URLSessionInstrumentationConfiguration(
+                shouldInstrument: { request in
+                    guard let host = request.url?.host else { return true }
+                    return !host.contains("last9.io")
+                },
+                semanticConvention: .stable
+            )
+        )
+
+        print("[Last9] OTel initialized — \(serviceName) (\(environment)) origin=\(origin)")
+    }
+
+    // MARK: - Lifecycle
+
+    /// Flush pending spans. Call in `applicationDidEnterBackground`.
+    func flush() {
+        tracerProvider.forceFlush()
+    }
+
+    /// Shutdown. Call in `applicationWillTerminate`.
+    func shutdown() {
+        tracerProvider.shutdown()
+    }
+
+    // MARK: - Convenience
+
+    /// Get a tracer for custom spans.
+    static func tracer(_ name: String = "app") -> Tracer {
+        OpenTelemetry.instance.tracerProvider.get(
+            instrumentationName: name,
+            instrumentationVersion: nil
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ios/` directory with a complete iOS OpenTelemetry integration example
- Uses **client monitoring tokens** with synthetic origins (`ios://com.yourcompany.yourapp`) — same auth flow as the Browser RUM SDK
- `Last9OTel.swift` is a drop-in setup file: auto-instruments URLSession, injects W3C traceparent, attaches device/OS/app version
- Includes examples for custom spans, screen tracking, and video playback events

## Files

| File | Purpose |
|------|---------|
| `ios/Package.swift` | SPM dependencies (opentelemetry-swift-core + opentelemetry-swift) |
| `ios/Sources/Last9OTel.swift` | Core setup — copy to any project |
| `ios/Sources/AppDelegate.swift` | Init example (UIKit) |
| `ios/Sources/ExampleUsage.swift` | Custom span patterns |
| `ios/.env.example` | Credential template |
| `ios/.gitignore` | Xcode/SPM ignores |
| `ios/README.md` | Quick start guide |

## Test plan

- [x] Verify SPM dependencies resolve (`swift package resolve`)
- [x] Copy `Last9OTel.swift` into a test iOS project and confirm compilation
- [x] Create a client monitoring token with origin `ios://com.example.testapp` and verify traces arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)