### PR TITLE
fix: improve RDS PostgreSQL monitoring setup documentation

### DIFF
--- a/aws/rds-postgresql-ecs/.env.example
+++ b/aws/rds-postgresql-ecs/.env.example
@@ -24,5 +24,5 @@ RDS_INSTANCE_ID=<your-rds-instance-id>
 LAST9_OTLP_ENDPOINT=YOUR_LAST9_ENDPOINT
 LAST9_AUTH_HEADER=Basic <your-base64-encoded-credentials>
 
-# Environment (prod, staging, dev)
+# Environment name for tagging and labeling (use any value: prod, staging, dev, uat, Dev, PROD, etc.)
 ENVIRONMENT=dev

--- a/aws/rds-postgresql-ecs/.gitignore
+++ b/aws/rds-postgresql-ecs/.gitignore
@@ -47,6 +47,7 @@ target/
 tmp/
 temp/
 *.tmp
+*.bak
 
 # Test coverage
 coverage/

--- a/aws/rds-postgresql-ecs/Dockerfile.dbm
+++ b/aws/rds-postgresql-ecs/Dockerfile.dbm
@@ -7,7 +7,6 @@ WORKDIR /app
 
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libpq-dev \
     wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/aws/rds-postgresql-ecs/QUICK_SETUP.md
+++ b/aws/rds-postgresql-ecs/QUICK_SETUP.md
@@ -52,7 +52,7 @@ LAST9_OTLP_ENDPOINT=<your-endpoint>           # From Last9 dashboard
 LAST9_USERNAME=<your-username>                # From Last9 dashboard
 LAST9_PASSWORD=<your-password>                # From Last9 dashboard
 
-# Environment
+# Environment (any value: prod, dev, uat, staging, etc.)
 ENVIRONMENT=prod
 
 # Database user creation (RECOMMENDED: false for production)
@@ -63,72 +63,103 @@ PG_USERNAME=otel_monitor                       # Your monitoring username
 PG_PASSWORD=<your-monitoring-password>         # Your monitoring password
 ```
 
-**If `CREATE_MONITORING_USER=false`**, you must:
-1. **Manually create the monitoring user** in PostgreSQL first (see Database Setup section below)
-2. **Add `PG_USERNAME` and `PG_PASSWORD`** to your `.env` file
+**If `CREATE_MONITORING_USER=false` (RECOMMENDED)**, you must:
+1. **First complete Step 1.5 below** to create the monitoring user
+2. **Add `PG_USERNAME` and `PG_PASSWORD`** to your `.env` file (you'll do this in Step 1.5.3)
 
 **Save and close the file.**
 
+**⚠️  IMPORTANT: Before proceeding to Step 2, you MUST complete Step 1.5 below to create the database monitoring user!**
+
 ---
 
-## Step 1.5: Setup Database Monitoring (REQUIRED if CREATE_MONITORING_USER=false)
+## Step 1.5: Setup Database Monitoring (REQUIRED)
 
-**⚠️ IMPORTANT: This step is REQUIRED if you have multiple databases on your RDS instance!**
+**⚠️ CRITICAL: This step is REQUIRED for ALL databases on your RDS instance!**
 
 The monitoring setup must be run on **EACH** database you want to monitor. The setup creates monitoring views and functions that are database-specific.
 
-### Option A: Automated Setup (Recommended)
+### Step-by-Step Instructions
 
-Use the helper script to automatically set up all databases:
+**1.5.1: Generate and Set a Secure Password**
 
 ```bash
 cd scripts
-export PGPASSWORD='your-master-password'
+
+# Generate a secure password
+MONITOR_PASSWORD=$(openssl rand -base64 24)
+echo "Generated password: $MONITOR_PASSWORD"
+echo "⚠️  SAVE THIS PASSWORD - you'll need it for Step 1!"
+
+# Replace the placeholder in the SQL script
+sed -i.bak "s/<SECURE_PASSWORD>/$MONITOR_PASSWORD/g" setup-db-user.sql
+
+# Verify the replacement worked
+grep "CREATE USER otel_monitor" setup-db-user.sql
+# Should show: CREATE USER otel_monitor WITH PASSWORD 'your-actual-password';
+```
+
+**1.5.2: Run Setup on ALL Databases**
+
+**Option A: Automated Setup (Recommended - sets up ALL databases)**
+
+```bash
+# Set your PostgreSQL master password
+export PGPASSWORD='your-postgres-master-password'
+
+# Run setup WITHOUT -d flag to auto-detect all databases
 ./setup-all-databases.sh -h your-rds-endpoint.rds.amazonaws.com -U postgres
