### PR TITLE
feat(javascript): NestJS SQS polling with OTel trace and log correlation

### DIFF
--- a/javascript/nestjs-sqs-correlation/.env.example
+++ b/javascript/nestjs-sqs-correlation/.env.example
@@ -1,0 +1,24 @@
+# SQS Configuration
+AWS_REGION=ap-south-1
+SQS_QUEUE_URL=https://sqs.ap-south-1.amazonaws.com/<account-id>/<queue-name>
+SQS_QUEUE_NAME=<queue-name>
+SQS_WAIT_TIME_SECONDS=5
+POLL_INTERVAL_MS=100
+
+# AWS credentials (use IAM role in production)
+AWS_ACCESS_KEY_ID=<your-access-key>
+AWS_SECRET_ACCESS_KEY=<your-secret-key>
+
+# For local testing with LocalStack
+# SQS_ENDPOINT=http://localhost:4566
+# AWS_ACCESS_KEY_ID=test
+# AWS_SECRET_ACCESS_KEY=test
+
+# OpenTelemetry
+OTEL_SERVICE_NAME=nestjs-sqs-subscriber
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.last9.io
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64-encoded-credentials>
+
+# App
+NODE_ENV=production
+PORT=3000

--- a/javascript/nestjs-sqs-correlation/.gitignore
+++ b/javascript/nestjs-sqs-correlation/.gitignore
@@ -1,0 +1,25 @@
+# Environment/secrets
+.env
+.env.local
+.env.*.local
+
+# Dependencies
+/node_modules/
+
+# Build artifacts
+/dist/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Local test/dev scripts
+test-send.mjs

--- a/javascript/nestjs-sqs-correlation/README.md
+++ b/javascript/nestjs-sqs-correlation/README.md
@@ -1,0 +1,91 @@
+# NestJS SQS Polling — OpenTelemetry Trace Correlation
+
+NestJS service that polls SQS at fixed intervals and correlates all logs and spans within a single poll cycle and per individual message.
+
+## Trace Structure
+
+```
+[sqs.poll_cycle]                  ← INTERNAL span, one per interval tick
+  ├── [<queue> receive]           ← CONSUMER span, auto by AwsInstrumentation
+  ├── [<queue> process]           ← CONSUMER span, per message (manual)
+  │     ├── link → producer trace ← cross-trace link to the sending service
+  │     ├── [your business logic] ← child spans (HTTP, DB, downstream SQS)
+  │     └── [SQS.DeleteMessage]   ← auto by AwsInstrumentation
+  └── [<queue> process]           ← parallel per message
+```
+
+Every log line emitted during message processing includes `trace_id` and `span_id` fields, allowing log-to-trace correlation in Last9.
+
+## Prerequisites
+
+- Node.js >= 20
+- AWS credentials with SQS access (or LocalStack for local testing)
+- Last9 OTLP endpoint and credentials
+
+## Quick Start
+
+```bash
+cp .env.example .env
+# Edit .env with your SQS URL and Last9 credentials
+
+npm install
+npm run start:dev
+```
+
+### Local Testing with LocalStack
+
+```bash
+docker compose up localstack otel-collector
+# Then start the app:
+npm run start:dev
+```
+
+Send a test message:
+```bash
+aws --endpoint-url=http://localhost:4566 sqs send-message \
+  --queue-url http://localhost:4566/000000000000/demo-queue \
+  --message-body '{"type":"test","data":"hello"}'
+```
+
+## Configuration
+
+| Variable | Description | Default |
+|---|---|---|
+| `SQS_QUEUE_URL` | Full SQS queue URL | required |
+| `SQS_QUEUE_NAME` | Queue name (used as span name) | required |
+| `AWS_REGION` | AWS region | `us-east-1` |
+| `SQS_WAIT_TIME_SECONDS` | Long-poll wait (0-20s) | `5` |
+| `POLL_INTERVAL_MS` | Delay between poll cycles | `5000` |
+| `SQS_ENDPOINT` | Override endpoint (LocalStack) | — |
+| `OTEL_SERVICE_NAME` | Service name in traces | `nestjs-sqs-subscriber` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint | required |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Auth headers for OTLP | required |
+
+## Key Implementation Details
+
+### Poll Cycle Span
+`SqsPollerService.pollOnce()` creates a root `sqs.poll_cycle` span wrapping the entire interval tick. All receive and process spans are children. Use this to correlate "why did this poll take long?" with the batch it processed.
+
+### Per-Message Spans
+Each `Message` from a `ReceiveMessageCommand` response gets its own `SPAN_KIND_CONSUMER` child span. This lets you see individual message latency, failures, and log lines separately — critical when processing batches of 10.
+
+### Producer Context Linking
+If the message sender uses `AwsInstrumentation` (which auto-injects `traceparent` into `MessageAttributes`), the consumer extracts that context and adds it as a **span link** — not a parent. This creates two independent trace trees (producer's + consumer's) that can navigate to each other in Last9.
+
+`MessageAttributeNames: ['All']` in `ReceiveMessageCommand` is required for this to work.
+
+### Log Correlation
+`getTraceContext()` reads the active span's `traceId` and `spanId` and injects them into log objects. In Last9, filter logs by `trace_id` to see all logs from a single message's processing.
+
+## Verification
+
+After starting, you should see in Last9:
+1. **Traces**: `sqs.poll_cycle` spans appearing at your poll interval
+2. **Child spans**: `<queue> process` spans for each received message
+3. **Logs**: Log entries with `trace_id` field matching the trace in the UI
+
+## References
+
+- [Last9 OTLP setup](https://docs.last9.io)
+- [@opentelemetry/instrumentation-aws-sdk](https://www.npmjs.com/package/@opentelemetry/instrumentation-aws-sdk)
+- [OTel Messaging Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/messaging/)

--- a/javascript/nestjs-sqs-correlation/docker-compose.yaml
+++ b/javascript/nestjs-sqs-correlation/docker-compose.yaml
@@ -1,0 +1,32 @@
+services:
+  localstack:
+    image: localstack/localstack:3
+    ports:
+      - "4566:4566"
+    environment:
+      SERVICES: sqs
+      DEFAULT_REGION: us-east-1
+    volumes:
+      - ./scripts/init-sqs.sh:/etc/localstack/init/ready.d/init-sqs.sh
+
+  app:
+    build: .
+    env_file: .env
+    environment:
+      AWS_REGION: us-east-1
+      SQS_ENDPOINT: http://localstack:4566
+      SQS_QUEUE_URL: http://localstack:4566/000000000000/demo-queue
+      SQS_QUEUE_NAME: demo-queue
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+    depends_on:
+      - localstack
+      - otel-collector
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.144.0
+    command: ["--config=/etc/otel-config.yaml"]
+    volumes:
+      - ./otel-config.yaml:/etc/otel-config.yaml
+    ports:
+      - "4318:4318"

--- a/javascript/nestjs-sqs-correlation/nest-cli.json
+++ b/javascript/nestjs-sqs-correlation/nest-cli.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "deleteOutDir": true
+  }
+}

