### PR TITLE
feat: add Java OTel HTTP body capture sample apps

### DIFF
--- a/java/http-body-capture-jakarta/.gitignore
+++ b/java/http-body-capture-jakarta/.gitignore
@@ -1,0 +1,2 @@
+target/
+*.jar

--- a/java/http-body-capture-jakarta/docker-compose.yml
+++ b/java/http-body-capture-jakarta/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.123.0
+    container_name: body-capture-jakarta-collector
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "4319:4317"   # OTLP gRPC (mapped to 4319 to avoid conflicts)
+      - "4320:4318"   # OTLP HTTP (mapped to 4320 to avoid conflicts)
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/java/http-body-capture-jakarta/otel-collector-config.yaml
+++ b/java/http-body-capture-jakarta/otel-collector-config.yaml
@@ -1,0 +1,22 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 1s
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/java/http-body-capture-jakarta/pom.xml
+++ b/java/http-body-capture-jakarta/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>http-body-capture-jakarta-demo</artifactId>
+    <version>1.0.0</version>
+    <name>http-body-capture-jakarta-demo</name>
+    <description>Spring Boot 3.2 (Jakarta) demo for java-otel-body-capture extension</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/java/http-body-capture-jakarta/src/main/java/com/example/bodycapture/ApiController.java
+++ b/java/http-body-capture-jakarta/src/main/java/com/example/bodycapture/ApiController.java
@@ -1,0 +1,43 @@
+package com.example.bodycapture;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RestController
+@RequestMapping("/api")
+public class ApiController {
+
+    private final Map<Integer, Map<String, Object>> users = new ConcurrentHashMap<>();
+    private final AtomicInteger idSeq = new AtomicInteger(1);
+
+    @PostMapping("/users")
+    public ResponseEntity<Map<String, Object>> createUser(@RequestBody Map<String, Object> body) {
+        int id = idSeq.getAndIncrement();
+        body.put("id", id);
+        users.put(id, body);
+        return ResponseEntity.status(201).body(body);
+    }
+
+    @GetMapping("/users/{id}")
+    public ResponseEntity<Map<String, Object>> getUser(@PathVariable int id) {
+        Map<String, Object> user = users.get(id);
+        if (user == null) {
+            return ResponseEntity.status(404).body(Map.of("error", "user not found", "id", id));
+        }
+        return ResponseEntity.ok(user);
+    }
+
+    @PostMapping("/echo")
+    public ResponseEntity<Map<String, Object>> echo(@RequestBody Map<String, Object> body) {
+        return ResponseEntity.ok(body);
+    }
+
+    @GetMapping("/health")
+    public ResponseEntity<Map<String, Object>> health() {
+        return ResponseEntity.ok(Map.of("status", "ok"));
+    }
+}

--- a/java/http-body-capture-jakarta/src/main/java/com/example/bodycapture/BodyCaptureApp.java
+++ b/java/http-body-capture-jakarta/src/main/java/com/example/bodycapture/BodyCaptureApp.java
@@ -1,0 +1,11 @@
+package com.example.bodycapture;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BodyCaptureApp {
+    public static void main(String[] args) {
+        SpringApplication.run(BodyCaptureApp.class, args);
+    }
+}

--- a/java/http-body-capture-jakarta/src/main/resources/application.properties
+++ b/java/http-body-capture-jakarta/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+server.port=8086
+spring.application.name=http-body-capture-jakarta-demo
+logging.level.org.springframework.web=INFO

--- a/java/http-body-capture-jakarta/start_app.sh
+++ b/java/http-body-capture-jakarta/start_app.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OTEL_AGENT_VERSION="2.13.3"
+OTEL_AGENT_JAR="$SCRIPT_DIR/otel-javaagent.jar"
+EXTENSION_JAR="$SCRIPT_DIR/last9-otel-body-capture.jar"
+EXTENSION_SRC="/Users/prathamesh2_/Projects/java-otel-body-capture"
+
+# Download OTel Java agent
+if [ ! -f "$OTEL_AGENT_JAR" ]; then
+    echo "Downloading OTel Java agent v${OTEL_AGENT_VERSION}..."
+    curl -fL -o "$OTEL_AGENT_JAR" \
+        "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_AGENT_VERSION}/opentelemetry-javaagent.jar"
+    echo "Done."
+fi
+
+# Build + copy the extension JAR
+echo "Building last9-otel-body-capture extension..."
+(cd "$EXTENSION_SRC" && gradle shadowJar --no-configuration-cache -q)
+cp "$EXTENSION_SRC/lib/build/libs/lib-0.1.0.jar" "$EXTENSION_JAR"
+echo "Extension JAR ready: $EXTENSION_JAR"
+
+# Build the sample app
+echo "Building sample app..."
+(cd "$SCRIPT_DIR" && mvn package -q -DskipTests)
+
+# Start with OTel agent + extension
+exec java \
+    -javaagent:"$OTEL_AGENT_JAR" \
+    -Dotel.javaagent.extensions="$EXTENSION_JAR" \
+    -Dotel.service.name=http-body-capture-jakarta-demo \
+    -Dotel.exporter.otlp.endpoint=http://localhost:4319 \
+    -Dotel.exporter.otlp.protocol=grpc \
+    -Dotel.metrics.exporter=none \
+    -Dotel.logs.exporter=none \
+    -Dotel.bodycapture.enabled=true \
+    -Dotel.bodycapture.capture_on_error_only=false \
+    -jar "$SCRIPT_DIR/target/http-body-capture-jakarta-demo-1.0.0.jar"

