### PR TITLE
feat: Python Lambda + DynamoDB OTel example with Chalice

### DIFF
--- a/aws/lambda-python/dynamodb/.chalice/collector-config.yaml
+++ b/aws/lambda-python/dynamodb/.chalice/collector-config.yaml
@@ -1,0 +1,19 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: localhost:4318
+
+exporters:
+  otlp:
+    endpoint: <YOUR_OTLP_ENDPOINT>:443
+    headers:
+      authorization: Basic <your-base64-credentials>
+    tls:
+      insecure: false
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp]

--- a/aws/lambda-python/dynamodb/.chalice/config.json
+++ b/aws/lambda-python/dynamodb/.chalice/config.json
@@ -1,0 +1,49 @@
+{
+  "version": "2.0",
+  "app_name": "lambda-dynamodb-otel",
+  "stages": {
+    "dev": {
+      "api_gateway_stage": "dev",
+      "lambda_timeout": 30,
+      "lambda_memory_size": 256,
+      "xray": true,
+      "layers": [
+        "arn:aws:lambda:ap-south-1:901920570463:layer:aws-otel-python-amd64-ver-1-25-0:1"
+      ],
+      "environment_variables": {
+        "AWS_LAMBDA_EXEC_WRAPPER": "/opt/otel-instrument",
+        "OPENTELEMETRY_COLLECTOR_CONFIG_FILE": "/var/task/.chalice/collector-config.yaml",
+        "OTEL_SERVICE_NAME": "lambda-dynamodb-otel",
+        "OTEL_PROPAGATORS": "tracecontext,xray",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+        "OTEL_TRACES_EXPORTER": "otlp",
+        "OTEL_TRACES_SAMPLER": "always_on",
+        "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=dev",
+        "DYNAMODB_TABLE": "items"
+      },
+      "iam_policy_file": "dev-policy.json"
+    },
+    "prod": {
+      "api_gateway_stage": "prod",
+      "lambda_timeout": 30,
+      "lambda_memory_size": 512,
+      "xray": true,
+      "layers": [
+        "arn:aws:lambda:ap-south-1:901920570463:layer:aws-otel-python-amd64-ver-1-25-0:1"
+      ],
+      "environment_variables": {
+        "AWS_LAMBDA_EXEC_WRAPPER": "/opt/otel-instrument",
+        "OPENTELEMETRY_COLLECTOR_CONFIG_FILE": "/var/task/.chalice/collector-config.yaml",
+        "OTEL_SERVICE_NAME": "lambda-dynamodb-otel",
+        "OTEL_PROPAGATORS": "tracecontext,xray",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+        "OTEL_TRACES_EXPORTER": "otlp",
+        "OTEL_TRACES_SAMPLER": "traceidratio",
+        "OTEL_TRACES_SAMPLER_ARG": "0.1",
+        "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=prod",
+        "DYNAMODB_TABLE": "items"
+      },
+      "iam_policy_file": "prod-policy.json"
+    }
+  }
+}

--- a/aws/lambda-python/dynamodb/.chalice/dev-policy.json
+++ b/aws/lambda-python/dynamodb/.chalice/dev-policy.json
@@ -1,0 +1,24 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:DeleteItem",
+        "dynamodb:Scan",
+        "dynamodb:Query"
+      ],
+      "Resource": "arn:aws:dynamodb:*:*:table/items"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "xray:PutTraceSegments",
+        "xray:PutTelemetryRecords"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/aws/lambda-python/dynamodb/.chalice/prod-policy.json
+++ b/aws/lambda-python/dynamodb/.chalice/prod-policy.json
@@ -1,0 +1,24 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:DeleteItem",
+        "dynamodb:Scan",
+        "dynamodb:Query"
+      ],
+      "Resource": "arn:aws:dynamodb:*:*:table/items"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "xray:PutTraceSegments",
+        "xray:PutTelemetryRecords"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/aws/lambda-python/dynamodb/.env.example
+++ b/aws/lambda-python/dynamodb/.env.example
@@ -1,0 +1,15 @@
+# AWS Configuration
+AWS_REGION=ap-south-1
+AWS_PROFILE=default
+
+# Last9 OTLP Credentials
+# Get these from https://app.last9.io/integrations?integration=OpenTelemetry
+OTLP_ENDPOINT=otlp.last9.io
+OTLP_AUTH_HEADER=Basic <your-base64-credentials>
+
+# Service Configuration
+OTEL_SERVICE_NAME=lambda-dynamodb-otel
+DEPLOY_STAGE=dev
+
+# DynamoDB
+DYNAMODB_TABLE=items

--- a/aws/lambda-python/dynamodb/.gitignore
+++ b/aws/lambda-python/dynamodb/.gitignore
@@ -1,0 +1,26 @@
+# Environment/secrets
+.env
+.env.local
+.env.*.local
+
+# Dependencies
+/.venv/
+__pycache__/
+*.pyc
+*.pyo
+
+# Chalice
+.chalice/deployments/
+.chalice/venv/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log