--- a/javascript/nestjs-sqs-correlation/otel-config.yaml
+++ b/javascript/nestjs-sqs-correlation/otel-config.yaml
@@ -1,0 +1,19 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlphttp:
+    endpoint: ${env:OTEL_EXPORTER_OTLP_ENDPOINT}
+    headers:
+      Authorization: ${env:OTEL_EXPORTER_OTLP_HEADERS}
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp, debug]

--- a/javascript/nestjs-sqs-correlation/package.json
+++ b/javascript/nestjs-sqs-correlation/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "nestjs-sqs-correlation",
+  "version": "0.0.1",
+  "description": "NestJS SQS polling with OpenTelemetry trace correlation per message and per poll cycle",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "build": "nest build",
+    "start": "node -r ./dist/instrumentation dist/main",
+    "start:dev": "ts-node -r ./src/instrumentation src/main.ts",
+    "start:prod": "node dist/main"
+  },
+  "dependencies": {
+    "@aws-sdk/client-sqs": "^3.758.0",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/config": "^3.2.3",
+    "@nestjs/core": "^10.4.4",
+    "@nestjs/platform-express": "^10.4.15",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api-logs": "^0.201.1",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.201.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.201.1",
+    "@opentelemetry/instrumentation": "^0.201.1",
+    "@opentelemetry/instrumentation-aws-sdk": "^0.48.0",
+    "@opentelemetry/instrumentation-http": "^0.201.1",
+    "@opentelemetry/resources": "^2.0.1",
+    "@opentelemetry/sdk-logs": "^0.201.1",
+    "@opentelemetry/sdk-trace-base": "^2.0.1",
+    "@opentelemetry/sdk-trace-node": "^2.0.1",
+    "dotenv": "^16.4.5",
+    "reflect-metadata": "^0.2.0",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.4.5",
+    "@nestjs/schematics": "^10.0.0",
+    "@types/node": "^20.3.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.1.3"
+  }
+}