--- a/java/http-body-capture-jakarta/test.sh
+++ b/java/http-body-capture-jakarta/test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# End-to-end test for Spring Boot 3.2 (Jakarta servlet) with last9-otel-body-capture extension.
+# Verifies that http.request.body and http.response.body appear as span attributes.
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APP_URL="http://localhost:8086"
+PASS=0
+FAIL=0
+
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+info()  { printf '\033[34m%s\033[0m\n' "$*"; }
+
+check() {
+    local desc="$1" expected="$2"
+    if docker logs body-capture-jakarta-collector 2>&1 | grep -q "$expected"; then
+        green "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        red   "  FAIL: $desc (expected to find '$expected' in collector logs)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ── 1. Start infrastructure ───────────────────────────────────────────────────
+info "Starting OTel collector..."
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" up -d
+
+# ── 2. Start app in background ────────────────────────────────────────────────
+info "Starting sample app (Spring Boot 3.2 / Jakarta)..."
+"$SCRIPT_DIR/start_app.sh" > /tmp/bodycapture-jakarta-app.log 2>&1 &
+APP_PID=$!
+
+info "Waiting for app to be ready..."
+for i in $(seq 1 60); do
+    if curl -sf "$APP_URL/api/health" > /dev/null 2>&1; then
+        green "App is up."
+        break
+    fi
+    if [ $i -eq 60 ]; then
+        red "App did not start in time. Logs:"
+        tail -30 /tmp/bodycapture-jakarta-app.log
+        kill $APP_PID 2>/dev/null || true
+        docker compose -f "$SCRIPT_DIR/docker-compose.yml" down
+        exit 1
+    fi
+    sleep 2
+done
+
+# ── 3. Send test requests ─────────────────────────────────────────────────────
+info ""
+info "Sending test requests..."
+
+curl -sf -X POST "$APP_URL/api/echo" \
+    -H "Content-Type: application/json" \
+    -d '{"message":"hello world","user":"alice"}' > /dev/null
+
+curl -sf -X POST "$APP_URL/api/users" \
+    -H "Content-Type: application/json" \
+    -d '{"name":"bob","email":"bob@example.com"}' > /dev/null
+
+curl -sf "$APP_URL/api/users/1" > /dev/null
+curl -sf "$APP_URL/api/users/999" > /dev/null || true
+
+info "Waiting for spans to flush to collector..."
+sleep 5
+
+# ── 4. Verify span attributes ─────────────────────────────────────────────────
+info ""
+info "Checking collector logs for body attributes..."
+
+check "http.request.body present on POST /api/echo"  "http.request.body"
+check "http.response.body present on POST /api/echo" "http.response.body"
+check "POST /api/users request body captured"        "bob@example.com"
+check "hello world captured in request body"         "hello world"
+
+# ── 5. Teardown ───────────────────────────────────────────────────────────────
+info ""
+info "Stopping app and collector..."
+kill $APP_PID 2>/dev/null || true
+wait $APP_PID 2>/dev/null || true
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" down
+
+# ── 6. Results ────────────────────────────────────────────────────────────────
+info ""
+echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && green "All tests passed." || { red "Some tests failed."; exit 1; }

--- a/java/http-body-capture/.gitignore
+++ b/java/http-body-capture/.gitignore
@@ -1,0 +1,2 @@
+target/
+*.jar

--- a/java/http-body-capture/docker-compose.yml
+++ b/java/http-body-capture/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.123.0
+    container_name: body-capture-collector
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "4317:4317"   # OTLP gRPC
+      - "4318:4318"   # OTLP HTTP
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/java/http-body-capture/otel-collector-config.yaml
+++ b/java/http-body-capture/otel-collector-config.yaml
@@ -1,0 +1,22 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 1s
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/java/http-body-capture/pom.xml
+++ b/java/http-body-capture/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.18</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>http-body-capture-demo</artifactId>
+    <version>1.0.0</version>
+    <name>http-body-capture-demo</name>
+    <description>Spring Boot demo for java-otel-body-capture extension</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/java/http-body-capture/src/main/java/com/example/bodycapture/ApiController.java
+++ b/java/http-body-capture/src/main/java/com/example/bodycapture/ApiController.java
@@ -1,0 +1,47 @@
+package com.example.bodycapture;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RestController
+@RequestMapping("/api")
+public class ApiController {
+
+    private final Map<Integer, Map<String, Object>> users = new ConcurrentHashMap<>();
+    private final AtomicInteger idSeq = new AtomicInteger(1);
+
+    // POST /api/users — create a user, return it
+    @PostMapping("/users")
+    public ResponseEntity<Map<String, Object>> createUser(@RequestBody Map<String, Object> body) {
+        int id = idSeq.getAndIncrement();
+        body.put("id", id);
+        users.put(id, body);
+        return ResponseEntity.status(201).body(body);
+    }
+
+    // GET /api/users/{id} — fetch a user
+    @GetMapping("/users/{id}")
+    public ResponseEntity<Map<String, Object>> getUser(@PathVariable int id) {
+        Map<String, Object> user = users.get(id);
+        if (user == null) {
+            return ResponseEntity.status(404).body(Map.of("error", "user not found", "id", id));
+        }
+        return ResponseEntity.ok(user);
+    }
+
+    // POST /api/echo — echo the request body back (useful for verifying body capture)
+    @PostMapping("/echo")
+    public ResponseEntity<Map<String, Object>> echo(@RequestBody Map<String, Object> body) {
+        return ResponseEntity.ok(body);
+    }
+
+    // GET /api/health
+    @GetMapping("/health")
+    public ResponseEntity<Map<String, Object>> health() {
+        return ResponseEntity.ok(Map.of("status", "ok"));
+    }
+}

--- a/java/http-body-capture/src/main/java/com/example/bodycapture/BodyCaptureApp.java
+++ b/java/http-body-capture/src/main/java/com/example/bodycapture/BodyCaptureApp.java
@@ -1,0 +1,11 @@
+package com.example.bodycapture;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BodyCaptureApp {
+    public static void main(String[] args) {
+        SpringApplication.run(BodyCaptureApp.class, args);
+    }
+}

--- a/java/http-body-capture/src/main/resources/application.properties
+++ b/java/http-body-capture/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+server.port=8085
+spring.application.name=http-body-capture-demo
+# Disable Spring's own request logging to avoid noise
+logging.level.org.springframework.web=INFO

--- a/java/http-body-capture/start_app.sh
+++ b/java/http-body-capture/start_app.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OTEL_AGENT_VERSION="2.13.3"
+OTEL_AGENT_JAR="$SCRIPT_DIR/otel-javaagent.jar"
+EXTENSION_JAR="$SCRIPT_DIR/last9-otel-body-capture.jar"
+EXTENSION_SRC="$HOME/Projects/java-otel-body-capture"
+
+# Download OTel Java agent
+if [ ! -f "$OTEL_AGENT_JAR" ]; then
+    echo "Downloading OTel Java agent v${OTEL_AGENT_VERSION}..."
+    curl -fL -o "$OTEL_AGENT_JAR" \
+        "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_AGENT_VERSION}/opentelemetry-javaagent.jar"
+    echo "Done."
+fi
+
+# Build + copy the extension JAR
+echo "Building last9-otel-body-capture extension..."
+(cd "$EXTENSION_SRC" && gradle shadowJar --no-configuration-cache -q)
+cp "$EXTENSION_SRC/lib/build/libs/lib-0.1.0.jar" "$EXTENSION_JAR"
+echo "Extension JAR ready: $EXTENSION_JAR"
+
+# Build the sample app
+echo "Building sample app..."
+(cd "$SCRIPT_DIR" && mvn package -q -DskipTests)
+
+# Start with OTel agent + extension
+exec java \
+    -javaagent:"$OTEL_AGENT_JAR" \
+    -Dotel.javaagent.extensions="$EXTENSION_JAR" \
+    -Dotel.service.name=http-body-capture-demo \
+    -Dotel.exporter.otlp.endpoint=http://localhost:4317 \
+    -Dotel.exporter.otlp.protocol=grpc \
+    -Dotel.metrics.exporter=none \
+    -Dotel.logs.exporter=none \
+    -Dotel.bodycapture.enabled=true \
+    -Dotel.bodycapture.capture_on_error_only=false \
+    -jar "$SCRIPT_DIR/target/http-body-capture-demo-1.0.0.jar"

--- a/java/http-body-capture/test.sh
+++ b/java/http-body-capture/test.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# End-to-end test: verifies that http.request.body and http.response.body
+# appear as span attributes when the last9-otel-body-capture extension is active.
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APP_URL="http://localhost:8085"
+PASS=0
+FAIL=0
+
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+info()  { printf '\033[34m%s\033[0m\n' "$*"; }
+
+check() {
+    local desc="$1" expected="$2"
+    if docker logs body-capture-collector 2>&1 | grep -q "$expected"; then
+        green "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        red   "  FAIL: $desc (expected to find '$expected' in collector logs)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ── 1. Start infrastructure ───────────────────────────────────────────────────
+info "Starting OTel collector..."
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" up -d
+sleep 2
+
+# ── 2. Start app in background ────────────────────────────────────────────────
+info "Starting sample app..."
+"$SCRIPT_DIR/start_app.sh" > /tmp/bodycapture-app.log 2>&1 &
+APP_PID=$!
+
+info "Waiting for app to be ready..."
+for i in $(seq 1 30); do
+    if curl -sf "$APP_URL/api/health" > /dev/null 2>&1; then
+        green "App is up."
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        red "App did not start in time. Logs:"
+        tail -30 /tmp/bodycapture-app.log
+        kill $APP_PID 2>/dev/null || true
+        docker compose -f "$SCRIPT_DIR/docker-compose.yml" down
+        exit 1
+    fi
+    sleep 2
+done
+
+# ── 3. Send test requests ─────────────────────────────────────────────────────
+info ""
+info "Sending test requests..."
+
+# Test 1: echo endpoint — request and response body should both appear
+curl -sf -X POST "$APP_URL/api/echo" \
+    -H "Content-Type: application/json" \
+    -d '{"message":"hello world","user":"alice"}' > /dev/null
+
+# Test 2: create a user
+curl -sf -X POST "$APP_URL/api/users" \
+    -H "Content-Type: application/json" \
+    -d '{"name":"bob","email":"bob@example.com"}' > /dev/null
+
+# Test 3: fetch the user that was just created
+curl -sf "$APP_URL/api/users/1" > /dev/null
+
+# Test 4: 404 — verify error body appears too
+curl -sf "$APP_URL/api/users/999" > /dev/null || true
+
+# Wait for OTel batch flush (batch timeout is 1s, add buffer)
+info "Waiting for spans to flush to collector..."
+sleep 5
+
+# ── 4. Verify span attributes ─────────────────────────────────────────────────
+info ""
+info "Checking collector logs for body attributes..."
+
+check "http.request.body present on POST /api/echo"  "http.request.body"
+check "http.response.body present on POST /api/echo" "http.response.body"
+check "POST /api/users request body captured"        "bob@example.com"
+check "hello world captured in request body"         "hello world"
+
+# ── 5. Teardown ───────────────────────────────────────────────────────────────
+info ""
+info "Stopping app and collector..."
+kill $APP_PID 2>/dev/null || true
+wait $APP_PID 2>/dev/null || true
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" down
+
+# ── 6. Results ────────────────────────────────────────────────────────────────
+info ""
+echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && green "All tests passed." || { red "Some tests failed."; exit 1; }

--- a/otel-collector/redis-cloud/.env.example
+++ b/otel-collector/redis-cloud/.env.example
@@ -1,0 +1,13 @@
+# Last9 OTLP credentials
+# Get these from: https://app.last9.io → Integrations → OTLP
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.last9.io
+OTEL_EXPORTER_OTLP_HEADERS_AUTHORIZATION=Basic <your-base64-credentials>
+
+# Redis connection
+# Local dev (docker compose default): redis:6379
+# Redis Cloud: your-endpoint.redis.cloud:port (e.g. redis-12345.c123.us-east-1-2.ec2.cloud.redislabs.com:12345)
+REDIS_ENDPOINT=redis:6379
+
+# Redis password (leave empty for passwordless local Redis)
+# Redis Cloud: set this to your database password
+REDIS_PASSWORD=

--- a/otel-collector/redis-cloud/.gitignore
+++ b/otel-collector/redis-cloud/.gitignore
@@ -1,0 +1,3 @@
+.env
+.env.local
+*.log

--- a/otel-collector/redis-cloud/README.md
+++ b/otel-collector/redis-cloud/README.md
@@ -1,0 +1,98 @@
+# Redis Cloud + OTel Collector
+
+Collects Redis metrics using the OpenTelemetry `redis` receiver and ships them to Last9. Works with Redis Cloud (Essentials and Pro), self-hosted Redis, and local dev.
+
+## What it collects
+
+OTel metric names use dots; they arrive in Last9 with dots replaced by underscores (e.g. `redis.memory.used` → `redis_memory_used`).
+
+- **Memory**: `redis_memory_used`, `redis_memory_peak`, `redis_memory_rss`, `redis_memory_fragmentation_ratio`, `redis_maxmemory`
+- **Cache efficiency**: `redis_keyspace_hits`, `redis_keyspace_misses`
+- **Evictions**: `redis_keys_evicted`, `redis_keys_expired`
+- **Connections**: `redis_clients_connected`, `redis_clients_blocked`, `redis_connections_rejected`
+- **Throughput**: `redis_commands`, `redis_commands_processed`, `redis_net_input`, `redis_net_output`
+- **Replication**: `redis_replication_offset`, `redis_slaves_connected`, `redis_role`
+- **Persistence**: `redis_rdb_changes_since_last_save`, `redis_uptime`
+- **Database**: `redis_db_keys`, `redis_db_expires`, `redis_db_avg_ttl`
+- **Host**: CPU, memory, disk, network via `hostmetrics`
+
+## Prerequisites
+
+- Docker and Docker Compose
+- Redis Cloud account (or local Redis for dev)
+- Last9 account with OTLP credentials
+
+## Quick start (local dev)
+
+```bash
+cp .env.example .env
+# Fill in your Last9 credentials in .env
+
+docker compose up -d
+
+# Generate load to produce metrics
+docker compose --profile generate up load-generator
+
+# Check collector output
+docker logs redis-otel-collector 2>&1 | grep -E "redis\.|Name:"
+
+# Clean up
+docker compose down
+```
+
+## Connecting to Redis Cloud
+
+1. Get your endpoint from the Redis Cloud console (database → General → Endpoint)
+2. Update `.env`:
+
+```env
+REDIS_ENDPOINT=redis-12345.c123.us-east-1-2.ec2.cloud.redislabs.com:12345
+REDIS_PASSWORD=your-database-password
+```
+
+3. Update `otel-collector-config.yaml` to enable TLS (Redis Cloud requires it):
+
+```yaml
+receivers:
+  redis:
+    tls:
+      insecure: false
+      insecure_skip_verify: true  # or provide ca_file for full verification
+```
+
+4. Run the collector (no local Redis service needed):
+
+```bash
+docker compose up otel-collector
+```
+
+## Configuration
+
+| File | Purpose |
+|------|---------|
+| `otel-collector-config.yaml` | Receiver, processors, exporter config |
+| `.env` | OTLP credentials and Redis connection |
+| `docker-compose.yaml` | Local Redis + OTel Collector services |
+| `generate-load.sh` | Generates keys, hits, misses, and expiry events |
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Last9 OTLP endpoint |
+| `OTEL_EXPORTER_OTLP_HEADERS_AUTHORIZATION` | `Basic <base64>` auth header |
+| `REDIS_ENDPOINT` | Redis host:port (default: `redis:6379`) |
+| `REDIS_PASSWORD` | Redis password (empty for passwordless) |
+
+## Verification
+
+```bash
+# Confirm metrics are flowing in collector logs
+docker logs redis-otel-collector 2>&1 | grep "redis.memory"
+
+# Check Redis stats directly
+redis-cli -h localhost -p 6379 INFO stats
+redis-cli -h localhost -p 6379 INFO memory
+```
+
+In Last9 metrics explorer, search for `redis_` — metric names arrive with dots converted to underscores (e.g. `redis_memory_used`, `redis_keyspace_hits`).

--- a/otel-collector/redis-cloud/docker-compose.yaml
+++ b/otel-collector/redis-cloud/docker-compose.yaml
@@ -1,0 +1,40 @@
+services:
+  redis:
+    image: redis:7.4
+    container_name: redis-local
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.144.0
+    container_name: redis-otel-collector
+    command: ["--config=/etc/otel/config.yaml"]
+    depends_on:
+      redis:
+        condition: service_healthy
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel/config.yaml:ro
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT}
+      - OTEL_EXPORTER_OTLP_HEADERS_AUTHORIZATION=${OTEL_EXPORTER_OTLP_HEADERS_AUTHORIZATION}
+      - REDIS_ENDPOINT=${REDIS_ENDPOINT:-redis:6379}
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-}
+    ports:
+      - "13137:13133"
+
+  load-generator:
+    image: redis:7.4
+    container_name: redis-load-generator
+    profiles: ["generate"]
+    depends_on:
+      redis:
+        condition: service_healthy
+    volumes:
+      - ./generate-load.sh:/scripts/generate-load.sh:ro
+    entrypoint: ["bash", "/scripts/generate-load.sh"]