+
+# ⚠️  DO NOT use -d flag - it will limit setup to specific databases only!
 ```
 
-**What it does:**
-- Auto-detects all databases on your RDS instance
-- Creates `otel_monitor` user (once)
-- Sets up monitoring schema, views, and functions in each database
-- Shows progress with colored output
+**IMPORTANT:**
+- **DO NOT** add `-d postgres` or `-d database_name` - this limits the script to only those databases
+- The script will automatically discover all databases and run setup on each one
+- You should see "Total databases: X" where X matches your database count
 
-**Example output:**
+**Example output (correct):**
 ```
-[INFO] Found databases: app_db,analytics_db,postgres
-[INFO] Starting setup on 3 database(s)...
+[INFO] Auto-detecting databases...
+[SUCCESS] Found databases: app_db,analytics_db,reporting_db,postgres
+[INFO] Starting setup on 4 database(s)...
 [SUCCESS] ✓ Setup completed successfully for database: app_db
 [SUCCESS] ✓ Setup completed successfully for database: analytics_db
+[SUCCESS] ✓ Setup completed successfully for database: reporting_db
 [SUCCESS] ✓ Setup completed successfully for database: postgres
 [SUCCESS] All databases setup successfully!
 ```
 
-### Option B: Manual Setup
+**Option B: Manual Setup (Only if you want specific databases)**
 
-For a single database or specific databases only:
+If you only want to monitor specific databases:
 
 ```bash
 cd scripts
 export PGPASSWORD='your-master-password'
-psql -h your-rds-endpoint.rds.amazonaws.com -U postgres -d database_name -f setup-db-user.sql
+
+# For specific databases, use -d with comma-separated list
+./setup-all-databases.sh -h your-rds-endpoint -U postgres -d "app_db,analytics_db,postgres"
 ```
 
-**For multiple databases, repeat for each:**
-```bash
-psql -h your-rds-endpoint -U postgres -d app_db -f setup-db-user.sql
-psql -h your-rds-endpoint -U postgres -d analytics_db -f setup-db-user.sql
-psql -h your-rds-endpoint -U postgres -d reporting_db -f setup-db-user.sql
-```
+**1.5.3: Update Your .env File**
 
-### Verify Setup
-
-After running the setup, verify it worked:
+Go back and update your `.env` file from Step 1 with the monitoring credentials:
 
 ```bash
-psql -h your-rds-endpoint -U postgres -d your_database -c "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'otel_monitor';"
+# Add these lines to your .env file
+PG_USERNAME=otel_monitor
+PG_PASSWORD=<the-password-you-generated-in-step-1.5.1>
 ```
 
-**Expected output:** Should show `otel_monitor` schema exists.
+**1.5.4: Verify Setup**
+
+```bash
+# Test connection with the new user
+psql -h your-rds-endpoint -U otel_monitor -d postgres -c "SELECT * FROM otel_monitor.pg_stat_statements() LIMIT 1;"
+```
+
+**Expected output:** Should show query statistics (not an authentication error).
 
 ### Important Note on Multi-Database Monitoring
 

--- a/aws/rds-postgresql-ecs/QUICK_SETUP.md
+++ b/aws/rds-postgresql-ecs/QUICK_SETUP.md
@@ -92,11 +92,14 @@ echo "Generated password: $MONITOR_PASSWORD"
 echo "⚠️  SAVE THIS PASSWORD - you'll need it for Step 1!"
 
 # Replace the placeholder in the SQL script
-sed -i.bak "s/<SECURE_PASSWORD>/$MONITOR_PASSWORD/g" setup-db-user.sql
+sed -i.bak "s|<SECURE_PASSWORD>|$MONITOR_PASSWORD|g" setup-db-user.sql
 
 # Verify the replacement worked
 grep "CREATE USER otel_monitor" setup-db-user.sql
 # Should show: CREATE USER otel_monitor WITH PASSWORD 'your-actual-password';
+
+# IMPORTANT: After running setup, restore the file to prevent accidental credential commits
+# You can do this later with: git checkout scripts/setup-db-user.sql
 ```
 
 **1.5.2: Run Setup on ALL Databases**