--- a/javascript/nestjs-sqs-correlation/scripts/init-sqs.sh
+++ b/javascript/nestjs-sqs-correlation/scripts/init-sqs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Creates a demo SQS queue in LocalStack for local testing
+awslocal sqs create-queue --queue-name demo-queue

--- a/javascript/nestjs-sqs-correlation/src/app.module.ts
+++ b/javascript/nestjs-sqs-correlation/src/app.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { SqsModule } from "./sqs/sqs.module";
+import { ProcessingModule } from "./processing/processing.module";
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    ProcessingModule,
+    SqsModule,
+  ],
+})
+export class AppModule {}

--- a/javascript/nestjs-sqs-correlation/src/instrumentation.ts
+++ b/javascript/nestjs-sqs-correlation/src/instrumentation.ts
@@ -1,0 +1,43 @@
+// Must be imported before any other module
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { LoggerProvider, BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
+import { logs } from "@opentelemetry/api-logs";
+import { registerInstrumentations } from "@opentelemetry/instrumentation";
+import { AwsInstrumentation } from "@opentelemetry/instrumentation-aws-sdk";
+import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+
+const resource = resourceFromAttributes({
+  "service.name": process.env.OTEL_SERVICE_NAME ?? "nestjs-sqs-subscriber",
+  "deployment.environment": process.env.NODE_ENV ?? "development",
+});
+
+// Traces
+const traceProvider = new NodeTracerProvider({
+  resource,
+  spanProcessors: [new BatchSpanProcessor(new OTLPTraceExporter())],
+});
+traceProvider.register();
+
+// Logs — exports structured log records to Last9 via OTLP
+// OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_EXPORTER_OTLP_HEADERS are read automatically
+const loggerProvider = new LoggerProvider({ resource });
+loggerProvider.addLogRecordProcessor(
+  new BatchLogRecordProcessor(new OTLPLogExporter()),
+);
+logs.setGlobalLoggerProvider(loggerProvider);
+
+registerInstrumentations({
+  instrumentations: [
+    new AwsInstrumentation({
+      // Extracts W3C traceparent from MessageAttributes on receive.
+      // Requires MessageAttributeNames: ['All'] in ReceiveMessageCommand.
+      // Set to true if producer embeds traceparent in message body JSON instead.
+      sqsExtractContextPropagationFromPayload: false,
+    }),
+    new HttpInstrumentation(),
+  ],
+});

--- a/javascript/nestjs-sqs-correlation/src/main.ts
+++ b/javascript/nestjs-sqs-correlation/src/main.ts
@@ -1,0 +1,16 @@
+// instrumentation must load before NestJS bootstraps
+import "./instrumentation";
+
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "./app.module";
+import { OtelLogger } from "./otel-logger";
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule, {
+    bufferLogs: true,
+  });
+  app.useLogger(new OtelLogger());
+  await app.listen(process.env.PORT ?? 3000);
+}
+
+bootstrap();