--- a/otel-collector/redis-cloud/generate-load.sh
+++ b/otel-collector/redis-cloud/generate-load.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Generates Redis load to produce meaningful metrics for testing
+
+REDIS_HOST=${REDIS_HOST:-redis}
+REDIS_PORT=${REDIS_PORT:-6379}
+CLI="redis-cli -h $REDIS_HOST -p $REDIS_PORT"
+
+echo "Seeding keys..."
+for i in $(seq 1 1000); do
+  $CLI SET "key:$i" "value:$i" EX 300 > /dev/null
+done
+
+echo "Seeding hashes..."
+for i in $(seq 1 200); do
+  $CLI HSET "user:$i" name "user$i" email "user$i@example.com" score "$((RANDOM % 1000))" > /dev/null
+done
+
+echo "Seeding lists..."
+for i in $(seq 1 100); do
+  $CLI RPUSH "queue:$i" "job1" "job2" "job3" > /dev/null
+done
+
+echo "Generating keyspace hits..."
+for i in $(seq 1 800); do
+  $CLI GET "key:$i" > /dev/null
+done
+
+echo "Generating keyspace misses..."
+for i in $(seq 2000 2200); do
+  $CLI GET "key:$i" > /dev/null
+done
+
+echo "Triggering key expiry (short TTL)..."
+for i in $(seq 1 50); do
+  $CLI SET "expire:$i" "temp" EX 1 > /dev/null
+done
+sleep 2
+
+echo "Load generation complete."
+$CLI INFO stats | grep -E "keyspace_hits|keyspace_misses|expired_keys|evicted_keys"

