### PR TITLE
feat(python): FastAPI OTLP exporter compare (HTTP vs gRPC, RemoteDisconnected repro)

### DIFF
--- a/python/fastapi-otlp-exporter-compare/.env.example
+++ b/python/fastapi-otlp-exporter-compare/.env.example
@@ -1,0 +1,18 @@
+# Switch exporter: http/protobuf (reproduces RemoteDisconnected on idle LB) or grpc (stable)
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+
+# Last9 OTLP endpoint
+# HTTP: https://otlp.last9.io
+# gRPC: https://otlp.last9.io:443
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.last9.io:443
+
+# Auth header from Last9 dashboard
+OTEL_EXPORTER_OTLP_HEADERS=authorization=<your-last9-auth-header>
+
+OTEL_SERVICE_NAME=fastapi-otlp-compare
+
+# Optional BSP tuning
+# OTEL_BSP_SCHEDULE_DELAY=5000
+# OTEL_BSP_EXPORT_TIMEOUT=30000
+# OTEL_BSP_MAX_QUEUE_SIZE=2048
+# OTEL_BSP_MAX_EXPORT_BATCH_SIZE=512

--- a/python/fastapi-otlp-exporter-compare/.gitignore
+++ b/python/fastapi-otlp-exporter-compare/.gitignore
@@ -1,0 +1,17 @@
+.env
+.env.local
+.env.*.local
+
+.venv/
+.venv-*/
+__pycache__/
+*.pyc
+
+.idea/
+.vscode/
+*.swp
+
+.DS_Store
+Thumbs.db
+
+*.log

--- a/python/fastapi-otlp-exporter-compare/README.md
+++ b/python/fastapi-otlp-exporter-compare/README.md
@@ -1,0 +1,99 @@
+# FastAPI OTLP Exporter Compare (HTTP vs gRPC)
+
+Reproduce and fix `requests.exceptions.ConnectionError: RemoteDisconnected` seen in production when OTLP HTTP exporter sits behind a load balancer that closes idle keep-alive TCP connections.
+
+## Why
+
+The OTLP HTTP exporter uses a long-lived `requests.Session`. Upstream LBs (ALB 60s, CloudFront 60s, nginx 75s) close idle TCP. Next export hits a half-closed socket:
+
+```
+requests.exceptions.ConnectionError: ('Connection aborted.',
+  RemoteDisconnected('Remote end closed connection without response'))
+```
+
+gRPC exporter uses HTTP/2 with keepalive pings — no idle-socket problem. Newer Python OTel SDK (>=1.27) also retries on `ConnectionError` silently.
+
+## What's here
+
+- `app.py` — FastAPI + Uvicorn, OTel SDK, exporter selected by `OTEL_EXPORTER_OTLP_PROTOCOL`
+- `repro.py` — driver that emits span, sleeps past LB idle window, emits again
+- `flaky_server.py` — fake OTLP endpoint that half-closes every 2nd request. Deterministic repro
+- `docker-compose.yaml` + `nginx.conf` — nginx with `keepalive_timeout 5s` in front of collector
+- `requirements.txt` — current OTel (>=1.27) — error retried silently
+- `requirements-legacy.txt` — customer's version (1.15) — raises full stack trace
+
+## Reproduce (deterministic)
+
+```bash
+# 1. Install legacy SDK (1.15 — matches customer logs)
+python3.11 -m venv .venv-legacy
+.venv-legacy/bin/pip install -r requirements-legacy.txt
+
+# 2. Start fake flaky OTLP server
+.venv-legacy/bin/python flaky_server.py &
+
+# 3. Run driver pointed at flaky server
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4319 \
+.venv-legacy/bin/python repro.py
+```
+
+Expected: traceback with `RemoteDisconnected('Remote end closed connection without response')` — identical to customer log.
+
+## Verify fixes
+
+**Fix 1 — upgrade SDK (>=1.27):**
+```bash
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4319 \
+.venv/bin/python repro.py
+```
+No traceback. Retry layer swallows it.
+
+**Fix 2 — switch to gRPC (any SDK version):**
+```bash
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+.venv-legacy/bin/python repro.py
+```
+No traceback. HTTP/2 keepalive pings prevent idle closes.
+
+## Alt: nginx + real collector
+
+```bash
+docker compose up -d
+# Point exporter at http://localhost:4318 (HTTP) or http://localhost:4317 (gRPC)
+```
+
+Nginx `keepalive_timeout 5s` simulates an aggressive LB. Less deterministic than `flaky_server.py` because urllib3 can detect cleanly-closed sockets and reconnect.
+
+## Production use
+
+For the FastAPI app (`app.py`) against Last9:
+
+```bash
+cp .env.example .env
+# edit .env with Last9 auth header
+set -a && source .env && set +a
+python app.py
+curl localhost:8000/work
+```
+
+Recommended settings:
+```
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.last9.io:443
+OTEL_EXPORTER_OTLP_HEADERS=authorization=<your-last9-auth-header>
+```
+
+## Fix ranking
+
+1. **gRPC exporter** — fixes root cause across all SDK versions
+2. **Upgrade OTel libs to >=1.27.0** — silently retries on `ConnectionError`
+3. **Keep HTTP, suppress noise** — if BSP retries succeed (no trace gaps in Last9):
+   ```python
+   logging.getLogger("opentelemetry.sdk._shared_internal").setLevel(logging.ERROR)
+   ```
+4. **Verify no data loss** — check Last9 for trace gaps during error bursts. BSP retries the failed batch; single log line usually means no loss.