--- a/javascript/nestjs-sqs-correlation/src/otel-logger.ts
+++ b/javascript/nestjs-sqs-correlation/src/otel-logger.ts
@@ -1,0 +1,64 @@
+import { LoggerService } from "@nestjs/common";
+import { SeverityNumber, logs } from "@opentelemetry/api-logs";
+import { context } from "@opentelemetry/api";
+
+// NestJS logger that emits structured records via OTel Logs API.
+// Records are exported to Last9 via OTLP alongside traces.
+// trace_id and span_id are set automatically from the active span context,
+// enabling log-to-trace correlation in the Last9 UI.
+export class OtelLogger implements LoggerService {
+  private readonly otelLogger = logs.getLogger("nestjs-sqs");
+
+  log(message: unknown, context?: string) {
+    this.emit(SeverityNumber.INFO, "INFO", message, context);
+  }
+
+  error(message: unknown, trace?: string, ctx?: string) {
+    this.emit(SeverityNumber.ERROR, "ERROR", message, ctx, trace);
+  }
+
+  warn(message: unknown, context?: string) {
+    this.emit(SeverityNumber.WARN, "WARN", message, context);
+  }
+
+  debug(message: unknown, context?: string) {
+    this.emit(SeverityNumber.DEBUG, "DEBUG", message, context);
+  }
+
+  verbose(message: unknown, context?: string) {
+    this.emit(SeverityNumber.TRACE, "TRACE", message, context);
+  }
+
+  private emit(
+    severityNumber: SeverityNumber,
+    severityText: string,
+    message: unknown,
+    logContext?: string,
+    stackTrace?: string,
+  ) {
+    const attributes: Record<string, string> = {};
+
+    if (logContext) attributes["code.namespace"] = logContext;
+    if (stackTrace) attributes["exception.stacktrace"] = stackTrace;
+
+    // Flatten structured log objects into attributes for queryability in Last9
+    if (typeof message === "object" && message !== null) {
+      for (const [k, v] of Object.entries(message)) {
+        if (typeof v === "string" || typeof v === "number") {
+          attributes[k] = String(v);
+        }
+      }
+    }
+
+    this.otelLogger.emit({
+      severityNumber,
+      severityText,
+      body:
+        typeof message === "string" ? message : JSON.stringify(message),
+      attributes,
+      // OTel SDK automatically attaches trace_id + span_id from active context.
+      // No manual injection needed here — the SDK reads context.active().
+      context: context.active(),
+    });
+  }
+}

--- a/javascript/nestjs-sqs-correlation/src/processing/message-processor.service.ts
+++ b/javascript/nestjs-sqs-correlation/src/processing/message-processor.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Message } from "@aws-sdk/client-sqs";
+import { trace } from "@opentelemetry/api";
+
+@Injectable()
+export class MessageProcessorService {
+  private readonly logger = new Logger(MessageProcessorService.name);
+
+  async handle(message: Message): Promise<void> {
+    const body = message.Body ? JSON.parse(message.Body) : {};
+
+    // Active span here is the per-message span set by SqsPollerService.
+    // Logs include trace_id + span_id from that context automatically.
+    this.logger.log({
+      message: "handling_message",
+      messageId: message.MessageId,
+      eventType: body.type,
+      ...getTraceContext(),
+    });
+
+    // Your business logic here.
+    // Any HTTP calls, DB queries, or downstream SQS sends made here
+    // will automatically be child spans of the per-message span.
+    await simulateWork(body);
+
+    this.logger.log({
+      message: "message_handled",
+      messageId: message.MessageId,
+      ...getTraceContext(),
+    });
+  }
+}
+
+function getTraceContext(): Record<string, string> {
+  const span = trace.getActiveSpan();
+  if (!span) return {};
+  const ctx = span.spanContext();
+  return { trace_id: ctx.traceId, span_id: ctx.spanId };
+}
+
+async function simulateWork(_body: unknown): Promise<void> {
+  await new Promise((r) => setTimeout(r, 50 + Math.random() * 100));
+}

--- a/javascript/nestjs-sqs-correlation/src/processing/processing.module.ts
+++ b/javascript/nestjs-sqs-correlation/src/processing/processing.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { MessageProcessorService } from "./message-processor.service";
+
+@Module({
+  providers: [MessageProcessorService],
+  exports: [MessageProcessorService],
+})
+export class ProcessingModule {}