--- a/otel-collector/redis-cloud/otel-collector-config.yaml
+++ b/otel-collector/redis-cloud/otel-collector-config.yaml
@@ -1,0 +1,76 @@
+receivers:
+  redis:
+    endpoint: "${env:REDIS_ENDPOINT}"
+    collection_interval: 10s
+    password: "${env:REDIS_PASSWORD}"
+    # Local dev (no TLS): insecure: true
+    # Redis Cloud (TLS): set insecure: false, insecure_skip_verify: true
+    tls:
+      insecure: true
+    metrics:
+      # Enable maxmemory to track configured memory limit vs actual usage
+      redis.maxmemory:
+        enabled: true
+      # Enable role to distinguish primary from replicas
+      redis.role:
+        enabled: true
+
+  hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.logical.count:
+            enabled: true
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+          system.memory.limit:
+            enabled: true
+      load:
+      disk:
+      filesystem:
+        metrics:
+          system.filesystem.utilization:
+            enabled: true
+      network:
+      paging:
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 10000
+    send_batch_max_size: 10000
+
+  resourcedetection/system:
+    detectors: ["system"]
+    system:
+      hostname_sources: ["os"]
+
+  resource/redis:
+    attributes:
+      - key: service.name
+        value: redis
+        action: insert
+      - key: db.system
+        value: redis
+        action: insert
+      - key: deployment.environment
+        value: dev
+        action: insert
+
+exporters:
+  otlp_grpc/last9:
+    endpoint: "${env:OTEL_EXPORTER_OTLP_ENDPOINT}"
+    headers:
+      "Authorization": "${env:OTEL_EXPORTER_OTLP_HEADERS_AUTHORIZATION}"
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    metrics:
+      receivers: [redis, hostmetrics]
+      processors: [batch, resourcedetection/system, resource/redis]
+      exporters: [otlp_grpc/last9, debug]

--- a/python/kafka-consumer/.env.example
+++ b/python/kafka-consumer/.env.example
@@ -1,0 +1,18 @@
+# Last9 OTLP credentials — get these from https://app.last9.io
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.last9.io
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <your-base64-encoded-credentials>
+
+# Service metadata
+OTEL_SERVICE_NAME=kafka-consumer
+SERVICE_VERSION=1.0.0
+DEPLOYMENT_ENVIRONMENT=production
+
+# Kafka
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+KAFKA_INPUT_TOPIC=orders
+KAFKA_OUTPUT_TOPIC=order-results
+KAFKA_CONSUMER_GROUP=order-processor
+
+# Test producer (producer.py only)
+MESSAGE_COUNT=5
+MESSAGE_DELAY_SECONDS=1.0

--- a/python/kafka-consumer/.gitignore
+++ b/python/kafka-consumer/.gitignore
@@ -1,0 +1,22 @@
+# Secrets
+.env
+.env.local
+.env.*.local
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log

--- a/python/kafka-consumer/Dockerfile
+++ b/python/kafka-consumer/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "consumer.py"]

