### PR TITLE
feat: add UAT environment support to RDS PostgreSQL CloudFormation templates

### DIFF
--- a/aws/rds-postgresql-ecs/cloudformation/postgresql-collector.yaml
+++ b/aws/rds-postgresql-ecs/cloudformation/postgresql-collector.yaml
@@ -22,6 +22,7 @@ Parameters:
       - prod
       - staging
       - dev
+      - uat
     Default: dev
     Description: Deployment environment
 

--- a/aws/rds-postgresql-ecs/cloudformation/quick-setup.yaml
+++ b/aws/rds-postgresql-ecs/cloudformation/quick-setup.yaml
@@ -88,7 +88,7 @@ Parameters:
   Environment:
     Type: String
     Default: prod
-    AllowedValues: [prod, staging, dev]
+    AllowedValues: [prod, staging, dev, uat]
     Description: Environment name for tagging
 
   CreateMonitoringUser:


### PR DESCRIPTION
## Summary
- Add 'uat' as an allowed value for the Environment parameter in RDS PostgreSQL CloudFormation templates
- Fixes ValidationError when customers deploy with ENVIRONMENT=uat

## Changes
- `cloudformation/quick-setup.yaml`: Add 'uat' to Environment AllowedValues
- `cloudformation/postgresql-collector.yaml`: Add 'uat' to Environment AllowedValues

## Context
Customer reported ValidationError: "Parameter 'Environment' must be one of AllowedValues" when using ENVIRONMENT=uat in their configuration. The templates only allowed prod, staging, and dev.

## Test Plan
- [ ] Verify CloudFormation stack can be created with ENVIRONMENT=uat
- [ ] Verify existing environments (prod, staging, dev) still work
- [ ] Validate template syntax with `aws cloudformation validate-template`