--- a/javascript/nestjs-sqs-correlation/src/sqs/sqs-poller.service.ts
+++ b/javascript/nestjs-sqs-correlation/src/sqs/sqs-poller.service.ts
@@ -1,0 +1,216 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from "@nestjs/common";
+import {
+  DeleteMessageCommand,
+  Message,
+  ReceiveMessageCommand,
+  SQSClient,
+} from "@aws-sdk/client-sqs";
+import {
+  SpanContext,
+  SpanKind,
+  SpanStatusCode,
+  context,
+  propagation,
+  trace,
+} from "@opentelemetry/api";
+import { MessageProcessorService } from "../processing/message-processor.service";
+
+@Injectable()
+export class SqsPollerService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(SqsPollerService.name);
+  private readonly tracer = trace.getTracer("sqs-poller");
+  private readonly sqs: SQSClient;
+  private pollingTimer: ReturnType<typeof setTimeout> | null = null;
+  private running = false;
+
+  constructor(private readonly processor: MessageProcessorService) {
+    this.sqs = new SQSClient({
+      region: process.env.AWS_REGION ?? "us-east-1",
+      ...(process.env.SQS_ENDPOINT
+        ? { endpoint: process.env.SQS_ENDPOINT }
+        : {}),
+    });
+  }
+
+  onModuleInit() {
+    this.running = true;
+    void this.schedulePoll();
+  }
+
+  onModuleDestroy() {
+    this.running = false;
+    if (this.pollingTimer) clearTimeout(this.pollingTimer);
+  }
+
+  // Uses setTimeout-chaining instead of setInterval so polls never overlap.
+  private schedulePoll() {
+    const intervalMs = parseInt(process.env.POLL_INTERVAL_MS ?? "5000", 10);
+    this.pollingTimer = setTimeout(async () => {
+      if (!this.running) return;
+      await this.pollOnce();
+      if (this.running) this.schedulePoll();
+    }, intervalMs);
+  }
+
+  private async pollOnce() {
+    // Root span for the entire polling cycle — groups all message processing
+    // for this interval tick under one traceable unit.
+    const pollSpan = this.tracer.startSpan("sqs.poll_cycle", {
+      kind: SpanKind.INTERNAL,
+      attributes: {
+        "messaging.system": "aws.sqs",
+        "messaging.destination.name": process.env.SQS_QUEUE_NAME,
+      },
+    });
+
+    await context.with(trace.setSpan(context.active(), pollSpan), async () => {
+      try {
+        // AwsInstrumentation auto-instruments this call and creates a
+        // SPAN_KIND_CONSUMER span named "<queue> receive" as a child.
+        const messages = await this.receiveMessages();
+
+        pollSpan.setAttribute("messaging.batch.message_count", messages.length);
+
+        this.logger.log({
+          message: "poll_cycle",
+          count: messages.length,
+          ...this.getTraceContext(),
+        });
+
+        if (messages.length > 0) {
+          // Process all messages concurrently, each in its own child span.
+          await Promise.all(messages.map((msg) => this.processMessage(msg)));
+        }
+
+        pollSpan.setStatus({ code: SpanStatusCode.OK });
+      } catch (err) {
+        pollSpan.recordException(err as Error);
+        pollSpan.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: String(err),
+        });
+        this.logger.error({
+          message: "poll_cycle_error",
+          error: String(err),
+          ...this.getTraceContext(),
+        });
+      } finally {
+        pollSpan.end();
+      }
+    });
+  }
+
+  private async receiveMessages(): Promise<Message[]> {
+    const response = await this.sqs.send(
+      new ReceiveMessageCommand({
+        QueueUrl: process.env.SQS_QUEUE_URL,
+        MaxNumberOfMessages: 10,
+        WaitTimeSeconds: parseInt(process.env.SQS_WAIT_TIME_SECONDS ?? "5", 10),
+        // 'All' is required for AwsInstrumentation to read the traceparent
+        // MessageAttribute injected by the producer.
+        MessageAttributeNames: ["All"],
+      }),
+    );
+    return response.Messages ?? [];
+  }
+
+  private async processMessage(message: Message) {
+    // Extract the producer's span context from MessageAttributes.
+    // AwsInstrumentation injects 'traceparent' on the send side automatically.
+    const producerSpanCtx = this.extractProducerContext(message);
+
+    // Per-message span: child of poll_cycle in this service's trace,
+    // linked to the producer's trace for cross-trace navigation.
+    //
+    // Using links (not parent) keeps consumer trace independent —
+    // each subscriber creates its own trace tree while still referencing origin.
+    const msgSpan = this.tracer.startSpan(
+      `${process.env.SQS_QUEUE_NAME ?? "queue"} process`,
+      {
+        kind: SpanKind.CONSUMER,
+        links: producerSpanCtx ? [{ context: producerSpanCtx }] : [],
+        attributes: {
+          "messaging.system": "aws.sqs",
+          "messaging.destination.name": process.env.SQS_QUEUE_NAME,
+          "messaging.message.id": message.MessageId,
+          "messaging.operation": "process",
+        },
+      },
+    );
+
+    await context.with(trace.setSpan(context.active(), msgSpan), async () => {
+      try {
+        this.logger.log({
+          message: "message_processing_start",
+          messageId: message.MessageId,
+          // trace_id + span_id appear in every log line — queryable in Last9
+          ...this.getTraceContext(),
+        });
+
+        await this.processor.handle(message);
+
+        // AwsInstrumentation auto-instruments DeleteMessage as a child span.
+        await this.deleteMessage(message);
+
+        msgSpan.setStatus({ code: SpanStatusCode.OK });
+
+        this.logger.log({
+          message: "message_processing_done",
+          messageId: message.MessageId,
+          ...this.getTraceContext(),
+        });
+      } catch (err) {
+        msgSpan.recordException(err as Error);
+        msgSpan.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: String(err),
+        });
+        this.logger.error({
+          message: "message_processing_failed",
+          messageId: message.MessageId,
+          error: String(err),
+          ...this.getTraceContext(),
+        });
+      } finally {
+        msgSpan.end();
+      }
+    });
+  }
+
+  private extractProducerContext(message: Message): SpanContext | null {
+    if (!message.MessageAttributes) return null;
+
+    // Build a carrier from MessageAttributes for W3C propagation extraction.
+    // AwsInstrumentation on the producer injects 'traceparent' here automatically.
+    const carrier: Record<string, string> = {};
+    for (const [key, attr] of Object.entries(message.MessageAttributes)) {
+      const val = attr as { StringValue?: string };
+      if (val.StringValue) carrier[key.toLowerCase()] = val.StringValue;
+    }
+
+    const extractedCtx = propagation.extract(context.active(), carrier);
+    const spanCtx = trace.getSpanContext(extractedCtx);
+    return spanCtx ?? null;
+  }
+
+  private async deleteMessage(message: Message) {
+    await this.sqs.send(
+      new DeleteMessageCommand({
+        QueueUrl: process.env.SQS_QUEUE_URL,
+        ReceiptHandle: message.ReceiptHandle!,
+      }),
+    );
+  }
+
+  private getTraceContext(): Record<string, string> {
+    const span = trace.getActiveSpan();
+    if (!span) return {};
+    const ctx = span.spanContext();
+    return { trace_id: ctx.traceId, span_id: ctx.spanId };
+  }
+}

