### PR TITLE
feat: vanilla Python Kafka consumer/producer with OTel trace propagation

### DIFF
--- a/python/kafka-consumer/.env.example
+++ b/python/kafka-consumer/.env.example
@@ -1,0 +1,18 @@
+# Last9 OTLP credentials — get these from https://app.last9.io
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.last9.io
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <your-base64-encoded-credentials>
+
+# Service metadata
+OTEL_SERVICE_NAME=kafka-consumer
+SERVICE_VERSION=1.0.0
+DEPLOYMENT_ENVIRONMENT=production
+
+# Kafka
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+KAFKA_INPUT_TOPIC=orders
+KAFKA_OUTPUT_TOPIC=order-results
+KAFKA_CONSUMER_GROUP=order-processor
+
+# Test producer (producer.py only)
+MESSAGE_COUNT=5
+MESSAGE_DELAY_SECONDS=1.0

--- a/python/kafka-consumer/.gitignore
+++ b/python/kafka-consumer/.gitignore
@@ -1,0 +1,22 @@
+# Secrets
+.env
+.env.local
+.env.*.local
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log

--- a/python/kafka-consumer/Dockerfile
+++ b/python/kafka-consumer/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "consumer.py"]

--- a/python/kafka-consumer/README.md
+++ b/python/kafka-consumer/README.md
@@ -1,0 +1,102 @@
+# Vanilla Python Kafka Consumer with OpenTelemetry
+
+Plain Python service (no framework) that consumes messages from a Kafka topic,
+processes them, and publishes results to another topic. Trace context is propagated
+end-to-end via W3C `traceparent` headers on each Kafka message.
+
+## How trace context flows
+
+```
+producer.py  ──[traceparent header]──▶  Kafka: orders
+                                               │
+                                          consumer.py
+                                               │
+                                       extract context
+                                               │
+                                     CONSUMER span (child of producer)
+                                       │           │
+                               process_order    PRODUCER span
+                                  (child)            │
+                                               inject context
+                                               [traceparent header]
+                                                     │
+                                        Kafka: order-results ──▶ next service
+```
+
+## Prerequisites
+
+- Python 3.11+
+- Docker and Docker Compose (for local Kafka)
+
+## Quick Start
+
+**1. Install dependencies**
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+**2. Configure credentials**
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` — set your Last9 OTLP endpoint and auth header. Get them from
+[app.last9.io](https://app.last9.io) → Integrations → OpenTelemetry.
+
+**3. Start Kafka and the consumer**
+
+```bash
+docker compose up --build
+```
+
+This starts a single-node Kafka (KRaft, no Zookeeper) and the consumer service.
+
+**4. Send test messages**
+
+```bash
+docker compose --profile generate up message-generator
+```
+
+Or run locally (with Kafka port-forwarded):
+
+```bash
+source .env && python producer.py
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `https://otlp.last9.io` | Last9 OTLP endpoint |
+| `OTEL_EXPORTER_OTLP_HEADERS` | — | `Authorization=Basic <token>` |
+| `OTEL_SERVICE_NAME` | `kafka-consumer` | Service name in traces |
+| `SERVICE_VERSION` | `1.0.0` | `service.version` resource attribute |
+| `DEPLOYMENT_ENVIRONMENT` | `development` | `deployment.environment` resource attribute |
+| `KAFKA_BOOTSTRAP_SERVERS` | `localhost:9092` | Kafka broker address |
+| `KAFKA_INPUT_TOPIC` | `orders` | Topic to consume from |
+| `KAFKA_OUTPUT_TOPIC` | `order-results` | Topic to publish results to |
+| `KAFKA_CONSUMER_GROUP` | `order-processor` | Consumer group ID |
+| `MESSAGE_COUNT` | `5` | Messages sent by `producer.py` |
+| `MESSAGE_DELAY_SECONDS` | `1.0` | Delay between messages in `producer.py` |
+
+## Running without Docker
+
+Start Kafka separately, then:
+
+```bash
+# Port 29092 is the host-accessible listener (29092→Kafka external, 9092 is Docker-internal only)
+export KAFKA_BOOTSTRAP_SERVERS=localhost:29092
+source .env
+python consumer.py          # terminal 1 — long-running consumer
+python producer.py          # terminal 2 — sends 5 test messages
+```
+
+## Verification
+
+Sign in to [Last9 Dashboard](https://app.last9.io) → APM → Traces. Filter by
+`service.name = kafka-consumer`. You should see connected spans showing the full
+producer → consumer → result-publisher chain within a single trace.

--- a/python/kafka-consumer/consumer.py
+++ b/python/kafka-consumer/consumer.py
@@ -1,0 +1,197 @@
+"""
+Vanilla Python Kafka consumer with OpenTelemetry trace context propagation.
+
+Reads orders from KAFKA_INPUT_TOPIC, processes them, and publishes results
+to KAFKA_OUTPUT_TOPIC. Trace context travels across services via W3C
+traceparent/tracestate headers on each Kafka message.
+
+Trace flow:
+  [producer] --[traceparent header]--> Kafka: orders
+                                            |
+                                       consumer.py
+                                            |
+                                    extract context   <-- W3C traceparent from headers
+                                            |
+                                  [CONSUMER span]     <-- child of producer's span
+                                            |
+                                  [process_order]     <-- child span (business logic)
+                                            |
+                                  [PRODUCER span]     <-- child span, inject new context
+                                            |
+                               Kafka: order-results --[traceparent header]--> next service
+"""
+
+import json
+import logging
+import os
+import signal
+import time
+
+from confluent_kafka import Consumer, KafkaError, KafkaException, Producer
+
+from opentelemetry import trace
+from opentelemetry.propagate import extract, inject
+from opentelemetry.trace import SpanKind, StatusCode
+
+from telemetry import init_tracing, shutdown_tracing
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+INPUT_TOPIC = os.environ.get("KAFKA_INPUT_TOPIC", "orders")
+OUTPUT_TOPIC = os.environ.get("KAFKA_OUTPUT_TOPIC", "order-results")
+CONSUMER_GROUP = os.environ.get("KAFKA_CONSUMER_GROUP", "order-processor")
+
+
+# ---------------------------------------------------------------------------
+# Header helpers
+# ---------------------------------------------------------------------------
+
+def headers_to_carrier(headers: list) -> dict:
+    """Convert Kafka message headers to an OTel text-map carrier."""
+    if not headers:
+        return {}
+    return {k: v.decode("utf-8") for k, v in headers if v is not None}
+
+
+def carrier_to_headers(carrier: dict) -> list:
+    """Convert an OTel text-map carrier to Kafka message headers."""
+    return [(k, v.encode("utf-8")) for k, v in carrier.items()]
+
+
+# ---------------------------------------------------------------------------
+# Business logic
+# ---------------------------------------------------------------------------
+
+def process_order(order: dict, tracer) -> dict:
+    """Process an order and return a result dict."""
+    with tracer.start_as_current_span("process_order") as span:
+        order_id = order.get("order_id", "unknown")
+        amount = float(order.get("amount", 0))
+
+        span.set_attribute("order.id", order_id)
+        span.set_attribute("order.amount", amount)
+        span.set_attribute("order.item", order.get("item", ""))
+
+        time.sleep(0.05)  # simulate processing work
+
+        logger.info("Processed order %s (amount=%.2f)", order_id, amount)
+        return {
+            "order_id": order_id,
+            "status": "processed",
+            "processed_at": time.time(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Output producer
+# ---------------------------------------------------------------------------
+
+def publish_result(kproducer: Producer, result: dict, tracer) -> None:
+    """Publish a result to the output topic with trace context in headers."""
+    with tracer.start_as_current_span(
+        f"{OUTPUT_TOPIC} publish",
+        kind=SpanKind.PRODUCER,
+        attributes={
+            "messaging.system": "kafka",
+            "messaging.destination.name": OUTPUT_TOPIC,
+            "messaging.operation.type": "publish",
+            "order.id": result.get("order_id", ""),
+        },
+    ):
+        carrier: dict = {}
+        inject(carrier)  # captures the current PRODUCER span context
+        headers = carrier_to_headers(carrier)
+
+        kproducer.produce(
+            topic=OUTPUT_TOPIC,
+            value=json.dumps(result).encode("utf-8"),
+            headers=headers,
+        )
+        kproducer.poll(0)  # trigger delivery callbacks (non-blocking)
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+def run() -> None:
+    provider = init_tracing()
+    tracer = trace.get_tracer(__name__)
+    running = True
+
+    consumer = Consumer({
+        "bootstrap.servers": BOOTSTRAP_SERVERS,
+        "group.id": CONSUMER_GROUP,
+        "auto.offset.reset": "earliest",
+        "enable.auto.commit": True,
+    })
+
+    kproducer = Producer({"bootstrap.servers": BOOTSTRAP_SERVERS})
+
+    def handle_shutdown(sig, frame):
+        nonlocal running
+        logger.info("Received signal %s — shutting down after current message…", sig)
+        running = False
+
+    signal.signal(signal.SIGINT, handle_shutdown)
+    signal.signal(signal.SIGTERM, handle_shutdown)
+
+    consumer.subscribe([INPUT_TOPIC])
+    logger.info(
+        "Subscribed to '%s', publishing results to '%s' (group=%s)",
+        INPUT_TOPIC, OUTPUT_TOPIC, CONSUMER_GROUP,
+    )
+
+    try:
+        while running:
+            msg = consumer.poll(timeout=1.0)
+            if msg is None:
+                continue
+
+            if msg.error():
+                if msg.error().code() == KafkaError._PARTITION_EOF:
+                    continue
+                raise KafkaException(msg.error())
+
+            # Extract W3C traceparent from Kafka message headers
+            carrier = headers_to_carrier(msg.headers() or [])
+            parent_ctx = extract(carrier)
+
+            with tracer.start_as_current_span(
+                f"{INPUT_TOPIC} receive",
+                context=parent_ctx,
+                kind=SpanKind.CONSUMER,
+                attributes={
+                    "messaging.system": "kafka",
+                    "messaging.source.name": INPUT_TOPIC,
+                    "messaging.operation.type": "receive",
+                    "messaging.message.offset": msg.offset(),
+                    "messaging.kafka.consumer.group": CONSUMER_GROUP,
+                    "messaging.kafka.partition": msg.partition(),
+                },
+            ) as span:
+                try:
+                    payload = json.loads(msg.value().decode("utf-8"))
+                    result = process_order(payload, tracer)
+                    publish_result(kproducer, result, tracer)
+                except Exception as exc:
+                    logger.exception(
+                        "Failed to process message at offset %d: %s",
+                        msg.offset(), exc,
+                    )
+                    span.record_exception(exc)
+                    span.set_status(StatusCode.ERROR, str(exc))
+    finally:
+        consumer.close()
+        kproducer.flush(timeout=5)
+        shutdown_tracing(provider)
+        logger.info("Consumer shut down cleanly.")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/kafka-consumer/docker-compose.yaml
+++ b/python/kafka-consumer/docker-compose.yaml
@@ -1,0 +1,79 @@
+services:
+  kafka:
+    image: confluentinc/cp-kafka:7.7.1
+    container_name: kafka
+    ports:
+      - "9092:9092"
+      - "29092:29092"   # host-accessible external listener
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:29092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:29092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_NUM_PARTITIONS: 2
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+    healthcheck:
+      test: ["CMD", "kafka-topics", "--bootstrap-server", "kafka:9092", "--list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  kafka-init:
+    image: confluentinc/cp-kafka:7.7.1
+    container_name: kafka-init
+    depends_on:
+      kafka:
+        condition: service_healthy
+    entrypoint: ["/bin/bash", "-c"]
+    command: >
+      "
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists
+        --topic orders --partitions 2 --replication-factor 1 &&
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists
+        --topic order-results --partitions 2 --replication-factor 1 &&
+      echo 'Topics ready.'
+      "
+
+  consumer:
+    build: .
+    container_name: kafka-consumer
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+    env_file:
+      - .env
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      KAFKA_INPUT_TOPIC: orders
+      KAFKA_OUTPUT_TOPIC: order-results
+      KAFKA_CONSUMER_GROUP: order-processor
+    restart: unless-stopped
+
+  # Run with: docker compose --profile generate up message-generator
+  message-generator:
+    build: .
+    container_name: kafka-message-generator
+    profiles: ["generate"]
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+    env_file:
+      - .env
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      KAFKA_INPUT_TOPIC: orders
+      MESSAGE_COUNT: "10"
+      MESSAGE_DELAY_SECONDS: "1.0"
+    command: ["python", "producer.py"]

--- a/python/kafka-consumer/producer.py
+++ b/python/kafka-consumer/producer.py
@@ -1,0 +1,98 @@
+"""
+Test message generator — sends sample order messages to the input topic
+with W3C trace context injected into Kafka headers.
+
+Run this to generate messages for the consumer:
+    python producer.py
+
+Environment variables:
+    MESSAGE_COUNT         — number of messages to send (default: 5)
+    MESSAGE_DELAY_SECONDS — delay between messages in seconds (default: 1.0)
+"""
+
+import json
+import logging
+import os
+import random
+import time
+import uuid
+
+from confluent_kafka import Producer as KafkaProducer
+
+from opentelemetry import trace
+from opentelemetry.propagate import inject
+from opentelemetry.trace import SpanKind
+
+from telemetry import init_tracing, shutdown_tracing
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+INPUT_TOPIC = os.environ.get("KAFKA_INPUT_TOPIC", "orders")
+
+ITEMS = ["widget", "gadget", "doohickey", "thingamajig", "gizmo"]
+
+
+def send_order(kproducer: KafkaProducer, tracer) -> None:
+    order = {
+        "order_id": str(uuid.uuid4()),
+        "item": random.choice(ITEMS),
+        "amount": round(random.uniform(10.0, 500.0), 2),
+        "currency": "USD",
+    }
+
+    with tracer.start_as_current_span(
+        f"{INPUT_TOPIC} publish",
+        kind=SpanKind.PRODUCER,
+        attributes={
+            "messaging.system": "kafka",
+            "messaging.destination.name": INPUT_TOPIC,
+            "messaging.operation.type": "publish",
+            "order.id": order["order_id"],
+            "order.item": order["item"],
+            "order.amount": order["amount"],
+        },
+    ):
+        carrier: dict = {}
+        inject(carrier)  # inject current PRODUCER span context into carrier
+        headers = [(k, v.encode("utf-8")) for k, v in carrier.items()]
+
+        kproducer.produce(
+            topic=INPUT_TOPIC,
+            value=json.dumps(order).encode("utf-8"),
+            headers=headers,
+        )
+        kproducer.poll(0)
+
+        logger.info(
+            "Sent order %s — %s @ %.2f %s",
+            order["order_id"], order["item"], order["amount"], order["currency"],
+        )
+
+
+def run() -> None:
+    provider = init_tracing()
+    tracer = trace.get_tracer(__name__)
+
+    kproducer = KafkaProducer({"bootstrap.servers": BOOTSTRAP_SERVERS})
+
+    count = int(os.environ.get("MESSAGE_COUNT", "5"))
+    delay = float(os.environ.get("MESSAGE_DELAY_SECONDS", "1.0"))
+
+    try:
+        for i in range(count):
+            send_order(kproducer, tracer)
+            if i < count - 1:
+                time.sleep(delay)
+    finally:
+        kproducer.flush(timeout=5)
+        shutdown_tracing(provider)
+        logger.info("Done — sent %d message(s).", count)
+
+
+if __name__ == "__main__":
+    run()

--- a/python/kafka-consumer/requirements.txt
+++ b/python/kafka-consumer/requirements.txt
@@ -1,0 +1,4 @@
+confluent-kafka==2.6.1
+opentelemetry-api==1.30.0
+opentelemetry-sdk==1.30.0
+opentelemetry-exporter-otlp-proto-http==1.30.0

--- a/python/kafka-consumer/telemetry.py
+++ b/python/kafka-consumer/telemetry.py
@@ -1,0 +1,60 @@
+"""
+Shared OpenTelemetry setup.
+
+Reads standard OTEL_* environment variables — no extra config needed.
+"""
+
+import logging
+import os
+
+from opentelemetry import trace
+from opentelemetry.baggage.propagation import W3CBaggagePropagator
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.propagate import set_global_textmap
+from opentelemetry.propagators.composite import CompositePropagator
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+logger = logging.getLogger(__name__)
+
+
+def init_tracing() -> TracerProvider:
+    """Initialize the global tracer provider.
+
+    Environment variables consumed:
+        OTEL_SERVICE_NAME            — service.name resource attribute
+        OTEL_EXPORTER_OTLP_ENDPOINT  — OTLP collector/Last9 endpoint
+        OTEL_EXPORTER_OTLP_HEADERS   — e.g. "Authorization=Basic <token>"
+        SERVICE_VERSION              — service.version resource attribute
+        DEPLOYMENT_ENVIRONMENT       — deployment.environment resource attribute
+    """
+    resource = Resource.create({
+        "service.name": os.environ.get("OTEL_SERVICE_NAME", "kafka-consumer"),
+        "service.version": os.environ.get("SERVICE_VERSION", "1.0.0"),
+        "deployment.environment": os.environ.get("DEPLOYMENT_ENVIRONMENT", "development"),
+    })
+
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+
+    set_global_textmap(CompositePropagator([
+        TraceContextTextMapPropagator(),
+        W3CBaggagePropagator(),
+    ]))
+
+    logger.info(
+        "Tracing initialised — service=%s endpoint=%s",
+        os.environ.get("OTEL_SERVICE_NAME", "kafka-consumer"),
+        os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "https://otlp.last9.io"),
+    )
+    return provider
+
+
+def shutdown_tracing(provider: TracerProvider) -> None:
+    """Flush pending spans and shut down gracefully."""
+    logger.info("Flushing spans before shutdown…")
+    provider.force_flush(timeout_millis=5000)
+    provider.shutdown()

--- a/python/kafka-python/.env.example
+++ b/python/kafka-python/.env.example
@@ -1,0 +1,18 @@
+# Last9 OTLP credentials — get these from https://app.last9.io
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.last9.io
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <your-base64-encoded-credentials>
+
+# Service metadata
+OTEL_SERVICE_NAME=kafka-python-consumer
+SERVICE_VERSION=1.0.0
+DEPLOYMENT_ENVIRONMENT=production
+
+# Kafka
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+KAFKA_INPUT_TOPIC=orders
+KAFKA_OUTPUT_TOPIC=order-results
+KAFKA_CONSUMER_GROUP=order-processor
+
+# Test producer (producer.py only)
+MESSAGE_COUNT=5
+MESSAGE_DELAY_SECONDS=1.0

--- a/python/kafka-python/.gitignore
+++ b/python/kafka-python/.gitignore
@@ -1,0 +1,22 @@
+# Secrets
+.env
+.env.local
+.env.*.local
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log

--- a/python/kafka-python/Dockerfile
+++ b/python/kafka-python/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "consumer.py"]

--- a/python/kafka-python/README.md
+++ b/python/kafka-python/README.md
@@ -1,0 +1,104 @@
+# Python Kafka Consumer with OpenTelemetry Auto-Instrumentation
+
+Plain Python service (no framework) that consumes messages from a Kafka topic,
+processes them, and publishes results to another topic. Uses
+[`opentelemetry-instrumentation-kafka-python`](https://pypi.org/project/opentelemetry-instrumentation-kafka-python/)
+to automatically propagate trace context — no manual `inject`/`extract` calls needed.
+
+## How it works
+
+A single call to `KafkaInstrumentor().instrument()` wraps all `KafkaProducer` and
+`KafkaConsumer` instances:
+
+- **Producer** — every `producer.send()` automatically creates a `PRODUCER` span
+  and injects `traceparent` into message headers. No manual code needed.
+- **Consumer (transport layer)** — auto-instrumented: creates a `CONSUMER` span and
+  extracts `traceparent` from headers.
+- **Consumer (business logic)** — `kafka-python` uses an iterator pattern; the
+  auto-instrumentor creates its span inside `__next__()` and the context doesn't
+  survive the yield into user code. We extract context from `msg.headers` manually
+  to parent business logic spans correctly. The Kafka send/receive spans themselves
+  remain fully automatic.
+
+## Trace flow
+
+```
+producer.py     │  orders (send)           (PRODUCER) ← auto-created, headers injected
+kafka-python    │  orders (receive)        (CONSUMER) ← auto-created, headers extracted
+kafka-python    │    process_order         (INTERNAL) ← manual child span
+kafka-python    │    order-results (send)  (PRODUCER) ← auto-created, headers injected
+```
+
+## vs. confluent-kafka example
+
+| | `kafka-python` (this example) | `confluent-kafka` |
+|---|---|---|
+| Auto-instrumentation | Yes — `KafkaInstrumentor` | No official package |
+| Header propagation | Automatic | Manual `inject`/`extract` |
+| Code complexity | Lower | Higher |
+
+## Prerequisites
+
+- Python 3.11+
+- Docker and Docker Compose (for local Kafka)
+
+## Quick Start
+
+**1. Install dependencies**
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+**2. Configure credentials**
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` — set your Last9 OTLP endpoint and auth header. Get them from
+[app.last9.io](https://app.last9.io) → Integrations → OpenTelemetry.
+
+**3. Start Kafka and the consumer**
+
+```bash
+docker compose up --build
+```
+
+**4. Send test messages**
+
+```bash
+docker compose --profile generate up message-generator
+```
+
+Or run locally (Kafka port-forwarded on `29093`):
+
+```bash
+export KAFKA_BOOTSTRAP_SERVERS=localhost:29093
+source .env
+python producer.py
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `https://otlp.last9.io` | Last9 OTLP endpoint |
+| `OTEL_EXPORTER_OTLP_HEADERS` | — | `Authorization=Basic <token>` |
+| `OTEL_SERVICE_NAME` | `kafka-python-consumer` | Service name in traces |
+| `SERVICE_VERSION` | `1.0.0` | `service.version` resource attribute |
+| `DEPLOYMENT_ENVIRONMENT` | `development` | `deployment.environment` resource attribute |
+| `KAFKA_BOOTSTRAP_SERVERS` | `localhost:9092` | Kafka broker address |
+| `KAFKA_INPUT_TOPIC` | `orders` | Topic to consume from |
+| `KAFKA_OUTPUT_TOPIC` | `order-results` | Topic to publish results to |
+| `KAFKA_CONSUMER_GROUP` | `order-processor` | Consumer group ID |
+| `MESSAGE_COUNT` | `5` | Messages sent by `producer.py` |
+| `MESSAGE_DELAY_SECONDS` | `1.0` | Delay between messages in `producer.py` |
+
+## Verification
+
+Sign in to [Last9 Dashboard](https://app.last9.io) → APM → Traces. Filter by
+`service.name = kafka-python-consumer`. You should see connected spans showing
+the full producer → consumer → result-publisher chain within a single trace.

--- a/python/kafka-python/consumer.py
+++ b/python/kafka-python/consumer.py
@@ -1,0 +1,151 @@
+"""
+Vanilla Python Kafka consumer with OpenTelemetry auto-instrumentation.
+
+Uses kafka-python + opentelemetry-instrumentation-kafka, which automatically:
+  - Creates a CONSUMER span for each message received
+  - Extracts W3C traceparent from message headers (links to the producer's trace)
+  - Creates a PRODUCER span when sending to the output topic
+  - Injects W3C traceparent into outgoing message headers
+
+Note on context propagation:
+  kafka-python uses an iterator pattern. The auto-instrumentor creates the CONSUMER
+  span inside __next__() and its context does not survive the yield boundary into
+  user code. We therefore extract the context from msg.headers manually to attach
+  business logic child spans to the correct trace. The Kafka-level CONSUMER/PRODUCER
+  spans (transport layer) are still fully automatic.
+"""
+
+import json
+import logging
+import os
+import signal
+import time
+
+from kafka import KafkaConsumer, KafkaProducer
+
+from opentelemetry import trace
+from opentelemetry.propagate import extract
+from opentelemetry.trace import SpanKind, StatusCode
+
+from telemetry import init_tracing, shutdown_tracing
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+INPUT_TOPIC = os.environ.get("KAFKA_INPUT_TOPIC", "orders")
+OUTPUT_TOPIC = os.environ.get("KAFKA_OUTPUT_TOPIC", "order-results")
+CONSUMER_GROUP = os.environ.get("KAFKA_CONSUMER_GROUP", "order-processor")
+
+
+def headers_to_carrier(headers) -> dict:
+    """Convert Kafka message headers to an OTel text-map carrier."""
+    if not headers:
+        return {}
+    return {k: v.decode("utf-8") for k, v in headers if v is not None}
+
+
+def process_order(order: dict, tracer) -> dict:
+    """Business logic: validate and process an order."""
+    with tracer.start_as_current_span("process_order") as span:
+        order_id = order.get("order_id", "unknown")
+        amount = float(order.get("amount", 0))
+
+        span.set_attribute("order.id", order_id)
+        span.set_attribute("order.amount", amount)
+        span.set_attribute("order.item", order.get("item", ""))
+
+        time.sleep(0.05)  # simulate processing work
+
+        logger.info("Processed order %s (amount=%.2f)", order_id, amount)
+        return {
+            "order_id": order_id,
+            "status": "processed",
+            "processed_at": time.time(),
+        }
+
+
+def run() -> None:
+    provider = init_tracing()
+    tracer = trace.get_tracer(__name__)
+    running = True
+
+    # Auto-instrumented: KafkaConsumer and KafkaProducer are wrapped by
+    # KafkaInstrumentor after init_tracing() is called.
+    consumer = KafkaConsumer(
+        INPUT_TOPIC,
+        bootstrap_servers=BOOTSTRAP_SERVERS,
+        group_id=CONSUMER_GROUP,
+        auto_offset_reset="earliest",
+        enable_auto_commit=True,
+        value_deserializer=lambda b: json.loads(b.decode("utf-8")),
+    )
+
+    producer = KafkaProducer(
+        bootstrap_servers=BOOTSTRAP_SERVERS,
+        value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+    )
+
+    def handle_shutdown(sig, frame):
+        nonlocal running
+        logger.info("Received signal %s — stopping after current message…", sig)
+        running = False
+
+    signal.signal(signal.SIGINT, handle_shutdown)
+    signal.signal(signal.SIGTERM, handle_shutdown)
+
+    logger.info(
+        "Subscribed to '%s', publishing results to '%s' (group=%s)",
+        INPUT_TOPIC, OUTPUT_TOPIC, CONSUMER_GROUP,
+    )
+
+    try:
+        for msg in consumer:
+            if not running:
+                break
+
+            # The auto-instrumentor created a CONSUMER span inside __next__() but
+            # its context doesn't survive the yield into user code. We extract
+            # context from the message headers so our business logic spans are
+            # correctly parented to the producer's trace.
+            carrier = headers_to_carrier(msg.headers)
+            ctx = extract(carrier)
+
+            with tracer.start_as_current_span(
+                f"{INPUT_TOPIC} process",
+                context=ctx,
+                kind=SpanKind.CONSUMER,
+                attributes={
+                    "messaging.system": "kafka",
+                    "messaging.source.name": INPUT_TOPIC,
+                    "messaging.operation.type": "process",
+                    "messaging.message.offset": msg.offset,
+                    "messaging.kafka.consumer.group": CONSUMER_GROUP,
+                    "messaging.kafka.partition": msg.partition,
+                },
+            ) as span:
+                try:
+                    result = process_order(msg.value, tracer)
+
+                    # send() is auto-instrumented: creates a PRODUCER span and
+                    # injects traceparent into the outgoing message headers.
+                    producer.send(OUTPUT_TOPIC, value=result)
+                except Exception as exc:
+                    logger.exception(
+                        "Failed to process message at offset %d: %s",
+                        msg.offset, exc,
+                    )
+                    span.record_exception(exc)
+                    span.set_status(StatusCode.ERROR, str(exc))
+    finally:
+        consumer.close()
+        producer.flush()
+        shutdown_tracing(provider)
+        logger.info("Consumer shut down cleanly.")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/kafka-python/docker-compose.yaml
+++ b/python/kafka-python/docker-compose.yaml
@@ -1,0 +1,79 @@
+services:
+  kafka:
+    image: confluentinc/cp-kafka:7.7.1
+    container_name: kafka-python-kafka
+    ports:
+      - "9093:9092"
+      - "29093:29092"   # host-accessible external listener
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:29092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-python-kafka:9092,EXTERNAL://localhost:29093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-python-kafka:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_NUM_PARTITIONS: 2
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+    healthcheck:
+      test: ["CMD", "kafka-topics", "--bootstrap-server", "kafka-python-kafka:9092", "--list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  kafka-init:
+    image: confluentinc/cp-kafka:7.7.1
+    container_name: kafka-python-init
+    depends_on:
+      kafka:
+        condition: service_healthy
+    entrypoint: ["/bin/bash", "-c"]
+    command: >
+      "
+      kafka-topics --bootstrap-server kafka-python-kafka:9092 --create --if-not-exists
+        --topic orders --partitions 2 --replication-factor 1 &&
+      kafka-topics --bootstrap-server kafka-python-kafka:9092 --create --if-not-exists
+        --topic order-results --partitions 2 --replication-factor 1 &&
+      echo 'Topics ready.'
+      "
+
+  consumer:
+    build: .
+    container_name: kafka-python-consumer
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+    env_file:
+      - .env
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka-python-kafka:9092
+      KAFKA_INPUT_TOPIC: orders
+      KAFKA_OUTPUT_TOPIC: order-results
+      KAFKA_CONSUMER_GROUP: order-processor
+    restart: unless-stopped
+
+  # Run with: docker compose --profile generate up message-generator
+  message-generator:
+    build: .
+    container_name: kafka-python-generator
+    profiles: ["generate"]
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+    env_file:
+      - .env
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka-python-kafka:9092
+      KAFKA_INPUT_TOPIC: orders
+      MESSAGE_COUNT: "10"
+      MESSAGE_DELAY_SECONDS: "1.0"
+    command: ["python", "producer.py"]

--- a/python/kafka-python/producer.py
+++ b/python/kafka-python/producer.py
@@ -1,0 +1,74 @@
+"""
+Test message generator — sends sample order messages to the input topic.
+
+The auto-instrumentor (KafkaInstrumentor) automatically creates a PRODUCER span
+and injects W3C traceparent into the message headers on every producer.send() call.
+No manual inject() needed.
+
+Run this to generate messages for the consumer:
+    python producer.py
+
+Environment variables:
+    MESSAGE_COUNT         — number of messages to send (default: 5)
+    MESSAGE_DELAY_SECONDS — delay between messages in seconds (default: 1.0)
+"""
+
+import json
+import logging
+import os
+import random
+import time
+import uuid
+
+from kafka import KafkaProducer
+
+from telemetry import init_tracing, shutdown_tracing
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+INPUT_TOPIC = os.environ.get("KAFKA_INPUT_TOPIC", "orders")
+
+ITEMS = ["widget", "gadget", "doohickey", "thingamajig", "gizmo"]
+
+
+def run() -> None:
+    provider = init_tracing()
+
+    # Auto-instrumented: every producer.send() creates a PRODUCER span and
+    # injects traceparent into the message headers automatically.
+    producer = KafkaProducer(
+        bootstrap_servers=BOOTSTRAP_SERVERS,
+        value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+    )
+
+    count = int(os.environ.get("MESSAGE_COUNT", "5"))
+    delay = float(os.environ.get("MESSAGE_DELAY_SECONDS", "1.0"))
+
+    try:
+        for i in range(count):
+            order = {
+                "order_id": str(uuid.uuid4()),
+                "item": random.choice(ITEMS),
+                "amount": round(random.uniform(10.0, 500.0), 2),
+                "currency": "USD",
+            }
+            producer.send(INPUT_TOPIC, value=order)
+            logger.info(
+                "Sent order %s — %s @ %.2f %s",
+                order["order_id"], order["item"], order["amount"], order["currency"],
+            )
+            if i < count - 1:
+                time.sleep(delay)
+    finally:
+        producer.flush()
+        shutdown_tracing(provider)
+        logger.info("Done — sent %d message(s).", count)
+
+
+if __name__ == "__main__":
+    run()

--- a/python/kafka-python/requirements.txt
+++ b/python/kafka-python/requirements.txt
@@ -1,0 +1,5 @@
+kafka-python-ng==2.2.3
+opentelemetry-api==1.30.0
+opentelemetry-sdk==1.30.0
+opentelemetry-exporter-otlp-proto-http==1.30.0
+opentelemetry-instrumentation-kafka-python==0.51b0

--- a/python/kafka-python/telemetry.py
+++ b/python/kafka-python/telemetry.py
@@ -1,0 +1,66 @@
+"""
+Shared OpenTelemetry setup.
+
+Reads standard OTEL_* environment variables — no extra config needed.
+"""
+
+import logging
+import os
+
+from opentelemetry import trace
+from opentelemetry.baggage.propagation import W3CBaggagePropagator
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.kafka import KafkaInstrumentor
+from opentelemetry.propagate import set_global_textmap
+from opentelemetry.propagators.composite import CompositePropagator
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+logger = logging.getLogger(__name__)
+
+
+def init_tracing() -> TracerProvider:
+    """Initialize the global tracer provider and auto-instrument kafka-python.
+
+    Environment variables consumed:
+        OTEL_SERVICE_NAME            — service.name resource attribute
+        OTEL_EXPORTER_OTLP_ENDPOINT  — OTLP collector / Last9 endpoint
+        OTEL_EXPORTER_OTLP_HEADERS   — e.g. "Authorization=Basic <token>"
+        SERVICE_VERSION              — service.version resource attribute
+        DEPLOYMENT_ENVIRONMENT       — deployment.environment resource attribute
+    """
+    resource = Resource.create({
+        "service.name": os.environ.get("OTEL_SERVICE_NAME", "kafka-python-consumer"),
+        "service.version": os.environ.get("SERVICE_VERSION", "1.0.0"),
+        "deployment.environment": os.environ.get("DEPLOYMENT_ENVIRONMENT", "development"),
+    })
+
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+
+    set_global_textmap(CompositePropagator([
+        TraceContextTextMapPropagator(),
+        W3CBaggagePropagator(),
+    ]))
+
+    # One call auto-instruments all KafkaProducer and KafkaConsumer instances.
+    # It injects/extracts W3C traceparent headers and creates PRODUCER/CONSUMER
+    # spans automatically — no manual inject/extract needed in application code.
+    KafkaInstrumentor().instrument()
+
+    logger.info(
+        "Tracing initialised — service=%s endpoint=%s",
+        os.environ.get("OTEL_SERVICE_NAME", "kafka-python-consumer"),
+        os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "https://otlp.last9.io"),
+    )
+    return provider
+
+
+def shutdown_tracing(provider: TracerProvider) -> None:
+    """Flush pending spans and shut down gracefully."""
+    logger.info("Flushing spans before shutdown…")
+    provider.force_flush(timeout_millis=5000)
+    provider.shutdown()


### PR DESCRIPTION
## Summary

- Adds `python/kafka-consumer/` — a plain Python (no framework) service that consumes from a Kafka topic, processes messages, and publishes results to another topic
- Trace context propagated end-to-end via W3C `traceparent` headers on Kafka messages using `confluent-kafka`
- Verified live: producer → consumer → re-publisher spans appear in a single distributed trace in Last9

## Trace flow

```
kafka-producer  │  orders publish          (PRODUCER)
kafka-consumer  │  orders receive          (CONSUMER)  ← extracts traceparent header
kafka-consumer  │    process_order         (INTERNAL)
kafka-consumer  │    order-results publish (PRODUCER)  ← injects traceparent header
```

## Files

| File | Purpose |
|---|---|
| `consumer.py` | Long-running consumer + result publisher |
| `producer.py` | Test message generator |
| `telemetry.py` | Shared OTel init (TracerProvider + OTLP + W3C propagator) |
| `docker-compose.yaml` | Single-node Kafka (KRaft, no Zookeeper) + consumer service |
| `Dockerfile` | `python:3.12-slim` image |
| `requirements.txt` | `confluent-kafka==2.6.1`, `opentelemetry-*==1.30.0` |
| `.env.example` | All env vars with placeholders |

## Test plan

- [x] `docker compose up` starts Kafka (KRaft) and consumer cleanly
- [x] `docker compose --profile generate up message-generator` sends test messages
- [x] Traces appear in Last9 APM with producer and consumer spans linked in one trace
- [x] `SIGTERM` causes graceful shutdown with span flush

🤖 Generated with [Claude Code](https://claude.com/claude-code)