--- a/python/kafka-consumer/README.md
+++ b/python/kafka-consumer/README.md
@@ -1,0 +1,102 @@
+# Vanilla Python Kafka Consumer with OpenTelemetry
+
+Plain Python service (no framework) that consumes messages from a Kafka topic,
+processes them, and publishes results to another topic. Trace context is propagated
+end-to-end via W3C `traceparent` headers on each Kafka message.
+
+## How trace context flows
+
+```
+producer.py  ──[traceparent header]──▶  Kafka: orders
+                                               │
+                                          consumer.py
+                                               │
+                                       extract context
+                                               │
+                                     CONSUMER span (child of producer)
+                                       │           │
+                               process_order    PRODUCER span
+                                  (child)            │
+                                               inject context
+                                               [traceparent header]
+                                                     │
+                                        Kafka: order-results ──▶ next service
+```
+
+## Prerequisites
+
+- Python 3.11+
+- Docker and Docker Compose (for local Kafka)
+
+## Quick Start
+
+**1. Install dependencies**
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+**2. Configure credentials**
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` — set your Last9 OTLP endpoint and auth header. Get them from
+[app.last9.io](https://app.last9.io) → Integrations → OpenTelemetry.
+
+**3. Start Kafka and the consumer**
+
+```bash
+docker compose up --build
+```
+
+This starts a single-node Kafka (KRaft, no Zookeeper) and the consumer service.
+
+**4. Send test messages**
+
+```bash
+docker compose --profile generate up message-generator
+```
+
+Or run locally (with Kafka port-forwarded):
+
+```bash
+source .env && python producer.py
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `https://otlp.last9.io` | Last9 OTLP endpoint |
+| `OTEL_EXPORTER_OTLP_HEADERS` | — | `Authorization=Basic <token>` |
+| `OTEL_SERVICE_NAME` | `kafka-consumer` | Service name in traces |
+| `SERVICE_VERSION` | `1.0.0` | `service.version` resource attribute |
+| `DEPLOYMENT_ENVIRONMENT` | `development` | `deployment.environment` resource attribute |
+| `KAFKA_BOOTSTRAP_SERVERS` | `localhost:9092` | Kafka broker address |
+| `KAFKA_INPUT_TOPIC` | `orders` | Topic to consume from |
+| `KAFKA_OUTPUT_TOPIC` | `order-results` | Topic to publish results to |
+| `KAFKA_CONSUMER_GROUP` | `order-processor` | Consumer group ID |
+| `MESSAGE_COUNT` | `5` | Messages sent by `producer.py` |
+| `MESSAGE_DELAY_SECONDS` | `1.0` | Delay between messages in `producer.py` |
+
+## Running without Docker
+
+Start Kafka separately, then:
+
+```bash
+# Port 29092 is the host-accessible listener (29092→Kafka external, 9092 is Docker-internal only)
+export KAFKA_BOOTSTRAP_SERVERS=localhost:29092
+source .env
+python consumer.py          # terminal 1 — long-running consumer
+python producer.py          # terminal 2 — sends 5 test messages
+```
+
+## Verification
+
+Sign in to [Last9 Dashboard](https://app.last9.io) → APM → Traces. Filter by
+`service.name = kafka-consumer`. You should see connected spans showing the full
+producer → consumer → result-publisher chain within a single trace.

--- a/python/kafka-consumer/consumer.py
+++ b/python/kafka-consumer/consumer.py
@@ -1,0 +1,197 @@
+"""
+Vanilla Python Kafka consumer with OpenTelemetry trace context propagation.
+
+Reads orders from KAFKA_INPUT_TOPIC, processes them, and publishes results
+to KAFKA_OUTPUT_TOPIC. Trace context travels across services via W3C
+traceparent/tracestate headers on each Kafka message.
+
+Trace flow:
+  [producer] --[traceparent header]--> Kafka: orders
+                                            |
+                                       consumer.py
+                                            |
+                                    extract context   <-- W3C traceparent from headers
+                                            |
+                                  [CONSUMER span]     <-- child of producer's span
+                                            |
+                                  [process_order]     <-- child span (business logic)
+                                            |
+                                  [PRODUCER span]     <-- child span, inject new context
+                                            |
+                               Kafka: order-results --[traceparent header]--> next service
+"""
+
+import json
+import logging
+import os
+import signal
+import time
+
+from confluent_kafka import Consumer, KafkaError, KafkaException, Producer
+
+from opentelemetry import trace
+from opentelemetry.propagate import extract, inject
+from opentelemetry.trace import SpanKind, StatusCode
+
+from telemetry import init_tracing, shutdown_tracing
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+INPUT_TOPIC = os.environ.get("KAFKA_INPUT_TOPIC", "orders")
+OUTPUT_TOPIC = os.environ.get("KAFKA_OUTPUT_TOPIC", "order-results")
+CONSUMER_GROUP = os.environ.get("KAFKA_CONSUMER_GROUP", "order-processor")
+
+
+# ---------------------------------------------------------------------------
+# Header helpers
+# ---------------------------------------------------------------------------
+
+def headers_to_carrier(headers: list) -> dict:
+    """Convert Kafka message headers to an OTel text-map carrier."""
+    if not headers:
+        return {}
+    return {k: v.decode("utf-8") for k, v in headers if v is not None}
+
+
+def carrier_to_headers(carrier: dict) -> list:
+    """Convert an OTel text-map carrier to Kafka message headers."""
+    return [(k, v.encode("utf-8")) for k, v in carrier.items()]
+
+
+# ---------------------------------------------------------------------------
+# Business logic
+# ---------------------------------------------------------------------------
+
+def process_order(order: dict, tracer) -> dict:
+    """Process an order and return a result dict."""
+    with tracer.start_as_current_span("process_order") as span:
+        order_id = order.get("order_id", "unknown")
+        amount = float(order.get("amount", 0))
+
+        span.set_attribute("order.id", order_id)
+        span.set_attribute("order.amount", amount)
+        span.set_attribute("order.item", order.get("item", ""))
+
+        time.sleep(0.05)  # simulate processing work
+
+        logger.info("Processed order %s (amount=%.2f)", order_id, amount)
+        return {
+            "order_id": order_id,
+            "status": "processed",
+            "processed_at": time.time(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Output producer
+# ---------------------------------------------------------------------------
+
+def publish_result(kproducer: Producer, result: dict, tracer) -> None:
+    """Publish a result to the output topic with trace context in headers."""
+    with tracer.start_as_current_span(
+        f"{OUTPUT_TOPIC} publish",
+        kind=SpanKind.PRODUCER,
+        attributes={
+            "messaging.system": "kafka",
+            "messaging.destination.name": OUTPUT_TOPIC,
+            "messaging.operation.type": "publish",
+            "order.id": result.get("order_id", ""),
+        },
+    ):
+        carrier: dict = {}
+        inject(carrier)  # captures the current PRODUCER span context
+        headers = carrier_to_headers(carrier)
+
+        kproducer.produce(
+            topic=OUTPUT_TOPIC,
+            value=json.dumps(result).encode("utf-8"),
+            headers=headers,
+        )
+        kproducer.poll(0)  # trigger delivery callbacks (non-blocking)
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+def run() -> None:
+    provider = init_tracing()
+    tracer = trace.get_tracer(__name__)
+    running = True
+
+    consumer = Consumer({
+        "bootstrap.servers": BOOTSTRAP_SERVERS,
+        "group.id": CONSUMER_GROUP,
+        "auto.offset.reset": "earliest",
+        "enable.auto.commit": True,
+    })
+
+    kproducer = Producer({"bootstrap.servers": BOOTSTRAP_SERVERS})
+
+    def handle_shutdown(sig, frame):
+        nonlocal running
+        logger.info("Received signal %s — shutting down after current message…", sig)
+        running = False
+
+    signal.signal(signal.SIGINT, handle_shutdown)
+    signal.signal(signal.SIGTERM, handle_shutdown)
+
+    consumer.subscribe([INPUT_TOPIC])
+    logger.info(
+        "Subscribed to '%s', publishing results to '%s' (group=%s)",
+        INPUT_TOPIC, OUTPUT_TOPIC, CONSUMER_GROUP,
+    )
+
+    try:
+        while running:
+            msg = consumer.poll(timeout=1.0)
+            if msg is None:
+                continue
+
+            if msg.error():
+                if msg.error().code() == KafkaError._PARTITION_EOF:
+                    continue
+                raise KafkaException(msg.error())
+
+            # Extract W3C traceparent from Kafka message headers
+            carrier = headers_to_carrier(msg.headers() or [])
+            parent_ctx = extract(carrier)
+
+            with tracer.start_as_current_span(
+                f"{INPUT_TOPIC} receive",
+                context=parent_ctx,
+                kind=SpanKind.CONSUMER,
+                attributes={
+                    "messaging.system": "kafka",
+                    "messaging.source.name": INPUT_TOPIC,
+                    "messaging.operation.type": "receive",
+                    "messaging.message.offset": msg.offset(),
+                    "messaging.kafka.consumer.group": CONSUMER_GROUP,
+                    "messaging.kafka.partition": msg.partition(),
+                },
+            ) as span:
+                try:
+                    payload = json.loads(msg.value().decode("utf-8"))
+                    result = process_order(payload, tracer)
+                    publish_result(kproducer, result, tracer)
+                except Exception as exc:
+                    logger.exception(
+                        "Failed to process message at offset %d: %s",
+                        msg.offset(), exc,
+                    )
+                    span.record_exception(exc)
+                    span.set_status(StatusCode.ERROR, str(exc))
+    finally:
+        consumer.close()
+        kproducer.flush(timeout=5)
+        shutdown_tracing(provider)
+        logger.info("Consumer shut down cleanly.")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/kafka-consumer/docker-compose.yaml
+++ b/python/kafka-consumer/docker-compose.yaml
@@ -1,0 +1,79 @@
+services:
+  kafka:
+    image: confluentinc/cp-kafka:7.7.1
+    container_name: kafka
+    ports:
+      - "9092:9092"
+      - "29092:29092"   # host-accessible external listener
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:29092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:29092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_NUM_PARTITIONS: 2
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+    healthcheck:
+      test: ["CMD", "kafka-topics", "--bootstrap-server", "kafka:9092", "--list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  kafka-init:
+    image: confluentinc/cp-kafka:7.7.1
+    container_name: kafka-init
+    depends_on:
+      kafka:
+        condition: service_healthy
+    entrypoint: ["/bin/bash", "-c"]
+    command: >
+      "
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists
+        --topic orders --partitions 2 --replication-factor 1 &&
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists
+        --topic order-results --partitions 2 --replication-factor 1 &&
+      echo 'Topics ready.'
+      "
+
+  consumer:
+    build: .
+    container_name: kafka-consumer
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+    env_file:
+      - .env
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      KAFKA_INPUT_TOPIC: orders
+      KAFKA_OUTPUT_TOPIC: order-results
+      KAFKA_CONSUMER_GROUP: order-processor
+    restart: unless-stopped
+
+  # Run with: docker compose --profile generate up message-generator
+  message-generator:
+    build: .
+    container_name: kafka-message-generator
+    profiles: ["generate"]
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+    env_file:
+      - .env
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      KAFKA_INPUT_TOPIC: orders
+      MESSAGE_COUNT: "10"
+      MESSAGE_DELAY_SECONDS: "1.0"
+    command: ["python", "producer.py"]

--- a/python/kafka-consumer/producer.py
+++ b/python/kafka-consumer/producer.py
@@ -1,0 +1,98 @@
+"""
+Test message generator — sends sample order messages to the input topic
+with W3C trace context injected into Kafka headers.
+
+Run this to generate messages for the consumer:
+    python producer.py
+
+Environment variables:
+    MESSAGE_COUNT         — number of messages to send (default: 5)
+    MESSAGE_DELAY_SECONDS — delay between messages in seconds (default: 1.0)
+"""
+
+import json
+import logging
+import os
+import random
+import time
+import uuid
+
+from confluent_kafka import Producer as KafkaProducer
+
+from opentelemetry import trace
+from opentelemetry.propagate import inject
+from opentelemetry.trace import SpanKind
+
+from telemetry import init_tracing, shutdown_tracing
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+INPUT_TOPIC = os.environ.get("KAFKA_INPUT_TOPIC", "orders")
+
+ITEMS = ["widget", "gadget", "doohickey", "thingamajig", "gizmo"]
+
+
+def send_order(kproducer: KafkaProducer, tracer) -> None:
+    order = {
+        "order_id": str(uuid.uuid4()),
+        "item": random.choice(ITEMS),
+        "amount": round(random.uniform(10.0, 500.0), 2),
+        "currency": "USD",
+    }
+
+    with tracer.start_as_current_span(
+        f"{INPUT_TOPIC} publish",
+        kind=SpanKind.PRODUCER,
+        attributes={
+            "messaging.system": "kafka",
+            "messaging.destination.name": INPUT_TOPIC,
+            "messaging.operation.type": "publish",
+            "order.id": order["order_id"],
+            "order.item": order["item"],
+            "order.amount": order["amount"],
+        },
+    ):
+        carrier: dict = {}
+        inject(carrier)  # inject current PRODUCER span context into carrier
+        headers = [(k, v.encode("utf-8")) for k, v in carrier.items()]
+
+        kproducer.produce(
+            topic=INPUT_TOPIC,
+            value=json.dumps(order).encode("utf-8"),
+            headers=headers,
+        )
+        kproducer.poll(0)
+
+        logger.info(
+            "Sent order %s — %s @ %.2f %s",
+            order["order_id"], order["item"], order["amount"], order["currency"],
+        )
+
+
+def run() -> None:
+    provider = init_tracing()
+    tracer = trace.get_tracer(__name__)
+
+    kproducer = KafkaProducer({"bootstrap.servers": BOOTSTRAP_SERVERS})
+
+    count = int(os.environ.get("MESSAGE_COUNT", "5"))
+    delay = float(os.environ.get("MESSAGE_DELAY_SECONDS", "1.0"))
+
+    try:
+        for i in range(count):
+            send_order(kproducer, tracer)
+            if i < count - 1:
+                time.sleep(delay)
+    finally:
+        kproducer.flush(timeout=5)
+        shutdown_tracing(provider)
+        logger.info("Done — sent %d message(s).", count)
+
+
+if __name__ == "__main__":
+    run()

--- a/python/kafka-consumer/requirements.txt
+++ b/python/kafka-consumer/requirements.txt
@@ -1,0 +1,4 @@
+confluent-kafka==2.6.1
+opentelemetry-api==1.30.0
+opentelemetry-sdk==1.30.0
+opentelemetry-exporter-otlp-proto-http==1.30.0

--- a/python/kafka-consumer/telemetry.py
+++ b/python/kafka-consumer/telemetry.py
@@ -1,0 +1,60 @@
+"""
+Shared OpenTelemetry setup.
+
+Reads standard OTEL_* environment variables — no extra config needed.
+"""
+
+import logging
+import os
+
+from opentelemetry import trace
+from opentelemetry.baggage.propagation import W3CBaggagePropagator
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.propagate import set_global_textmap
+from opentelemetry.propagators.composite import CompositePropagator
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+logger = logging.getLogger(__name__)
+
+
+def init_tracing() -> TracerProvider:
+    """Initialize the global tracer provider.
+
+    Environment variables consumed:
+        OTEL_SERVICE_NAME            — service.name resource attribute
+        OTEL_EXPORTER_OTLP_ENDPOINT  — OTLP collector/Last9 endpoint
+        OTEL_EXPORTER_OTLP_HEADERS   — e.g. "Authorization=Basic <token>"
+        SERVICE_VERSION              — service.version resource attribute
+        DEPLOYMENT_ENVIRONMENT       — deployment.environment resource attribute
+    """
+    resource = Resource.create({
+        "service.name": os.environ.get("OTEL_SERVICE_NAME", "kafka-consumer"),
+        "service.version": os.environ.get("SERVICE_VERSION", "1.0.0"),
+        "deployment.environment": os.environ.get("DEPLOYMENT_ENVIRONMENT", "development"),
+    })
+
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+
+    set_global_textmap(CompositePropagator([
+        TraceContextTextMapPropagator(),
+        W3CBaggagePropagator(),
+    ]))
+
+    logger.info(
+        "Tracing initialised — service=%s endpoint=%s",
+        os.environ.get("OTEL_SERVICE_NAME", "kafka-consumer"),
+        os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "https://otlp.last9.io"),
+    )
+    return provider
+
+
+def shutdown_tracing(provider: TracerProvider) -> None:
+    """Flush pending spans and shut down gracefully."""
+    logger.info("Flushing spans before shutdown…")
+    provider.force_flush(timeout_millis=5000)
+    provider.shutdown()

--- a/python/kafka-python/.env.example
+++ b/python/kafka-python/.env.example
@@ -1,0 +1,18 @@
+# Last9 OTLP credentials — get these from https://app.last9.io
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.last9.io
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <your-base64-encoded-credentials>
+
+# Service metadata
+OTEL_SERVICE_NAME=kafka-python-consumer
+SERVICE_VERSION=1.0.0
+DEPLOYMENT_ENVIRONMENT=production
+
+# Kafka
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+KAFKA_INPUT_TOPIC=orders
+KAFKA_OUTPUT_TOPIC=order-results
+KAFKA_CONSUMER_GROUP=order-processor
+
+# Test producer (producer.py only)
+MESSAGE_COUNT=5
+MESSAGE_DELAY_SECONDS=1.0

--- a/python/kafka-python/.gitignore
+++ b/python/kafka-python/.gitignore
@@ -1,0 +1,22 @@
+# Secrets
+.env
+.env.local
+.env.*.local
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log

--- a/python/kafka-python/Dockerfile
+++ b/python/kafka-python/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "consumer.py"]

--- a/python/kafka-python/README.md
+++ b/python/kafka-python/README.md
@@ -1,0 +1,104 @@
+# Python Kafka Consumer with OpenTelemetry Auto-Instrumentation
+
+Plain Python service (no framework) that consumes messages from a Kafka topic,
+processes them, and publishes results to another topic. Uses
+[`opentelemetry-instrumentation-kafka-python`](https://pypi.org/project/opentelemetry-instrumentation-kafka-python/)
+to automatically propagate trace context — no manual `inject`/`extract` calls needed.
+
+## How it works
+
+A single call to `KafkaInstrumentor().instrument()` wraps all `KafkaProducer` and
+`KafkaConsumer` instances:
+
+- **Producer** — every `producer.send()` automatically creates a `PRODUCER` span
+  and injects `traceparent` into message headers. No manual code needed.
+- **Consumer (transport layer)** — auto-instrumented: creates a `CONSUMER` span and
+  extracts `traceparent` from headers.
+- **Consumer (business logic)** — `kafka-python` uses an iterator pattern; the
+  auto-instrumentor creates its span inside `__next__()` and the context doesn't
+  survive the yield into user code. We extract context from `msg.headers` manually
+  to parent business logic spans correctly. The Kafka send/receive spans themselves
+  remain fully automatic.
+
+## Trace flow
+
+```
+producer.py     │  orders (send)           (PRODUCER) ← auto-created, headers injected
+kafka-python    │  orders (receive)        (CONSUMER) ← auto-created, headers extracted
+kafka-python    │    process_order         (INTERNAL) ← manual child span
+kafka-python    │    order-results (send)  (PRODUCER) ← auto-created, headers injected
+```
+
+## vs. confluent-kafka example
+
+| | `kafka-python` (this example) | `confluent-kafka` |
+|---|---|---|
+| Auto-instrumentation | Yes — `KafkaInstrumentor` | No official package |
+| Header propagation | Automatic | Manual `inject`/`extract` |
+| Code complexity | Lower | Higher |
+
+## Prerequisites
+
+- Python 3.11+
+- Docker and Docker Compose (for local Kafka)
+
+## Quick Start
+
+**1. Install dependencies**
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+**2. Configure credentials**
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` — set your Last9 OTLP endpoint and auth header. Get them from
+[app.last9.io](https://app.last9.io) → Integrations → OpenTelemetry.
+
+**3. Start Kafka and the consumer**
+
+```bash
+docker compose up --build
+```
+
+**4. Send test messages**
+
+```bash
+docker compose --profile generate up message-generator
+```
+
+Or run locally (Kafka port-forwarded on `29093`):
+
+```bash
+export KAFKA_BOOTSTRAP_SERVERS=localhost:29093
+source .env
+python producer.py
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `https://otlp.last9.io` | Last9 OTLP endpoint |
+| `OTEL_EXPORTER_OTLP_HEADERS` | — | `Authorization=Basic <token>` |
+| `OTEL_SERVICE_NAME` | `kafka-python-consumer` | Service name in traces |
+| `SERVICE_VERSION` | `1.0.0` | `service.version` resource attribute |
+| `DEPLOYMENT_ENVIRONMENT` | `development` | `deployment.environment` resource attribute |
+| `KAFKA_BOOTSTRAP_SERVERS` | `localhost:9092` | Kafka broker address |
+| `KAFKA_INPUT_TOPIC` | `orders` | Topic to consume from |
+| `KAFKA_OUTPUT_TOPIC` | `order-results` | Topic to publish results to |
+| `KAFKA_CONSUMER_GROUP` | `order-processor` | Consumer group ID |
+| `MESSAGE_COUNT` | `5` | Messages sent by `producer.py` |
+| `MESSAGE_DELAY_SECONDS` | `1.0` | Delay between messages in `producer.py` |
+
+## Verification
+
+Sign in to [Last9 Dashboard](https://app.last9.io) → APM → Traces. Filter by
+`service.name = kafka-python-consumer`. You should see connected spans showing
+the full producer → consumer → result-publisher chain within a single trace.

--- a/python/kafka-python/consumer.py
+++ b/python/kafka-python/consumer.py
@@ -1,0 +1,151 @@
+"""
+Vanilla Python Kafka consumer with OpenTelemetry auto-instrumentation.
+
+Uses kafka-python + opentelemetry-instrumentation-kafka, which automatically:
+  - Creates a CONSUMER span for each message received
+  - Extracts W3C traceparent from message headers (links to the producer's trace)
+  - Creates a PRODUCER span when sending to the output topic
+  - Injects W3C traceparent into outgoing message headers
+
+Note on context propagation:
+  kafka-python uses an iterator pattern. The auto-instrumentor creates the CONSUMER
+  span inside __next__() and its context does not survive the yield boundary into
+  user code. We therefore extract the context from msg.headers manually to attach
+  business logic child spans to the correct trace. The Kafka-level CONSUMER/PRODUCER
+  spans (transport layer) are still fully automatic.
+"""
+
+import json
+import logging
+import os
+import signal
+import time
+
+from kafka import KafkaConsumer, KafkaProducer
+
+from opentelemetry import trace
+from opentelemetry.propagate import extract
+from opentelemetry.trace import SpanKind, StatusCode
+
+from telemetry import init_tracing, shutdown_tracing
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+INPUT_TOPIC = os.environ.get("KAFKA_INPUT_TOPIC", "orders")
+OUTPUT_TOPIC = os.environ.get("KAFKA_OUTPUT_TOPIC", "order-results")
+CONSUMER_GROUP = os.environ.get("KAFKA_CONSUMER_GROUP", "order-processor")
+
+
+def headers_to_carrier(headers) -> dict:
+    """Convert Kafka message headers to an OTel text-map carrier."""
+    if not headers:
+        return {}
+    return {k: v.decode("utf-8") for k, v in headers if v is not None}
+
+
+def process_order(order: dict, tracer) -> dict:
+    """Business logic: validate and process an order."""
+    with tracer.start_as_current_span("process_order") as span:
+        order_id = order.get("order_id", "unknown")
+        amount = float(order.get("amount", 0))
+
+        span.set_attribute("order.id", order_id)
+        span.set_attribute("order.amount", amount)
+        span.set_attribute("order.item", order.get("item", ""))
+
+        time.sleep(0.05)  # simulate processing work
+
+        logger.info("Processed order %s (amount=%.2f)", order_id, amount)
+        return {
+            "order_id": order_id,
+            "status": "processed",
+            "processed_at": time.time(),
+        }
+
+
+def run() -> None:
+    provider = init_tracing()
+    tracer = trace.get_tracer(__name__)
+    running = True
+
+    # Auto-instrumented: KafkaConsumer and KafkaProducer are wrapped by
+    # KafkaInstrumentor after init_tracing() is called.
+    consumer = KafkaConsumer(
+        INPUT_TOPIC,
+        bootstrap_servers=BOOTSTRAP_SERVERS,
+        group_id=CONSUMER_GROUP,
+        auto_offset_reset="earliest",
+        enable_auto_commit=True,
+        value_deserializer=lambda b: json.loads(b.decode("utf-8")),
+    )
+
+    producer = KafkaProducer(
+        bootstrap_servers=BOOTSTRAP_SERVERS,
+        value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+    )
+
+    def handle_shutdown(sig, frame):
+        nonlocal running
+        logger.info("Received signal %s — stopping after current message…", sig)
+        running = False
+
+    signal.signal(signal.SIGINT, handle_shutdown)
+    signal.signal(signal.SIGTERM, handle_shutdown)
+
+    logger.info(
+        "Subscribed to '%s', publishing results to '%s' (group=%s)",
+        INPUT_TOPIC, OUTPUT_TOPIC, CONSUMER_GROUP,
+    )
+
+    try:
+        for msg in consumer:
+            if not running:
+                break
+
+            # The auto-instrumentor created a CONSUMER span inside __next__() but
+            # its context doesn't survive the yield into user code. We extract
+            # context from the message headers so our business logic spans are
+            # correctly parented to the producer's trace.
+            carrier = headers_to_carrier(msg.headers)
+            ctx = extract(carrier)
+
+            with tracer.start_as_current_span(
+                f"{INPUT_TOPIC} process",
+                context=ctx,
+                kind=SpanKind.CONSUMER,
+                attributes={
+                    "messaging.system": "kafka",
+                    "messaging.source.name": INPUT_TOPIC,
+                    "messaging.operation.type": "process",
+                    "messaging.message.offset": msg.offset,
+                    "messaging.kafka.consumer.group": CONSUMER_GROUP,
+                    "messaging.kafka.partition": msg.partition,
+                },
+            ) as span:
+                try:
+                    result = process_order(msg.value, tracer)
+
+                    # send() is auto-instrumented: creates a PRODUCER span and
+                    # injects traceparent into the outgoing message headers.
+                    producer.send(OUTPUT_TOPIC, value=result)
+                except Exception as exc:
+                    logger.exception(
+                        "Failed to process message at offset %d: %s",
+                        msg.offset, exc,
+                    )
+                    span.record_exception(exc)
+                    span.set_status(StatusCode.ERROR, str(exc))
+    finally:
+        consumer.close()
+        producer.flush()
+        shutdown_tracing(provider)
+        logger.info("Consumer shut down cleanly.")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/kafka-python/docker-compose.yaml
+++ b/python/kafka-python/docker-compose.yaml
@@ -1,0 +1,79 @@
+services:
+  kafka:
+    image: confluentinc/cp-kafka:7.7.1
+    container_name: kafka-python-kafka
+    ports:
+      - "9093:9092"
+      - "29093:29092"   # host-accessible external listener
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:29092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-python-kafka:9092,EXTERNAL://localhost:29093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-python-kafka:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_NUM_PARTITIONS: 2
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+    healthcheck:
+      test: ["CMD", "kafka-topics", "--bootstrap-server", "kafka-python-kafka:9092", "--list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  kafka-init:
+    image: confluentinc/cp-kafka:7.7.1
+    container_name: kafka-python-init
+    depends_on:
+      kafka:
+        condition: service_healthy
+    entrypoint: ["/bin/bash", "-c"]
+    command: >
+      "
+      kafka-topics --bootstrap-server kafka-python-kafka:9092 --create --if-not-exists
+        --topic orders --partitions 2 --replication-factor 1 &&
+      kafka-topics --bootstrap-server kafka-python-kafka:9092 --create --if-not-exists
+        --topic order-results --partitions 2 --replication-factor 1 &&
+      echo 'Topics ready.'
+      "
+
+  consumer:
+    build: .
+    container_name: kafka-python-consumer
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+    env_file:
+      - .env
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka-python-kafka:9092
+      KAFKA_INPUT_TOPIC: orders
+      KAFKA_OUTPUT_TOPIC: order-results
+      KAFKA_CONSUMER_GROUP: order-processor
+    restart: unless-stopped
+
+  # Run with: docker compose --profile generate up message-generator
+  message-generator:
+    build: .
+    container_name: kafka-python-generator
+    profiles: ["generate"]
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+    env_file:
+      - .env
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka-python-kafka:9092
+      KAFKA_INPUT_TOPIC: orders
+      MESSAGE_COUNT: "10"
+      MESSAGE_DELAY_SECONDS: "1.0"
+    command: ["python", "producer.py"]

--- a/python/kafka-python/producer.py
+++ b/python/kafka-python/producer.py
@@ -1,0 +1,74 @@
+"""
+Test message generator — sends sample order messages to the input topic.
+
+The auto-instrumentor (KafkaInstrumentor) automatically creates a PRODUCER span
+and injects W3C traceparent into the message headers on every producer.send() call.
+No manual inject() needed.
+
+Run this to generate messages for the consumer:
+    python producer.py
+
+Environment variables:
+    MESSAGE_COUNT         — number of messages to send (default: 5)
+    MESSAGE_DELAY_SECONDS — delay between messages in seconds (default: 1.0)
+"""
+
+import json
+import logging
+import os
+import random
+import time
+import uuid
+
+from kafka import KafkaProducer
+
+from telemetry import init_tracing, shutdown_tracing
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+INPUT_TOPIC = os.environ.get("KAFKA_INPUT_TOPIC", "orders")
+
+ITEMS = ["widget", "gadget", "doohickey", "thingamajig", "gizmo"]
+
+
+def run() -> None:
+    provider = init_tracing()
+
+    # Auto-instrumented: every producer.send() creates a PRODUCER span and
+    # injects traceparent into the message headers automatically.
+    producer = KafkaProducer(
+        bootstrap_servers=BOOTSTRAP_SERVERS,
+        value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+    )
+
+    count = int(os.environ.get("MESSAGE_COUNT", "5"))
+    delay = float(os.environ.get("MESSAGE_DELAY_SECONDS", "1.0"))
+
+    try:
+        for i in range(count):
+            order = {
+                "order_id": str(uuid.uuid4()),
+                "item": random.choice(ITEMS),
+                "amount": round(random.uniform(10.0, 500.0), 2),
+                "currency": "USD",
+            }
+            producer.send(INPUT_TOPIC, value=order)
+            logger.info(
+                "Sent order %s — %s @ %.2f %s",
+                order["order_id"], order["item"], order["amount"], order["currency"],
+            )
+            if i < count - 1:
+                time.sleep(delay)
+    finally:
+        producer.flush()
+        shutdown_tracing(provider)
+        logger.info("Done — sent %d message(s).", count)
+
+
+if __name__ == "__main__":
+    run()

--- a/python/kafka-python/requirements.txt
+++ b/python/kafka-python/requirements.txt
@@ -1,0 +1,5 @@
+kafka-python-ng==2.2.3
+opentelemetry-api==1.30.0
+opentelemetry-sdk==1.30.0
+opentelemetry-exporter-otlp-proto-http==1.30.0
+opentelemetry-instrumentation-kafka-python==0.51b0

--- a/python/kafka-python/telemetry.py
+++ b/python/kafka-python/telemetry.py
@@ -1,0 +1,66 @@
+"""
+Shared OpenTelemetry setup.
+
+Reads standard OTEL_* environment variables — no extra config needed.
+"""
+
+import logging
+import os
+
+from opentelemetry import trace
+from opentelemetry.baggage.propagation import W3CBaggagePropagator
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.kafka import KafkaInstrumentor
+from opentelemetry.propagate import set_global_textmap
+from opentelemetry.propagators.composite import CompositePropagator
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+logger = logging.getLogger(__name__)
+
+
+def init_tracing() -> TracerProvider:
+    """Initialize the global tracer provider and auto-instrument kafka-python.
+
+    Environment variables consumed:
+        OTEL_SERVICE_NAME            — service.name resource attribute
+        OTEL_EXPORTER_OTLP_ENDPOINT  — OTLP collector / Last9 endpoint
+        OTEL_EXPORTER_OTLP_HEADERS   — e.g. "Authorization=Basic <token>"
+        SERVICE_VERSION              — service.version resource attribute
+        DEPLOYMENT_ENVIRONMENT       — deployment.environment resource attribute
+    """
+    resource = Resource.create({
+        "service.name": os.environ.get("OTEL_SERVICE_NAME", "kafka-python-consumer"),
+        "service.version": os.environ.get("SERVICE_VERSION", "1.0.0"),
+        "deployment.environment": os.environ.get("DEPLOYMENT_ENVIRONMENT", "development"),
+    })
+
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+
+    set_global_textmap(CompositePropagator([
+        TraceContextTextMapPropagator(),
+        W3CBaggagePropagator(),
+    ]))
+
+    # One call auto-instruments all KafkaProducer and KafkaConsumer instances.
+    # It injects/extracts W3C traceparent headers and creates PRODUCER/CONSUMER
+    # spans automatically — no manual inject/extract needed in application code.
+    KafkaInstrumentor().instrument()
+
+    logger.info(
+        "Tracing initialised — service=%s endpoint=%s",
+        os.environ.get("OTEL_SERVICE_NAME", "kafka-python-consumer"),
+        os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "https://otlp.last9.io"),
+    )
+    return provider
+
+
+def shutdown_tracing(provider: TracerProvider) -> None:
+    """Flush pending spans and shut down gracefully."""
+    logger.info("Flushing spans before shutdown…")
+    provider.force_flush(timeout_millis=5000)
+    provider.shutdown()


### PR DESCRIPTION
## Summary

- Adds two Spring Boot sample apps demonstrating the [`last9/java-otel-body-capture`](https://github.com/last9/java-otel-body-capture) extension
- `java/http-body-capture` — Spring Boot 2.7 (javax.servlet), port 8085
- `java/http-body-capture-jakarta` — Spring Boot 3.2 / Jakarta servlet, port 8086

## What's included

Each app has:
- Spring Boot REST API with `/api/echo`, `/api/users`, `/api/health` endpoints
- `start_app.sh` — downloads OTel Java agent, builds the extension, starts the app with body capture enabled
- `test.sh` — end-to-end test that spins up an OTel collector, sends requests, and verifies `http.request.body` and `http.response.body` appear in spans
- `docker-compose.yml` + `otel-collector-config.yaml` for local collector

## Test plan

- [ ] `bash java/http-body-capture/test.sh` passes (4/4)
- [ ] `bash java/http-body-capture-jakarta/test.sh` passes (4/4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)