--- a/javascript/nestjs-sqs-correlation/src/sqs/sqs-poller.service.ts
+++ b/javascript/nestjs-sqs-correlation/src/sqs/sqs-poller.service.ts
@@ -183,19 +183,52 @@ export class SqsPollerService implements OnModuleInit, OnModuleDestroy {
   }
 
   private extractProducerContext(message: Message): SpanContext | null {
-    if (!message.MessageAttributes) return null;
+    // Path 1: direct app → SQS (or SNS→SQS with rawMessageDelivery=true)
+    // AwsInstrumentation injects traceparent into MessageAttributes automatically.
+    const fromAttrs = this.extractFromMessageAttributes(message);
+    if (fromAttrs) return fromAttrs;
 
-    // Build a carrier from MessageAttributes for W3C propagation extraction.
-    // AwsInstrumentation on the producer injects 'traceparent' here automatically.
+    // Path 2: SNS→SQS with rawMessageDelivery=false (default SNS subscription).
+    // SNS wraps the message in a JSON envelope; MessageAttributes are embedded
+    // inside the body under body.MessageAttributes[key].Value.
+    //
+    // Preferred fix: enable rawMessageDelivery on the SNS→SQS subscription so
+    // MessageAttributes pass through to SQS (Path 1 works for both).
+    // Use this fallback only when you cannot change the SNS subscription config.
+    return this.extractFromSnsEnvelope(message);
+  }
+
+  private extractFromMessageAttributes(message: Message): SpanContext | null {
+    if (!message.MessageAttributes) return null;
     const carrier: Record<string, string> = {};
     for (const [key, attr] of Object.entries(message.MessageAttributes)) {
       const val = attr as { StringValue?: string };
       if (val.StringValue) carrier[key.toLowerCase()] = val.StringValue;
     }
+    return this.spanContextFrom(carrier);
+  }
 
