### PR TITLE
feat(ruby): k8s Downward API → OTel resource attributes example

### DIFF
--- a/ruby/k8s-downward-api/.gitignore
+++ b/ruby/k8s-downward-api/.gitignore
@@ -1,0 +1,7 @@
+.env
+.env.local
+Gemfile.lock
+/vendor/
+.bundle/
+.DS_Store
+*.log

--- a/ruby/k8s-downward-api/Dockerfile
+++ b/ruby/k8s-downward-api/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:3.3-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY Gemfile ./
+RUN bundle install
+
+COPY app.rb config.ru instrumentation.rb ./
+
+EXPOSE 4567
+
+CMD ["bundle", "exec", "rackup", "-o", "0.0.0.0", "-p", "4567"]

--- a/ruby/k8s-downward-api/Gemfile
+++ b/ruby/k8s-downward-api/Gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+gem 'sinatra', '~> 4.0'
+gem 'puma'
+gem 'rackup'
+
+gem 'opentelemetry-sdk', '~> 1.5'
+gem 'opentelemetry-exporter-otlp', '~> 0.28'
+gem 'opentelemetry-instrumentation-sinatra', '~> 0.24'
+gem 'opentelemetry-instrumentation-rack', '~> 0.25'

--- a/ruby/k8s-downward-api/README.md
+++ b/ruby/k8s-downward-api/README.md
@@ -1,0 +1,85 @@
+# Ruby + Kubernetes Downward API → OTel Resource Attributes
+
+Sinatra app demonstrating how to enrich OpenTelemetry traces with
+[Kubernetes resource semantic conventions](https://opentelemetry.io/docs/specs/semconv/resource/k8s/)
+using the Kubernetes Downward API. No Ruby-specific k8s detector gem required.
+
+## How It Works
+
+1. Kubernetes Downward API exposes pod metadata (name, UID, namespace, node, IP, labels)
+   as environment variables inside the container.
+2. A single `OTEL_RESOURCE_ATTRIBUTES` env var composes those values into OTel's
+   resource attribute format: `k8s.pod.name=$(K8S_POD_NAME),...`
+3. The Ruby OTel SDK reads `OTEL_RESOURCE_ATTRIBUTES` automatically at startup
+   and attaches them to every span.
+
+## Attributes Emitted
+
+| Attribute | Source |
+|---|---|
+| `k8s.cluster.name` | hardcoded |
+| `k8s.namespace.name` | `metadata.namespace` |
+| `k8s.node.name` | `spec.nodeName` |
+| `k8s.pod.name` | `metadata.name` |
+| `k8s.pod.uid` | `metadata.uid` |
+| `k8s.pod.ip` | `status.podIP` |
+| `k8s.container.name` | hardcoded |
+| `k8s.deployment.name` | label `app.kubernetes.io/name` |
+| `host.ip` | `status.hostIP` |
+| `service.version` | label `app.kubernetes.io/version` |
+| `service.namespace` | `metadata.namespace` |
+| `service.instance.id` | composed |
+
+Downward API cannot provide `k8s.deployment.name`, `k8s.cluster.name`,
+`k8s.replicaset.name` directly. Workarounds:
+- `k8s.deployment.name` → inject pod label `app.kubernetes.io/name`
+- `k8s.cluster.name` → hardcode per environment
+- For higher fidelity (replicaset, owner refs) use the Collector
+  [`k8sattributes`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor)
+  processor — enriches server-side, requires RBAC.
+
+## Prerequisites
+
+- Docker
+- [kind](https://kind.sigs.k8s.io/) — `brew install kind`
+- kubectl
+
+## Run
+
+```bash
+./setup.sh
+```
+
+Port-forward and test:
+
+```bash
+kubectl -n demo port-forward svc/ruby-k8s-demo 4567:4567 &
+curl localhost:4567/hello
+```
+
+Watch collector spans:
+
+```bash
+kubectl -n demo logs -l app=otel-collector -f
+```
+
+Look for `Resource attributes:` block containing `k8s.pod.name`, `k8s.namespace.name`, etc.
+
+## Cleanup
+
+```bash
+kind delete cluster --name kind-local
+```
+
+## Send to Last9
+
+Edit `k8s/deployment.yaml` env:
+
+```yaml
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: https://otlp.last9.io
+- name: OTEL_EXPORTER_OTLP_HEADERS
+  value: "Authorization=Basic <your-token>"
+```
+
+Or point the local collector at Last9 in `k8s/collector.yaml`.

--- a/ruby/k8s-downward-api/app.rb
+++ b/ruby/k8s-downward-api/app.rb
@@ -1,0 +1,15 @@
+require 'sinatra'
+require 'json'
+require_relative 'instrumentation'
+
+set :bind, '0.0.0.0'
+set :port, 4567
+
+get '/hello' do
+  content_type :json
+  { message: 'hello from k8s', pod: ENV['K8S_POD_NAME'] }.to_json
+end
+
+get '/health' do
+  'ok'
+end

--- a/ruby/k8s-downward-api/config.ru
+++ b/ruby/k8s-downward-api/config.ru
@@ -1,0 +1,2 @@
+require_relative 'app'
+run Sinatra::Application

--- a/ruby/k8s-downward-api/instrumentation.rb
+++ b/ruby/k8s-downward-api/instrumentation.rb
@@ -1,0 +1,12 @@
+require 'opentelemetry/sdk'
+require 'opentelemetry/exporter/otlp'
+require 'opentelemetry/instrumentation/sinatra'
+require 'opentelemetry/instrumentation/rack'
+
+# Resource attributes from OTEL_RESOURCE_ATTRIBUTES env var
+# are merged automatically by the SDK. Downward API injects k8s.* attrs there.
+OpenTelemetry::SDK.configure do |c|
+  c.service_name = ENV.fetch('OTEL_SERVICE_NAME', 'ruby-k8s-demo')
+  c.use 'OpenTelemetry::Instrumentation::Sinatra'
+  c.use 'OpenTelemetry::Instrumentation::Rack'
+end

--- a/ruby/k8s-downward-api/k8s/collector.yaml
+++ b/ruby/k8s-downward-api/k8s/collector.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: demo
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          http:
+            endpoint: 0.0.0.0:4318
+          grpc:
+            endpoint: 0.0.0.0:4317
+
+    processors:
+      batch: {}
+
+    exporters:
+      debug:
+        verbosity: detailed
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.144.0
+          args: ["--config=/etc/otel/config.yaml"]
+          ports:
+            - containerPort: 4318
+            - containerPort: 4317
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otel
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: demo
+spec:
+  selector:
+    app: otel-collector
+  ports:
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317

--- a/ruby/k8s-downward-api/k8s/deployment.yaml
+++ b/ruby/k8s-downward-api/k8s/deployment.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruby-k8s-demo
+  namespace: demo
+  labels:
+    app.kubernetes.io/name: ruby-k8s-demo
+    app.kubernetes.io/version: "1.0.0"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ruby-k8s-demo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ruby-k8s-demo
+        app.kubernetes.io/version: "1.0.0"
+    spec:
+      containers:
+        - name: app
+          image: ruby-k8s-demo:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 4567
+          env:
+            # OTel service identity
+            - name: OTEL_SERVICE_NAME
+              value: ruby-k8s-demo
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://otel-collector.demo.svc.cluster.local:4318
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: http/protobuf
+
+            # Downward API — fieldRef values
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: K8S_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: K8S_NAMESPACE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: K8S_SERVICE_ACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            # Labels via fieldRef — quoted fieldPath syntax
+            - name: K8S_DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/name']
+            - name: K8S_APP_VERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/version']
+
+            # Hardcoded — cannot come from Downward API
+            - name: K8S_CLUSTER_NAME
+              value: kind-local
+            - name: K8S_CONTAINER_NAME
+              value: app
+
+            # Compose OTEL_RESOURCE_ATTRIBUTES — SDK reads this automatically
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: >-
+                k8s.cluster.name=$(K8S_CLUSTER_NAME),
+                k8s.namespace.name=$(K8S_NAMESPACE_NAME),
+                k8s.node.name=$(K8S_NODE_NAME),
+                k8s.pod.name=$(K8S_POD_NAME),
+                k8s.pod.uid=$(K8S_POD_UID),
+                k8s.pod.ip=$(K8S_POD_IP),
+                k8s.container.name=$(K8S_CONTAINER_NAME),
+                k8s.deployment.name=$(K8S_DEPLOYMENT_NAME),
+                host.ip=$(K8S_HOST_IP),
+                service.version=$(K8S_APP_VERSION),
+                service.namespace=$(K8S_NAMESPACE_NAME),
+                service.instance.id=$(K8S_NAMESPACE_NAME).$(K8S_POD_NAME).$(K8S_CONTAINER_NAME),
+                deployment.environment=local
+
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4567
+            initialDelaySeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 4567
+            initialDelaySeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ruby-k8s-demo
+  namespace: demo
+spec:
+  selector:
+    app.kubernetes.io/name: ruby-k8s-demo
+  ports:
+    - port: 4567
+      targetPort: 4567

--- a/ruby/k8s-downward-api/k8s/namespace.yaml
+++ b/ruby/k8s-downward-api/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo

--- a/ruby/k8s-downward-api/setup.sh
+++ b/ruby/k8s-downward-api/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER=kind-local
+IMAGE=ruby-k8s-demo:latest
+
+command -v kind >/dev/null || { echo "install kind: brew install kind"; exit 1; }
+command -v kubectl >/dev/null || { echo "install kubectl: brew install kubectl"; exit 1; }
+
+if ! kind get clusters | grep -q "^${CLUSTER}$"; then
+  kind create cluster --name "${CLUSTER}"
+fi
+
+docker build -t "${IMAGE}" .
+kind load docker-image "${IMAGE}" --name "${CLUSTER}"
+
+kubectl apply -f k8s/namespace.yaml
+kubectl apply -f k8s/collector.yaml
+kubectl apply -f k8s/deployment.yaml
+
+kubectl -n demo rollout status deploy/otel-collector --timeout=120s
+kubectl -n demo rollout status deploy/ruby-k8s-demo --timeout=120s
+
+echo
+echo "Port-forward app:  kubectl -n demo port-forward svc/ruby-k8s-demo 4567:4567"
+echo "Curl:              curl localhost:4567/hello"
+echo "Collector logs:    kubectl -n demo logs -l app=otel-collector -f"


### PR DESCRIPTION
## Summary
- New Ruby example at `ruby/k8s-downward-api/` showing how to enrich OTel traces with Kubernetes semantic convention attributes using the Downward API — no Ruby-specific k8s detector gem required.
- Sinatra app + Dockerfile + k8s manifests (Deployment with Downward API env vars, Service, Namespace, OTel Collector with debug exporter).
- `setup.sh` spins up a local kind cluster, loads the image, deploys everything, and surfaces `k8s.*` attrs in collector logs.

Attributes emitted on span resource:
`k8s.cluster.name`, `k8s.namespace.name`, `k8s.node.name`, `k8s.pod.name`, `k8s.pod.uid`, `k8s.pod.ip`, `k8s.container.name`, `k8s.deployment.name`, `host.ip`, `service.version`, `service.namespace`, `service.instance.id`.

For attributes the Downward API cannot reach (`k8s.replicaset.name`, owner chain, node UID), README points to the Collector `k8sattributesprocessor` as the complementary approach.

## Test plan
- [x] `./setup.sh` creates kind cluster, builds and loads image, deploys app + collector
- [x] `curl localhost:4567/hello` via port-forward produces spans
- [x] Collector `debug` exporter logs contain all 12+ k8s/service resource attrs
- [ ] Reviewer verifies README is self-contained

🤖 Generated with [Claude Code](https://claude.com/claude-code)