@@ -155,11 +158,16 @@ PG_PASSWORD=<the-password-you-generated-in-step-1.5.1>
 **1.5.4: Verify Setup**
 
 ```bash
-# Test connection with the new user
-psql -h your-rds-endpoint -U otel_monitor -d postgres -c "SELECT * FROM otel_monitor.pg_stat_statements() LIMIT 1;"
+# Test 1: Verify schema was created
+psql -h your-rds-endpoint -U otel_monitor -d postgres -c "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'otel_monitor';"
+
+# Test 2: Verify monitoring function exists and works
+psql -h your-rds-endpoint -U otel_monitor -d postgres -c "SELECT COUNT(*) FROM otel_monitor.pg_stat_statements();"
 ```
 
-**Expected output:** Should show query statistics (not an authentication error).
+**Expected output:**
+- Test 1: Should show `otel_monitor` schema exists
+- Test 2: Should show a count of query statistics (not an authentication error)
 
 ### Important Note on Multi-Database Monitoring
 

--- a/aws/rds-postgresql-ecs/README.md
+++ b/aws/rds-postgresql-ecs/README.md
@@ -33,7 +33,7 @@ MONITOR_PASSWORD=$(openssl rand -base64 24)
 echo "Generated password: $MONITOR_PASSWORD"
 echo "SAVE THIS PASSWORD - you'll need it for .env file!"
 
-sed -i.bak "s/<SECURE_PASSWORD>/$MONITOR_PASSWORD/g" setup-db-user.sql
+sed -i.bak "s|<SECURE_PASSWORD>|$MONITOR_PASSWORD|g" setup-db-user.sql
 
 # 2. Run setup on ALL databases (auto-detect)
 export PGPASSWORD='your-postgres-master-password'
@@ -135,7 +135,7 @@ echo "Save this password - you'll need it for the .env file!"
 
 # Update the SQL script with the password
 cd scripts
-sed -i.bak "s/<SECURE_PASSWORD>/$MONITOR_PASSWORD/g" setup-db-user.sql
+sed -i.bak "s|<SECURE_PASSWORD>|$MONITOR_PASSWORD|g" setup-db-user.sql
 ```
 
 Or manually edit `scripts/setup-db-user.sql` line 20 and replace `<SECURE_PASSWORD>` with your chosen password.

--- a/aws/rds-postgresql-ecs/README.md
+++ b/aws/rds-postgresql-ecs/README.md
@@ -15,17 +15,56 @@ Choose your deployment method:
 
 ### Option 1: Quick Setup (Recommended - CloudFormation)
 
-**Automated deployment in 4 steps (~10 minutes):**
+**Automated deployment in 5 steps (~10 minutes):**
+
+#### Prerequisites
+- **IMPORTANT:** You must create the monitoring user in your database(s) **before** running the quick setup
+- The CloudFormation stack expects the `otel_monitor` user to already exist
+
+#### Quick Steps
+
+**Step 1: Create monitoring user in ALL databases**
 
 ```bash
-cd aws/rds-postgresql-ecs
+cd aws/rds-postgresql-ecs/scripts
+
+# 1. Set a secure password in the SQL script
+MONITOR_PASSWORD=$(openssl rand -base64 24)
+echo "Generated password: $MONITOR_PASSWORD"
+echo "SAVE THIS PASSWORD - you'll need it for .env file!"
+
+sed -i.bak "s/<SECURE_PASSWORD>/$MONITOR_PASSWORD/g" setup-db-user.sql
+
+# 2. Run setup on ALL databases (auto-detect)
+export PGPASSWORD='your-postgres-master-password'
+./setup-all-databases.sh -h your-rds-endpoint.rds.amazonaws.com -U postgres
+
+# DO NOT use -d flag - it will limit setup to only those databases!
+```
+
+**Step 2: Configure environment**
+
+```bash
+cd ..
 cp .env.example .env