+  private extractFromSnsEnvelope(message: Message): SpanContext | null {
+    if (!message.Body) return null;
+    try {
+      const envelope = JSON.parse(message.Body) as {
+        Type?: string;
+        MessageAttributes?: Record<string, { Type: string; Value: string }>;
+      };
+      if (envelope.Type !== "Notification" || !envelope.MessageAttributes) return null;
+      const carrier: Record<string, string> = {};
+      for (const [key, attr] of Object.entries(envelope.MessageAttributes)) {
+        if (attr.Type === "String") carrier[key.toLowerCase()] = attr.Value;
+      }
+      return this.spanContextFrom(carrier);
+    } catch {
+      return null;
+    }
+  }
+
+  private spanContextFrom(carrier: Record<string, string>): SpanContext | null {
     const extractedCtx = propagation.extract(context.active(), carrier);
-    const spanCtx = trace.getSpanContext(extractedCtx);
-    return spanCtx ?? null;
+    return trace.getSpanContext(extractedCtx) ?? null;
   }
 
   private async deleteMessage(message: Message) {

--- a/javascript/nestjs-sqs-correlation/src/sqs/sqs-producer.service.ts
+++ b/javascript/nestjs-sqs-correlation/src/sqs/sqs-producer.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from "@nestjs/common";
+import {
+  MessageAttributeValue,
+  SendMessageCommand,
+  SQSClient,
+} from "@aws-sdk/client-sqs";
+import { context, propagation, trace } from "@opentelemetry/api";
+
+@Injectable()
+export class SqsProducerService {
+  private readonly sqs: SQSClient;
+
+  constructor() {
+    this.sqs = new SQSClient({
+      region: process.env.AWS_REGION ?? "us-east-1",
+      ...(process.env.SQS_ENDPOINT
+        ? { endpoint: process.env.SQS_ENDPOINT }
+        : {}),
+    });
+  }
+
+  async send(payload: Record<string, unknown>): Promise<void> {
+    // Inject the active span's W3C traceparent into MessageAttributes so the
+    // consumer (SqsPollerService) can extract and link back to this trace.
+    //
+    // AwsInstrumentation does this automatically when you have it registered —
+    // shown here explicitly for clarity on what propagation looks like.
+    const messageAttributes: Record<string, MessageAttributeValue> = {};
+    propagation.inject(context.active(), messageAttributes, {
+      set(carrier, key, value) {
+        carrier[key] = { DataType: "String", StringValue: value };
+      },
+    });
+
+    await this.sqs.send(
+      new SendMessageCommand({
+        QueueUrl: process.env.SQS_QUEUE_URL,
+        MessageBody: JSON.stringify(payload),
+        MessageAttributes: messageAttributes,
+      }),
+    );
+  }
+}
+
+export function getTraceContext(): Record<string, string> {
+  const span = trace.getActiveSpan();
+  if (!span) return {};
+  const ctx = span.spanContext();
+  return { trace_id: ctx.traceId, span_id: ctx.spanId };
+}

--- a/javascript/nestjs-sqs-correlation/src/sqs/sqs.module.ts
+++ b/javascript/nestjs-sqs-correlation/src/sqs/sqs.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { SqsPollerService } from "./sqs-poller.service";
+import { SqsProducerService } from "./sqs-producer.service";
+import { ProcessingModule } from "../processing/processing.module";
+
+@Module({
+  imports: [ProcessingModule],
+  providers: [SqsPollerService, SqsProducerService],
+  exports: [SqsProducerService],
+})
+export class SqsModule {}

--- a/javascript/nestjs-sqs-correlation/tsconfig.json
+++ b/javascript/nestjs-sqs-correlation/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2021",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": false
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `javascript/nestjs-sqs-correlation/` — NestJS service that polls SQS at fixed intervals with full OpenTelemetry trace and log correlation
- Creates a `sqs.poll_cycle` (INTERNAL) root span per interval tick, grouping all message processing under one traceable unit
- Creates a per-message `SPAN_KIND_CONSUMER` child span for each received message, with a span link to the producer's trace context (extracted from `MessageAttributes.traceparent`)
- Emits structured logs via OTel Logs API with `trace_id` + `span_id` fields for log-to-trace correlation in Last9
- Uses `setTimeout` chaining (not `setInterval`) to prevent poll cycles from overlapping

## Span structure

```
sqs.poll_cycle (INTERNAL)
├── <queue> receive (CONSUMER)  ← auto by AwsInstrumentation
├── <queue> process (CONSUMER)  ← manual, per message
│     ├── link → producer trace
│     └── SQS.DeleteMessage     ← auto by AwsInstrumentation
└── <queue> process (CONSUMER)  ← parallel per message
```

## Test plan

- [ ] `npm install && npm run start:dev` with LocalStack or real SQS queue
- [ ] Send test message, verify `sqs.poll_cycle` and `<queue> process` spans appear in Last9
- [ ] Verify log entries include `trace_id` and `span_id` fields matching the trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)