--- a/python/fastapi-otlp-exporter-compare/app.py
+++ b/python/fastapi-otlp-exporter-compare/app.py
@@ -1,0 +1,59 @@
+"""
+FastAPI + OTel exporter compare: HTTP vs gRPC.
+
+Context: OTLP HTTP exporter on long-lived `requests.Session` can hit
+`RemoteDisconnected` when an upstream LB closes an idle keep-alive TCP
+connection. gRPC exporter uses HTTP/2 with keepalive pings and avoids it.
+
+Toggle with OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf | grpc
+"""
+import os
+import logging
+import uvicorn
+from fastapi import FastAPI
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+
+PROTOCOL = os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf").lower()
+ENDPOINT = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+HEADERS = os.getenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+SERVICE_NAME = os.getenv("OTEL_SERVICE_NAME", "fastapi-otlp-compare")
+
+if PROTOCOL == "grpc":
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    exporter = OTLPSpanExporter(endpoint=ENDPOINT or None)
+else:
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    exporter = OTLPSpanExporter(endpoint=ENDPOINT or None)
+
+provider = TracerProvider(resource=Resource.create({"service.name": SERVICE_NAME}))
+provider.add_span_processor(BatchSpanProcessor(exporter))
+trace.set_tracer_provider(provider)
+
+logging.getLogger("opentelemetry.sdk._shared_internal").setLevel(logging.ERROR)
+
+app = FastAPI()
+FastAPIInstrumentor.instrument_app(app)
+RequestsInstrumentor().instrument()
+
+tracer = trace.get_tracer(__name__)
+
+
+@app.get("/")
+async def root():
+    return {"protocol": PROTOCOL, "endpoint": ENDPOINT or "default"}
+
+
+@app.get("/work")
+async def work():
+    with tracer.start_as_current_span("work"):
+        return {"ok": True}
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/python/fastapi-otlp-exporter-compare/docker-compose.yaml
+++ b/python/fastapi-otlp-exporter-compare/docker-compose.yaml
@@ -1,0 +1,24 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.144.0
+    container_name: otel-collector-repro
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml:ro
+    expose:
+      - "4318"
+      - "4317"
+
+  # nginx in front of collector with aggressive idle timeout.
+  # Closes idle keep-alive TCP after 5s → forces RemoteDisconnected
+  # on stale sockets from long-lived requests.Session in HTTP exporter.
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: nginx-repro
+    depends_on:
+      - otel-collector
+    ports:
+      - "4318:4318"   # OTLP HTTP (via nginx → collector)
+      - "4317:4317"   # OTLP gRPC (via nginx stream → collector)
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro

--- a/python/fastapi-otlp-exporter-compare/flaky_server.py
+++ b/python/fastapi-otlp-exporter-compare/flaky_server.py
@@ -1,0 +1,62 @@
+"""
+Fake OTLP HTTP server that half-closes mid-request to force
+RemoteDisconnected on the client. Deterministic repro.
+
+Behavior: accept POST, read headers, send FIN (close write side) without
+response body. Client sees 'Remote end closed connection without response'.
+
+Run: python flaky_server.py
+Point exporter at: http://localhost:4319/v1/traces
+"""
+import socket
+import threading
+
+HOST, PORT = "0.0.0.0", 4319
+counter = {"n": 0}
+lock = threading.Lock()
+
+
+def handle(conn: socket.socket, addr):
+    with lock:
+        counter["n"] += 1
+        n = counter["n"]
+    try:
+        # Drain request headers
+        data = b""
+        conn.settimeout(5)
+        while b"\r\n\r\n" not in data:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+        # Every 2nd request: close without responding (RemoteDisconnected)
+        if n % 2 == 0:
+            print(f"[{n}] half-close — dropping connection")
+            conn.shutdown(socket.SHUT_RDWR)
+        else:
+            print(f"[{n}] ok → 200")
+            conn.sendall(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: application/x-protobuf\r\n"
+                b"Content-Length: 0\r\n"
+                b"Connection: keep-alive\r\n\r\n"
+            )
+    except Exception as e:
+        print(f"[{n}] err {e}")
+    finally:
+        conn.close()
+
+
+def main():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind((HOST, PORT))
+    s.listen(16)
+    print(f"flaky OTLP on {HOST}:{PORT}")
+    while True:
+        conn, addr = s.accept()
+        threading.Thread(target=handle, args=(conn, addr), daemon=True).start()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/fastapi-otlp-exporter-compare/nginx.conf
+++ b/python/fastapi-otlp-exporter-compare/nginx.conf
@@ -1,0 +1,36 @@
+worker_processes 1;
+events { worker_connections 1024; }
+
+http {
+    # Aggressive idle timeout — simulates LB that closes keep-alive TCP fast.
+    keepalive_timeout 5s;
+    keepalive_requests 100;
+    client_body_timeout 10s;
+    send_timeout 10s;
+
+    upstream collector_http {
+        server otel-collector:4318;
+        keepalive 8;
+    }
+
+    server {
+        listen 4318;
+        location / {
+            proxy_pass http://collector_http;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+        }
+    }
+}
+
+stream {
+    upstream collector_grpc {
+        server otel-collector:4317;
+    }
+    server {
+        listen 4317;
+        proxy_pass collector_grpc;
+        # gRPC / HTTP2 — keepalive pings keep socket alive
+        proxy_timeout 10m;
+    }
+}

--- a/python/fastapi-otlp-exporter-compare/otel-collector-config.yaml
+++ b/python/fastapi-otlp-exporter-compare/otel-collector-config.yaml
@@ -1,0 +1,17 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+exporters:
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [debug]

--- a/python/fastapi-otlp-exporter-compare/repro.py
+++ b/python/fastapi-otlp-exporter-compare/repro.py
@@ -1,0 +1,62 @@
+"""
+Repro driver: emit span, idle past nginx keepalive_timeout (5s), emit again.
+Second export hits half-closed socket on HTTP exporter → RemoteDisconnected.
+gRPC mode stays healthy via HTTP/2 keepalive pings.
+
+Run:
+  # HTTP mode (reproduces):
+  OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \\
+  OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \\
+  python repro.py
+
+  # gRPC mode (stable):
+  OTEL_EXPORTER_OTLP_PROTOCOL=grpc \\
+  OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \\
+  python repro.py
+"""
+import os
+import time
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+PROTOCOL = os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf").lower()
+ENDPOINT = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+
+if PROTOCOL == "grpc":
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    exporter = OTLPSpanExporter(endpoint=ENDPOINT, insecure=True)
+else:
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    exporter = OTLPSpanExporter(endpoint=f"{ENDPOINT.rstrip('/')}/v1/traces")
+
+provider = TracerProvider(resource=Resource.create({"service.name": "repro"}))
+# Short schedule so flushes happen per iteration
+processor = BatchSpanProcessor(exporter, schedule_delay_millis=500)
+provider.add_span_processor(processor)
+trace.set_tracer_provider(provider)
+tracer = trace.get_tracer(__name__)
+
+
+def emit(label: str):
+    with tracer.start_as_current_span(f"span-{label}"):
+        pass
+    provider.force_flush(timeout_millis=5000)
+    print(f"[{label}] flushed")
+
+
+print(f"protocol={PROTOCOL} endpoint={ENDPOINT}")
+emit("warmup")
+print("sleeping 15s (past nginx keepalive_timeout=5s)…")
+time.sleep(15)
+emit("after-idle-1")
+time.sleep(15)
+emit("after-idle-2")
+
+provider.shutdown()
+print("done")

--- a/python/fastapi-otlp-exporter-compare/requirements-legacy.txt
+++ b/python/fastapi-otlp-exporter-compare/requirements-legacy.txt
@@ -1,0 +1,9 @@
+# Pinned to customer's reported versions to reproduce RemoteDisconnected log.
+# Newer SDK (>=1.27) retries on ConnectionError silently and hides the error.
+opentelemetry-api==1.15.0
+opentelemetry-sdk==1.15.0
+opentelemetry-exporter-otlp-proto-http==1.15.0
+opentelemetry-exporter-otlp-proto-grpc==1.15.0
+opentelemetry-distro==0.36b0
+requests>=2.28,<3
+protobuf<4

--- a/python/fastapi-otlp-exporter-compare/requirements.txt
+++ b/python/fastapi-otlp-exporter-compare/requirements.txt
@@ -1,0 +1,10 @@
+fastapi>=0.115.0
+uvicorn>=0.30.0
+requests>=2.32.0
+
+opentelemetry-api>=1.27.0
+opentelemetry-sdk>=1.27.0
+opentelemetry-exporter-otlp-proto-http>=1.27.0
+opentelemetry-exporter-otlp-proto-grpc>=1.27.0
+opentelemetry-instrumentation-fastapi>=0.48b0
+opentelemetry-instrumentation-requests>=0.48b0


### PR DESCRIPTION
## Summary

- New example `python/fastapi-otlp-exporter-compare/` reproducing `requests.exceptions.ConnectionError: RemoteDisconnected('Remote end closed connection without response')` seen when the OTLP HTTP exporter sits behind a load balancer that closes idle keep-alive TCP connections.
- Deterministic repro via `flaky_server.py` (fake OTLP endpoint that half-closes every 2nd request) + legacy SDK 1.15 pins matching the reported stack trace.
- Alternative repro via nginx (`keepalive_timeout 5s`) + real OTel Collector in `docker-compose.yaml`.
- Single app toggles between HTTP and gRPC exporter via `OTEL_EXPORTER_OTLP_PROTOCOL`, proving the gRPC exporter is immune (HTTP/2 keepalive pings).

## Verified

- Legacy SDK 1.15 + HTTP + flaky server → reproduces exact traceback.
- Legacy SDK 1.15 + gRPC → clean.
- Current SDK >=1.27 + HTTP + flaky server → clean (retry layer swallows the error).
- Sample `app.py` sends traces successfully to a real Last9 OTLP endpoint (verified via trace query).

## Fix ranking documented in README

1. Switch to gRPC exporter — root cause fix across all SDK versions.
2. Upgrade `opentelemetry-*` to >=1.27 — retries on `ConnectionError` silently.
3. Keep HTTP, suppress noise if BSP retries succeed.

## Test plan

- [x] `docker compose up -d` brings up collector + nginx
- [x] `python3.11 -m venv .venv-legacy && .venv-legacy/bin/pip install -r requirements-legacy.txt`
- [x] `.venv-legacy/bin/python flaky_server.py &`
- [x] HTTP mode against flaky server reproduces traceback
- [x] gRPC mode against collector is clean
- [x] `app.py` exports to real Last9 OTLP endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)