-# Edit .env with your credentials
+nano .env  # Edit with your credentials
+```
+
+Add to `.env`:
+```bash
+PG_USERNAME=otel_monitor
+PG_PASSWORD=<password-from-step-1>
+# ... other credentials
+```
+
+**Step 3-5: Deploy**
+
+```bash
 ./build-and-push-images.sh
 ./quick-setup.sh
 ```
 
-👉 **[See Full Quick Setup Guide](QUICK_SETUP.md)** - Step-by-step instructions
+👉 **[See Full Quick Setup Guide](QUICK_SETUP.md)** - Detailed instructions with troubleshooting
 
 **What's automated:**
 - Auto-discovers RDS configuration
@@ -33,6 +72,9 @@ cp .env.example .env
 - Deploys CloudFormation stack with ECS Fargate
 - Configures security groups and networking
 - Sets up all 3 collectors
+
+**What's NOT automated (you must do manually):**
+- Creating the monitoring database user (Step 1 above)
 
 ---
 
@@ -66,7 +108,7 @@ RDS_INSTANCE_ID=your-rds-instance
 LAST9_OTLP_ENDPOINT=https://your-endpoint.last9.io
 LAST9_AUTH_HEADER=Basic <base64-encoded-user:pass>
 
-# Environment
+# Environment (any value: prod, dev, uat, etc.)
 ENVIRONMENT=prod
 ```
 
@@ -77,45 +119,72 @@ ENVIRONMENT=prod
 
 #### Step 2: Create Monitoring User
 
-**IMPORTANT: If you have multiple databases on your RDS instance, you must run the setup on EACH database.**
+**IMPORTANT: This step must be completed for ALL databases on your RDS instance.**
 
-**Option 1: Automated Setup (Recommended for multiple databases)**
+Follow these steps carefully:
 
-Run this helper script to automatically set up monitoring on all databases:
+**2.1: Set a Secure Password**
+
+First, generate a strong password and update the SQL script:
 
 ```bash
+# Generate a secure password
+MONITOR_PASSWORD=$(openssl rand -base64 24)
+echo "Generated password: $MONITOR_PASSWORD"
+echo "Save this password - you'll need it for the .env file!"
+
+# Update the SQL script with the password
 cd scripts
-export PGPASSWORD='your-master-password'
-./setup-all-databases.sh -h your-rds-endpoint -U postgres
+sed -i.bak "s/<SECURE_PASSWORD>/$MONITOR_PASSWORD/g" setup-db-user.sql
 ```
 
-**What it does:**
-- Auto-detects all databases on your RDS instance
-- Runs setup on each database automatically
-- Creates `otel_monitor` user (once)
-- Creates monitoring schema, views, and functions in each database
-- Shows progress and summary report
+Or manually edit `scripts/setup-db-user.sql` line 20 and replace `<SECURE_PASSWORD>` with your chosen password.
 
-**Option 2: Manual Setup (Single database)**
+**2.2: Run Setup on All Databases**
 
-If you only have one database or want to set up specific databases:
+**Option A: Automated Setup (Recommended - sets up ALL databases)**
 
 ```bash
+# Make sure you're in the scripts directory
+cd scripts
+
+# Set your PostgreSQL master password
+export PGPASSWORD='your-postgres-master-password'
+
+# Run setup - DO NOT use -d flag to auto-detect all databases
+./setup-all-databases.sh -h your-rds-endpoint.rds.amazonaws.com -U postgres
+```
+
+**IMPORTANT:**
+- Do NOT use the `-d` flag - this limits setup to specific databases only
+- The script will auto-detect all databases and run setup on each one
+- You should see "Total databases: X" where X is your actual database count
+
+**Option B: Manual Setup (Single database or specific databases)**
+
+If you want to run setup on specific databases only:
+
+```bash
+# For a single database
 psql -h your-rds-endpoint -U postgres -d your_database_name -f scripts/setup-db-user.sql
+
+# For specific databases (comma-separated)
+./setup-all-databases.sh -h your-rds-endpoint -U postgres -d "db1,db2,db3"
 ```
 
-**For multiple databases, repeat for each:**
+**What the setup does:**
+- Creates `otel_monitor` user with your secure password (once, on first run)
+- Grants `pg_monitor` role for read-only monitoring access
+- Creates monitoring schema, views, and functions in each database
+- Enables `pg_stat_statements` extension per database
+
+**2.3: Update .env with the Password**
+
 ```bash
-psql -h your-rds-endpoint -U postgres -d database1 -f scripts/setup-db-user.sql
-psql -h your-rds-endpoint -U postgres -d database2 -f scripts/setup-db-user.sql
-psql -h your-rds-endpoint -U postgres -d database3 -f scripts/setup-db-user.sql
+# Update your .env file with the monitoring credentials
+PG_USERNAME=otel_monitor
+PG_PASSWORD=your-generated-password-from-step-2.1
 ```
-
-**What it does:**
-- Creates `otel_monitor` user with read-only access (if not exists)
-- Grants `pg_monitor` role
-- Creates helper functions and views for monitoring
-- Enables `pg_stat_statements` extension
 
 #### Step 3: Build Docker Images
 