--- a/aws/lambda-python/dynamodb/README.md
+++ b/aws/lambda-python/dynamodb/README.md
@@ -1,0 +1,116 @@
+# Python Lambda + DynamoDB with OpenTelemetry - Last9 Integration
+
+A Chalice-based Lambda API that performs DynamoDB CRUD operations, fully traced via the AWS Distro for OpenTelemetry (ADOT) Python layer. No manual SDK setup — all DynamoDB spans are created automatically.
+
+## How It Works
+
+```
+HTTP Request
+  └── Chalice Lambda handler (ADOT creates root span)
+        └── DynamoDB.GetItem / PutItem / DeleteItem / Scan
+              (auto-instrumented by ADOT botocore layer)
+                    └── Last9 via OTLP
+```
+
+The `AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-instrument` env var activates ADOT's zero-code instrumentation. Every `boto3` call to DynamoDB becomes a child span with attributes like `db.system`, `aws.dynamodb.table_names`, and `rpc.method`.
+
+## Prerequisites
+
+- Python 3.11+
+- AWS CLI configured (`aws configure`)
+- Chalice: `pip install chalice`
+- Last9 account — get OTLP credentials from [Last9 Integrations](https://app.last9.io/integrations?integration=OpenTelemetry)
+
+## Quick Start
+
+### 1. Configure credentials
+
+```bash
+cp .env.example .env
+# Edit .env with your AWS region and Last9 OTLP credentials
+```
+
+Update `.chalice/collector-config.yaml`:
+```yaml
+exporters:
+  otlp:
+    endpoint: otlp.last9.io:443
+    headers:
+      authorization: Basic <your-base64-credentials>
+```
+
+### 2. Install dependencies
+
+```bash
+pip install chalice boto3
+```
+
+### 3. Deploy
+
+```bash
+chmod +x deploy.sh
+./deploy.sh
+```
+
+The script:
+- Creates the `items` DynamoDB table (PAY_PER_REQUEST billing)
+- Injects credentials into collector config
+- Deploys via `chalice deploy`
+
+### 4. Test the API
+
+```bash
+# Get the API URL from chalice deploy output, then:
+
+# List all items
+curl https://<api-id>.execute-api.<region>.amazonaws.com/dev/items
+
+# Create an item
+curl -X POST https://<api-id>.execute-api.<region>.amazonaws.com/dev/items \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Widget", "description": "A test item"}'
+
+# Get by ID
+curl https://<api-id>.execute-api.<region>.amazonaws.com/dev/items/<item-id>
+
+# Delete
+curl -X DELETE https://<api-id>.execute-api.<region>.amazonaws.com/dev/items/<item-id>
+```
+
+### 5. Verify traces in Last9
+
+1. Log in to [Last9](https://app.last9.io)
+2. Navigate to **Traces**
+3. Filter by service name `lambda-dynamodb-otel`
+4. Each request shows a root Lambda span with nested DynamoDB child spans
+
+## Configuration
+
+| Variable | Description | Example |
+|---|---|---|
+| `AWS_REGION` | AWS region | `ap-south-1` |
+| `OTLP_ENDPOINT` | Last9 OTLP host | `otlp.last9.io` |
+| `OTLP_AUTH_HEADER` | Last9 auth header | `Basic abc123==` |
+| `OTEL_SERVICE_NAME` | Service name in traces | `lambda-dynamodb-otel` |
+| `DEPLOY_STAGE` | Chalice stage | `dev` or `prod` |
+| `DYNAMODB_TABLE` | DynamoDB table name | `items` |
+
+## ADOT Layer ARNs
+
+Replace the layer ARN in `.chalice/config.json` for your region:
+
+| Region | Layer ARN |
+|---|---|
+| ap-south-1 | `arn:aws:lambda:ap-south-1:901920570463:layer:aws-otel-python-amd64-ver-1-25-0:1` |
+| us-east-1 | `arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-python-amd64-ver-1-25-0:1` |
+| us-west-2 | `arn:aws:lambda:us-west-2:901920570463:layer:aws-otel-python-amd64-ver-1-25-0:1` |
+| eu-west-1 | `arn:aws:lambda:eu-west-1:901920570463:layer:aws-otel-python-amd64-ver-1-25-0:1` |
+
+Find the latest version at [ADOT Lambda Layers](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python).
+
+## Teardown
+
+```bash
+chalice delete --stage dev
+aws dynamodb delete-table --table-name items --region ap-south-1
+```

--- a/aws/lambda-python/dynamodb/app.py
+++ b/aws/lambda-python/dynamodb/app.py
@@ -1,0 +1,76 @@
+import os
+import uuid
+
+import boto3
+from chalice import Chalice, NotFoundError, BadRequestError
+from opentelemetry import trace
+
+app = Chalice(app_name="lambda-dynamodb-otel")
+tracer = trace.get_tracer(__name__)
+
+TABLE_NAME = os.environ.get("DYNAMODB_TABLE", "items")
+AWS_REGION = os.environ.get("AWS_REGION", "ap-south-1")
+
+dynamodb = boto3.resource("dynamodb", region_name=AWS_REGION)
+table = dynamodb.Table(TABLE_NAME)
+
+
+@app.middleware("all")
+def otel_attributes(event, get_response):
+    """Enrich the ADOT-created span with app-level attributes."""
+    span = trace.get_current_span()
+    if span.is_recording():
+        span.set_attribute("app.framework", "chalice")
+        span.set_attribute("app.table", TABLE_NAME)
+    return get_response(event)
+
+
+@app.route("/items", methods=["GET"])
+def list_items():
+    """Scan the DynamoDB table — auto-instrumented by ADOT botocore layer."""
+    with tracer.start_as_current_span("list_items") as span:
+        result = table.scan()
+        items = result.get("Items", [])
+        span.set_attribute("dynamodb.items_returned", len(items))
+    return {"items": items, "count": len(items)}
+
+
+@app.route("/items/{item_id}", methods=["GET"])
+def get_item(item_id):
+    """Fetch a single item by ID — DynamoDB.GetItem span created automatically."""
+    with tracer.start_as_current_span("get_item") as span:
+        span.set_attribute("item.id", item_id)
+        result = table.get_item(Key={"id": item_id})
+        item = result.get("Item")
+        if not item:
+            raise NotFoundError(f"Item {item_id!r} not found")
+    return item
+
+
+@app.route("/items", methods=["POST"])
+def create_item():
+    """Create a new item — DynamoDB.PutItem span created automatically."""
+    body = app.current_request.json_body
+    if not body or "name" not in body:
+        raise BadRequestError("Request body must include 'name'")
+
+    item = {
+        "id": str(uuid.uuid4()),
+        "name": body["name"],
+        "description": body.get("description", ""),
+    }
+
+    with tracer.start_as_current_span("create_item") as span:
+        span.set_attribute("item.name", item["name"])
+        table.put_item(Item=item)
+
+    return item
+
+
+@app.route("/items/{item_id}", methods=["DELETE"])
+def delete_item(item_id):
+    """Delete an item — DynamoDB.DeleteItem span created automatically."""
+    with tracer.start_as_current_span("delete_item") as span:
+        span.set_attribute("item.id", item_id)
+        table.delete_item(Key={"id": item_id})
+    return {"deleted": item_id}

--- a/aws/lambda-python/dynamodb/deploy.sh
+++ b/aws/lambda-python/dynamodb/deploy.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+# Load environment variables
+if [ -f .env ]; then
+  export $(grep -v '^#' .env | xargs)
+fi
+
+STAGE=${DEPLOY_STAGE:-dev}
+TABLE=${DYNAMODB_TABLE:-items}
+REGION=${AWS_REGION:-ap-south-1}
+
+echo "==> Deploying stage: $STAGE"
+
+# 1. Create DynamoDB table if it doesn't exist
+echo "==> Ensuring DynamoDB table '$TABLE' exists..."
+aws dynamodb describe-table --table-name "$TABLE" --region "$REGION" > /dev/null 2>&1 || \
+aws dynamodb create-table \
+  --table-name "$TABLE" \
+  --attribute-definitions AttributeName=id,AttributeType=S \
+  --key-schema AttributeName=id,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --region "$REGION"
+echo "    Table ready."
+
+# 2. Inject Last9 credentials into collector config
+echo "==> Updating collector config..."
+sed \
+  -e "s|<YOUR_OTLP_ENDPOINT>|${OTLP_ENDPOINT}|g" \
+  -e "s|Basic <your-base64-credentials>|${OTLP_AUTH_HEADER}|g" \
+  .chalice/collector-config.yaml > /tmp/collector-config-resolved.yaml
+cp /tmp/collector-config-resolved.yaml .chalice/collector-config.yaml
+
+# 3. Deploy with Chalice
+echo "==> Running chalice deploy..."
+chalice deploy --stage "$STAGE"
+
+echo ""
+echo "Deployment complete. Traces will appear in Last9 within 1-2 minutes."

--- a/aws/lambda-python/dynamodb/requirements.txt
+++ b/aws/lambda-python/dynamodb/requirements.txt
@@ -1,0 +1,3 @@
+chalice>=1.31.0
+boto3>=1.34.0
+opentelemetry-api>=1.20.0


### PR DESCRIPTION
## Summary

- Adds a Chalice-based Python Lambda function with real DynamoDB CRUD operations (Scan, GetItem, PutItem, DeleteItem)
- Uses ADOT Python layer for zero-code OTel instrumentation — all DynamoDB spans created automatically via botocore
- Includes IAM policy files, ADOT collector config, and a `deploy.sh` that creates the DynamoDB table and deploys via Chalice

## Test plan

- [ ] `cp .env.example .env` and fill in AWS + Last9 credentials
- [ ] `./deploy.sh` — should create `items` table and deploy Lambda
- [ ] Call each endpoint (`GET /items`, `POST /items`, `GET /items/{id}`, `DELETE /items/{id}`)
- [ ] Verify traces appear in Last9 with root Lambda span and nested DynamoDB child spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)