### PR TITLE
feat(python/agent-context): last9_genai agent_context multi-agent handoff demo

### DIFF
--- a/python/agent-context/README.md
+++ b/python/agent-context/README.md
@@ -1,0 +1,59 @@
+# last9_genai agent identity example
+
+Demonstrates `last9_genai.agent_context()` — a Python context manager that
+attaches OTel GenAI semantic-convention agent attributes
+(`gen_ai.agent.id`, `gen_ai.agent.name`, `gen_ai.agent.description`,
+`gen_ai.agent.version`) to every span created inside it.
+
+The script simulates a multi-agent handoff:
+
+1. `Router` classifies the user's query.
+2. `Refund Agent` handles the refund.
+
+Both agents share the same `conversation_context` (so all their spans group
+under one conversation in the Last9 LLM dashboard) and the Refund Agent adds
+a `workflow_context` to track the nested retrieval / tool-use flow.
+
+## Why this matters
+
+OpenTelemetry's GenAI semantic conventions define a first-class way to identify
+the agent that produced a span. Major frameworks (OpenAI Agents SDK,
+`autogen-core`) already emit these on their own agent spans. `agent_context()`
+lets you tag any hand-rolled or SDK-agnostic code the same way, so the Last9
+Agents Monitoring dashboard can filter, group, and drill into spans by agent.
+
+## Run
+
+```bash
+export OPENAI_API_KEY=...
+
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-aps1.last9.io:443
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <your-token>"
+export OTEL_SERVICE_NAME=last9-genai-agent-demo
+export OTEL_RESOURCE_ATTRIBUTES=deployment.environment=local
+
+uv run --python 3.12 \
+    --with 'last9-genai>=1.2' \
+    --with opentelemetry-exporter-otlp \
+    --with openai \
+    python last9_agent_context.py
+```
+
+## What to verify in Last9
+
+Open the Agents Monitoring dashboard and look for the conversation
+`agent-demo-<timestamp>`. The spans should carry:
+
+- `gen_ai.conversation.id` = the session id
+- `user.id` = `demo-user`
+- `gen_ai.agent.name` = `Router` on the classification call
+- `gen_ai.agent.name` = `Refund Agent` on the reply call
+- `gen_ai.agent.id`, `gen_ai.agent.description`, `gen_ai.agent.version`
+  present on each call
+- `workflow.id` = `refund-flow` on the Refund Agent span
+
+## Requires
+
+- `last9-genai >= 1.2.0` (ships `agent_context()`)
+- `openai >= 1.0`
+- `opentelemetry-exporter-otlp`

--- a/python/agent-context/last9_agent_context.py
+++ b/python/agent-context/last9_agent_context.py
@@ -1,0 +1,106 @@
+"""
+Demo: tracking multi-agent identity with last9_genai.agent_context().
+
+Shows the OTel GenAI semantic-convention agent attributes
+(`gen_ai.agent.id`, `gen_ai.agent.name`, `gen_ai.agent.description`,
+`gen_ai.agent.version`) being auto-propagated onto every span within
+an `agent_context()` block, composed with `conversation_context()` and
+`workflow_context()`.
+
+Run:
+    export OPENAI_API_KEY=...
+    export OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-aps1.last9.io:443
+    export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <token>"
+    export OTEL_SERVICE_NAME=last9-genai-agent-demo
+    export OTEL_RESOURCE_ATTRIBUTES=deployment.environment=local
+
+    uv run --with 'last9-genai>=1.2' --with opentelemetry-exporter-otlp \\
+        --with openai python last9_agent_context.py
+"""
+
+import os
+import time
+
+from openai import OpenAI
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from last9_genai import (
+    Last9SpanProcessor,
+    agent_context,
+    conversation_context,
+    workflow_context,
+)
+
+
+provider = TracerProvider()
+provider.add_span_processor(Last9SpanProcessor())
+provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+trace.set_tracer_provider(provider)
+
+tracer = trace.get_tracer("agent-demo")
+client = OpenAI()
+
+
+def call_llm(model: str, prompt: str) -> str:
+    """Single LLM call wrapped in its own span so the agent attrs attach."""
+    with tracer.start_as_current_span(f"chat.{model}") as span:
+        span.set_attribute("gen_ai.request.model", model)
+        span.set_attribute("gen_ai.operation.name", "chat")
+        span.set_attribute("gen_ai.system", "openai")
+
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+
+        span.set_attribute("gen_ai.usage.input_tokens", response.usage.prompt_tokens)
+        span.set_attribute(
+            "gen_ai.usage.output_tokens", response.usage.completion_tokens
+        )
+        return response.choices[0].message.content or ""
+
+
+def router_agent(query: str) -> str:
+    with agent_context(
+        agent_name="Router",
+        agent_id="router_v1",
+        agent_description="Classifies a user query into a support topic",
+        agent_version="1.0",
+    ):
+        return call_llm("gpt-4o-mini", f"Classify in one word: {query}")
+
+
+def refund_agent(query: str) -> str:
+    with agent_context(
+        agent_name="Refund Agent",
+        agent_id="refund_v3",
+        agent_description="Handles refund-related requests",
+        agent_version="3.1",
+    ):
+        with workflow_context(workflow_id="refund-flow", workflow_type="tool_use"):
+            return call_llm(
+                "gpt-4o-mini",
+                f"Draft a one-line apology for this refund: {query}",
+            )
+
+
+def main() -> None:
+    session_id = f"agent-demo-{int(time.time())}"
+
+    with conversation_context(conversation_id=session_id, user_id="demo-user"):
+        query = "I want to return my order"
+        topic = router_agent(query)
+        print(f"Router classified topic as: {topic.strip()}")
+
+        reply = refund_agent(query)
+        print(f"Refund Agent replied: {reply.strip()}")
+
+    provider.force_flush()
+    provider.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `python/agent-context/last9_agent_context.py` — small demo that tags
  spans with `gen_ai.agent.*` attributes via `last9_genai.agent_context()`,
  composed with `conversation_context()` and `workflow_context()`.
- Simulates a Router → Refund Agent handoff so the traces exercise per-agent
  grouping in the Last9 Agents Monitoring dashboard.
- Adds a README covering setup, run instructions, and verification checklist.

## Why

`last9-genai` 1.2.0 ships `agent_context()` which attaches OTel GenAI
semantic-convention agent attributes (`gen_ai.agent.id`, `.name`,
`.description`, `.version`) to every span created inside it. These match
what OpenAI Agents SDK and autogen-core emit natively on their own agent
spans. This example gives customers a copy-pasteable pattern for tagging
hand-rolled or SDK-agnostic agent code the same way.

## Test plan

- [x] Script runs end-to-end, emits 2 traces (one per agent call).
- [x] Traces land in Last9 with `gen_ai.agent.{id,name,description,version}`,
      `gen_ai.conversation.id`, `workflow.id` populated — verified via MCP
      attribute index.
- [ ] Reviewer runs with their own OpenAI key + OTLP credentials.

## Requires

- `last9-genai >= 1.2.0`
- OpenAI API key
- Last9 OTLP endpoint + auth token

🤖 Generated with [Claude Code](https://claude.com/claude-code)