@@ -192,7 +261,7 @@ docker logs cloudwatch-collector
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `COLLECTION_INTERVAL` | `30` | Metrics collection interval (seconds) |
-| `ENVIRONMENT` | `prod` | Environment label for metrics |
+| `ENVIRONMENT` | `prod` | Environment label for metrics (any value accepted) |
 
 ---
 

--- a/aws/rds-postgresql-ecs/cloudformation/postgresql-collector.yaml
+++ b/aws/rds-postgresql-ecs/cloudformation/postgresql-collector.yaml
@@ -18,13 +18,8 @@ Parameters:
 
   Environment:
     Type: String
-    AllowedValues:
-      - prod
-      - staging
-      - dev
-      - uat
     Default: dev
-    Description: Deployment environment
+    Description: Environment name for tagging and labeling metrics (e.g., prod, staging, dev, uat, etc.)
 
   Last9OtlpEndpoint:
     Type: String

--- a/aws/rds-postgresql-ecs/cloudformation/quick-setup.yaml
+++ b/aws/rds-postgresql-ecs/cloudformation/quick-setup.yaml
@@ -88,8 +88,7 @@ Parameters:
   Environment:
     Type: String
     Default: prod
-    AllowedValues: [prod, staging, dev, uat]
-    Description: Environment name for tagging
+    Description: Environment name for tagging and labeling metrics (e.g., prod, staging, dev, uat, etc.)
 
   CreateMonitoringUser:
     Type: String

--- a/aws/rds-postgresql-ecs/config/otel-collector-config.yaml
+++ b/aws/rds-postgresql-ecs/config/otel-collector-config.yaml
@@ -106,12 +106,13 @@ processors:
     # Instance-wide metrics will have database="_instance_wide" for consistent filtering
 
   # Filter processor to drop noisy metrics if needed
-  filter/metrics:
-    metrics:
-      exclude:
-        match_type: regexp
-        metric_names:
-          - ".*_total$"  # Exclude if duplicating counters
+  # Uncomment and add to pipeline processors list to enable
+  # filter/metrics:
+  #   metrics:
+  #     exclude:
+  #       match_type: regexp
+  #       metric_names:
+  #         - ".*_total$"  # Exclude if duplicating counters
 
 exporters:
   # Last9 OTLP exporter
@@ -131,11 +132,12 @@ exporters:
       num_consumers: 10
       queue_size: 1000
 
-  # Debug exporter for troubleshooting (disable in production)
-  debug:
-    verbosity: detailed
-    sampling_initial: 2
-    sampling_thereafter: 2
+  # Debug exporter for troubleshooting (disabled in production)
+  # Uncomment and add to pipeline exporters list to enable
+  # debug:
+  #   verbosity: detailed
+  #   sampling_initial: 2
+  #   sampling_thereafter: 2
 
 extensions:
   # Health check endpoint for ECS health checks
@@ -157,7 +159,7 @@ service:
       # IMPORTANT: resource processor must run BEFORE transform/metrics
       # so that resource attributes exist when transform tries to read them
       processors: [memory_limiter, resource, transform/metrics, batch]
-      exporters: [otlp/last9, debug]
+      exporters: [otlp/last9]
 
   telemetry:
     logs:

--- a/aws/rds-postgresql-ecs/config/otel-collector-config.yaml
+++ b/aws/rds-postgresql-ecs/config/otel-collector-config.yaml
@@ -154,7 +154,9 @@ service:
     # Metrics pipeline
     metrics:
       receivers: [postgresql, prometheus/self]
-      processors: [memory_limiter, transform/metrics, resource, batch]
+      # IMPORTANT: resource processor must run BEFORE transform/metrics
+      # so that resource attributes exist when transform tries to read them
+      processors: [memory_limiter, resource, transform/metrics, batch]
       exporters: [otlp/last9, debug]
 
   telemetry:

--- a/aws/rds-postgresql-ecs/config/queries.yaml
+++ b/aws/rds-postgresql-ecs/config/queries.yaml
@@ -1,3 +1,22 @@
+# ⚠️  WARNING: This file is currently NOT IN USE ⚠️
+#
+# This file contains custom PostgreSQL queries in postgres_exporter format,
+# but there is no sqlquery receiver configured in otel-collector-config.yaml.
+#
+# These queries are NOT being collected. The metrics documented in README.md
+# come from:
+# 1. Built-in postgresql receiver (34 metrics)
+# 2. dbm-collector.py script (9 DBM metrics)
+# 3. cloudwatch-collector.py script (14 RDS metrics)
+#
+# To use these queries, you would need to:
+# 1. Add sqlquery receiver to otel-collector-config.yaml
+# 2. Convert queries to OTel sqlquery receiver format (different from postgres_exporter)
+# 3. Update the receiver pipeline to include sqlquery
+#
+# For now, this file is kept for reference but is NOT functional.
+#
+# Original header:
 # Custom PostgreSQL Queries for Enhanced Monitoring
 # These queries extend the built-in OTEL PostgreSQL receiver metrics
 

--- a/aws/rds-postgresql-ecs/quick-setup.sh
+++ b/aws/rds-postgresql-ecs/quick-setup.sh
@@ -184,7 +184,7 @@ collect_configuration() {
 
     # Environment
     if [ -z "$ENVIRONMENT" ]; then
-        echo -n "Environment [prod/staging/dev] [prod]: "
+        echo -n "Environment (e.g., prod, staging, dev, uat) [prod]: "
         read ENVIRONMENT
         ENVIRONMENT=${ENVIRONMENT:-prod}
     else

--- a/aws/rds-postgresql-ecs/scripts/dbm-collector.py
+++ b/aws/rds-postgresql-ecs/scripts/dbm-collector.py
@@ -581,8 +581,12 @@ def setup_otlp_exporter(config: Config) -> metrics.Meter:
     return metrics.get_meter("postgresql.dbm")
 
 
-def output_otlp(data: Dict[str, Any], meter: metrics.Meter, config: Config) -> None:
-    """Output data via OTLP to Last9."""
+def output_otlp(data: Dict[str, Any], meter: metrics.Meter, config: Config, last_statements: Dict[int, Dict]) -> None:
+    """Output data via OTLP to Last9.
+
+    Args:
+        last_statements: Dictionary to track previous pg_stat_statements values for delta computation
+    """
 
     # Create/get metric instruments (these are cached by name)
     query_calls = meter.create_counter(
@@ -658,7 +662,13 @@ def output_otlp(data: Dict[str, Any], meter: metrics.Meter, config: Config) -> N
     )
 
     # Record query metrics from pg_stat_statements
+    # Compute deltas since pg_stat_statements values are cumulative
+    current_statements = {}
+
     for metric in data.get('query_metrics', []):
+        query_id = metric['query_id']
+        current_statements[query_id] = metric
+
         # Create a short, readable query preview (max 100 chars)
         query_text = metric['query'].strip()
         query_text_preview = query_text[:100]
@@ -673,14 +683,36 @@ def output_otlp(data: Dict[str, Any], meter: metrics.Meter, config: Config) -> N
             "query_text_preview": query_text_preview,  # Add readable SQL preview
         }
 
-        # Record cumulative metrics
-        query_calls.add(metric['calls'], attributes)
-        query_total_time.add(metric['total_time_ms'], attributes)
-        query_rows.add(metric['rows'], attributes)
-        query_buffer_hits.add(metric['shared_blks_hit'], attributes)
-        query_buffer_reads.add(metric['shared_blks_read'], attributes)
-        query_io_read_time.add(metric['blk_read_time_ms'], attributes)
-        query_io_write_time.add(metric['blk_write_time_ms'], attributes)
+        # Compute deltas from last collection (pg_stat_statements is cumulative)
+        if query_id in last_statements:
+            prev = last_statements[query_id]
+            # Calculate delta values (current - previous)
+            delta_calls = max(0, metric['calls'] - prev['calls'])
+            delta_time = max(0, metric['total_time_ms'] - prev['total_time_ms'])
+            delta_rows = max(0, metric['rows'] - prev['rows'])
+            delta_buffer_hits = max(0, metric['shared_blks_hit'] - prev['shared_blks_hit'])
+            delta_buffer_reads = max(0, metric['shared_blks_read'] - prev['shared_blks_read'])
+            delta_io_read = max(0, metric['blk_read_time_ms'] - prev['blk_read_time_ms'])
+            delta_io_write = max(0, metric['blk_write_time_ms'] - prev['blk_write_time_ms'])
+        else:
+            # First time seeing this query, use current values as delta
+            delta_calls = metric['calls']
+            delta_time = metric['total_time_ms']
+            delta_rows = metric['rows']
+            delta_buffer_hits = metric['shared_blks_hit']
+            delta_buffer_reads = metric['shared_blks_read']
+            delta_io_read = metric['blk_read_time_ms']
+            delta_io_write = metric['blk_write_time_ms']
+
+        # Record delta metrics (not cumulative totals)
+        if delta_calls > 0:  # Only record if there were calls in this interval
+            query_calls.add(delta_calls, attributes)
+            query_total_time.add(delta_time, attributes)
+            query_rows.add(delta_rows, attributes)
+            query_buffer_hits.add(delta_buffer_hits, attributes)
+            query_buffer_reads.add(delta_buffer_reads, attributes)
+            query_io_read_time.add(delta_io_read, attributes)
+            query_io_write_time.add(delta_io_write, attributes)
 
         # Record query info (mapping signature to query text)
         # Truncate query to avoid label size limits (max 200 chars)
@@ -727,6 +759,10 @@ def output_otlp(data: Dict[str, Any], meter: metrics.Meter, config: Config) -> N
         }
     )
 
+    # Update last_statements for next delta computation
+    last_statements.clear()
+    last_statements.update(current_statements)
+
     logger.info(
         f"Exported to OTLP: "
         f"{len(data.get('query_metrics', []))} query metrics, "
@@ -765,7 +801,7 @@ def main():
                 if config.output_format == 'json':
                     output_json(data)
                 elif config.output_format == 'otlp':
-                    output_otlp(data, meter, config)
+                    output_otlp(data, meter, config, collector.last_statements)
 
                 # Summary log
                 logger.info(


### PR DESCRIPTION
## Summary
Improves the RDS PostgreSQL monitoring setup documentation to prevent common user errors encountered during database setup.

## Problems Addressed

### 1. Password Placeholder Not Replaced
**Issue:** Users were running `setup-db-user.sql` with `<SECURE_PASSWORD>` placeholder, causing authentication failures.

**Fix:** Added step-by-step instructions to generate and replace the password placeholder before running setup scripts.

### 2. Setup Running on Only 1 Database Instead of All
**Issue:** Users were using `-d postgres` flag, limiting setup to a single database when they had 10+ databases.

**Fix:** 
- Added explicit warnings to NOT use `-d` flag for auto-detection
- Clarified that omitting `-d` enables auto-discovery of all databases
- Added example outputs showing correct multi-database setup

### 3. Username Mismatch
**Issue:** Script creates `otel_monitor` but documentation showed mixed usage of `monitoring_user`.

**Fix:** Consistently use `otel_monitor` throughout all documentation.

### 4. Missing Prerequisites in Quick Setup (Option 1)
**Issue:** CloudFormation quick setup option didn't mention database user must be created first.

**Fix:** Added clear prerequisite section showing database setup must be done before CloudFormation deployment.

### 5. Environment Value Format Restrictions
**Issue:** CloudFormation templates enforced `AllowedValues: [prod, staging, dev, uat]`, rejecting valid values like "UAT", "Dev", "production".

**Fix:** Removed validation constraints, allowing any string value for environment names.

## Changes Made

### Documentation Files
- `README.md`: Added step-by-step setup instructions with sub-steps (2.1, 2.2, 2.3)
- `QUICK_SETUP.md`: Restructured Step 1.5 with clear password generation and replacement instructions
- `.env.example`: Clarified environment can be any value

### CloudFormation Templates
- `cloudformation/postgresql-collector.yaml`: Removed `AllowedValues` constraint for Environment parameter
- `cloudformation/quick-setup.yaml`: Removed `AllowedValues` constraint for Environment parameter

### Scripts
- `quick-setup.sh`: Updated environment prompt to show examples instead of restrictions

## Testing Checklist
- [ ] Documentation changes reviewed for clarity
- [ ] CloudFormation templates validate successfully
- [ ] Environment parameter accepts arbitrary string values (e.g., "UAT", "Dev", "PROD")

## Related Issues
Addresses customer issue where:
- Authentication failed with error: `password authentication failed for user "monitoring_user"`
- Setup ran on only 1 database instead of 10 databases
- Environment value "uat" was rejected by CloudFormation

## Screenshots/Examples
Example of improved documentation showing clear warnings:
```bash
# DO NOT use -d flag - it will limit setup to only those databases!
./setup-all-databases.sh -h your-rds-endpoint.rds.amazonaws.com -U postgres
```