### PR TITLE
feat(otel-collector): cloudflare tunnel journald logs with severity remap

### DIFF
--- a/cloudflare-tunnel/.env.example
+++ b/cloudflare-tunnel/.env.example
@@ -1,0 +1,2 @@
+LAST9_OTLP_ENDPOINT=https://otlp-aps1.last9.io
+LAST9_AUTH_HEADER=Basic <your_base64_encoded_credentials>

--- a/cloudflare-tunnel/README.md
+++ b/cloudflare-tunnel/README.md
@@ -1,0 +1,98 @@
+# Cloudflare Tunnel Logs → Last9
+
+Send `cloudflared` (Cloudflare Tunnel daemon) logs to Last9 via the OpenTelemetry Collector journald receiver, with correct severity mapping.
+
+## How it works
+
+`cloudflared` runs as a systemd service and writes logs to the system journal. The OTel Collector reads from journald, parses the severity from the log message body, and ships logs to Last9 over OTLP.
+
+**Why parse severity from body, not `PRIORITY`?**  
+`cloudflared` sets `PRIORITY=6` (INFO) for all log entries regardless of actual level. Severity must be extracted from the level token in the message body (`INF`, `WRN`, `ERR`, `DBG`, `FTL`).
+
+## Prerequisites
+
+- `cloudflared` installed and running as a systemd service
+- Docker + Docker Compose on the same host
+- Last9 account — get OTLP credentials from [Integrations](https://app.last9.io/integrations?integration=OpenTelemetry)
+
+## Setup
+
+**1. Clone and configure**
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env`:
+
+```bash
+LAST9_OTLP_ENDPOINT=https://otlp-aps1.last9.io
+LAST9_AUTH_HEADER=Basic <your_base64_encoded_credentials>
+CLOUDFLARE_CONNECTOR_ID=<your_connector_id>        # from Cloudflare dashboard
+CLOUDFLARE_TUNNEL_NAME=<your_tunnel_name>
+SERVICE_NAMESPACE=production
+```
+
+**2. Verify cloudflared is running**
+
+```bash
+systemctl status cloudflared
+journalctl -u cloudflared -n 20 --no-pager
+```
+
+**3. Start the collector**
+
+```bash
+docker compose up -d
+```
+
+**4. Verify logs are flowing**
+
+```bash
+# Check collector is reading journald
+docker compose logs -f otelcol
+
+# Look for lines like:
+# "Sending" otelcol.signal=logs
+```
+
+## Configuration reference
+
+| Field | Description |
+|-------|-------------|
+| `CLOUDFLARE_CONNECTOR_ID` | Connector ID from Cloudflare Zero Trust dashboard |
+| `CLOUDFLARE_TUNNEL_NAME` | Human-readable tunnel name for filtering in Last9 |
+| `SERVICE_NAMESPACE` | Logical grouping (e.g. `production`, `staging`) |
+
+## Severity mapping
+
+| cloudflared token | OTel severity |
+|-------------------|---------------|
+| `DBG` | Debug |
+| `INF` | Info |
+| `WRN` | Warn |
+| `ERR` | Error |
+| `FTL` | Fatal |
+
+## Viewing logs
+
+Visit [Last9 Log Explorer](https://app.last9.io/logs) and filter by `service.name = cloudflare-tunnel`.
+
+## Troubleshooting
+
+**No logs appearing**
+
+```bash
+# Confirm collector can read journald
+docker compose exec otelcol journalctl -u cloudflared -n 5
+# If permission denied, ensure the container's supplemental group matches
+# the systemd-journal GID on your host: `getent group systemd-journal`
+```
+
+**All logs showing as INFO severity**
+
+The regex parses the level token from the message. Confirm cloudflared log format:
+```bash
+journalctl -u cloudflared -n 5 --output=cat
+# Expected format: 2026-01-01T00:00:00Z ERR some error message
+```

--- a/cloudflare-tunnel/docker-compose.test.yml
+++ b/cloudflare-tunnel/docker-compose.test.yml
@@ -1,0 +1,13 @@
+services:
+  # Single container runs journald + cloudflared + otelcol together.
+  # This avoids cross-container boot ID mismatches when journalctl reads the journal.
+  all-in-one:
+    build:
+      context: .
+      dockerfile: test/Dockerfile.allInOne
+    privileged: true
+    volumes:
+      - ./test/otel-collector-test-config.yaml:/etc/otelcol-contrib/config.yaml:ro
+    environment:
+      - LAST9_OTLP_ENDPOINT=${LAST9_OTLP_ENDPOINT}
+      - LAST9_AUTH_HEADER=${LAST9_AUTH_HEADER}

--- a/cloudflare-tunnel/docker-compose.yml
+++ b/cloudflare-tunnel/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.120.0
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
+      # Journald log directories — collector reads cloudflared logs from host
+      - /run/log/journal:/run/log/journal:ro
+      - /var/log/journal:/var/log/journal:ro
+      - /etc/machine-id:/etc/machine-id:ro
+    environment:
+      - LAST9_OTLP_ENDPOINT=${LAST9_OTLP_ENDPOINT}
+      - LAST9_AUTH_HEADER=${LAST9_AUTH_HEADER}
+      - CLOUDFLARE_CONNECTOR_ID=${CLOUDFLARE_CONNECTOR_ID}
+      - CLOUDFLARE_TUNNEL_NAME=${CLOUDFLARE_TUNNEL_NAME}
+      - SERVICE_NAMESPACE=${SERVICE_NAMESPACE:-production}
+    restart: unless-stopped
+    # Required to access journald socket on the host
+    group_add:
+      - "systemd-journal"

--- a/cloudflare-tunnel/otel-collector-config.yaml
+++ b/cloudflare-tunnel/otel-collector-config.yaml
@@ -1,0 +1,57 @@
+receivers:
+  journald:
+    directory: /var/log/journal
+    units:
+      - cloudflared
+    priority: info
+    operators:
+      # Tag logs with tunnel identity (replace with your values)
+      - type: add
+        field: attributes["connector.id"]
+        value: "${CLOUDFLARE_CONNECTOR_ID}"
+      - type: add
+        field: attributes["tunnel.name"]
+        value: "${CLOUDFLARE_TUNNEL_NAME}"
+
+      # cloudflared emits PRIORITY=6 for all levels regardless of actual severity.
+      # Parse the level token from the MESSAGE body instead (INF/WRN/ERR/DBG/FTL).
+      - type: regex_parser
+        parse_from: body["MESSAGE"]
+        regex: '^\d{4}-\d{2}-\d{2}T[\d:Z]+ (?P<log_level>[A-Z]{2,4})'
+        on_error: send
+      - type: severity_parser
+        parse_from: attributes.log_level
+        mapping:
+          debug: DBG
+          info:  INF
+          warn:  WRN
+          error: ERR
+          fatal: FTL
+
+processors:
+  resource:
+    attributes:
+      - key: service.name
+        value: "cloudflare-tunnel"
+        action: upsert
+      - key: service.namespace
+        value: "${SERVICE_NAMESPACE}"
+        action: upsert
+  batch:
+    timeout: 5s
+    send_batch_size: 200
+
+exporters:
+  debug:
+    verbosity: detailed
+  otlphttp/last9:
+    endpoint: "${LAST9_OTLP_ENDPOINT}"
+    headers:
+      Authorization: "${LAST9_AUTH_HEADER}"
+
+service:
+  pipelines:
+    logs:
+      receivers: [journald]
+      processors: [resource, batch]
+      exporters: [otlphttp/last9]

--- a/cloudflare-tunnel/test/Dockerfile.allInOne
+++ b/cloudflare-tunnel/test/Dockerfile.allInOne
@@ -1,0 +1,20 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+    systemd \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# cloudflared — arch-aware download
+RUN ARCH=$(dpkg --print-architecture) && \
+    curl -fsSL "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${ARCH}" \
+    -o /usr/local/bin/cloudflared && chmod +x /usr/local/bin/cloudflared
+
+# otelcol-contrib binary — copy from official image
+COPY --from=otel/opentelemetry-collector-contrib:0.120.0 /otelcol-contrib /usr/local/bin/otelcol-contrib
+
+COPY test/run-all.sh /run-all.sh
+RUN chmod +x /run-all.sh
+
+CMD ["/run-all.sh"]

--- a/cloudflare-tunnel/test/otel-collector-test-config.yaml
+++ b/cloudflare-tunnel/test/otel-collector-test-config.yaml
@@ -1,0 +1,64 @@
+receivers:
+  journald:
+    # In production, use: units: [cloudflared]  (matches _SYSTEMD_UNIT=cloudflared.service)
+    # In this test, cloudflared runs via systemd-cat which sets SYSLOG_IDENTIFIER, not
+    # _SYSTEMD_UNIT — so we skip the units filter and rely on the regex operator to only
+    # process lines that match the cloudflared timestamp+level format.
+    priority: debug
+    operators:
+      - type: add
+        field: attributes["connector.id"]
+        value: "test-connector-001"
+      - type: add
+        field: attributes["tunnel.name"]
+        value: "hello-world-test"
+
+      # cloudflared sets PRIORITY=6 for all journal entries regardless of actual severity.
+      # Extract the real level from the message body level token (INF/WRN/ERR/DBG/FTL).
+      - type: regex_parser
+        parse_from: body["MESSAGE"]
+        regex: '^\d{4}-\d{2}-\d{2}T[\d:Z]+ (?P<log_level>[A-Z]{2,4})'
+        on_error: send
+      - type: severity_parser
+        parse_from: attributes.log_level
+        mapping:
+          debug: DBG
+          info:  INF
+          warn:  WRN
+          error: ERR
+          fatal: FTL
+
+processors:
+  resource:
+    attributes:
+      - key: service.name
+        value: "cloudflare-tunnel-test"
+        action: upsert
+      - key: service.namespace
+        value: "test"
+        action: upsert
+      - key: deployment.environment
+        value: "local"
+        action: upsert
+  batch:
+    timeout: 5s
+    send_batch_size: 200
+
+exporters:
+  # Prints each log record to stdout so we can verify locally before checking Last9
+  debug:
+    verbosity: detailed
+  otlphttp/last9:
+    endpoint: "${LAST9_OTLP_ENDPOINT}"
+    headers:
+      Authorization: "${LAST9_AUTH_HEADER}"
+
+service:
+  telemetry:
+    logs:
+      level: info
+  pipelines:
+    logs:
+      receivers: [journald]
+      processors: [resource, batch]
+      exporters: [debug, otlphttp/last9]

--- a/cloudflare-tunnel/test/run-all.sh
+++ b/cloudflare-tunnel/test/run-all.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+# Generate machine ID
+if [ ! -s /etc/machine-id ]; then
+    dd if=/dev/urandom bs=16 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n' > /etc/machine-id
+fi
+echo "Machine ID: $(cat /etc/machine-id)"
+
+# Create dirs for persistent journal storage
+MACHINE_ID=$(cat /etc/machine-id)
+mkdir -p /run/systemd/journal
+mkdir -p /var/log/journal/${MACHINE_ID}
+
+# Start journald
+echo "[1/3] Starting systemd-journald..."
+/lib/systemd/systemd-journald &
+JOURNALD_PID=$!
+
+# Wait for socket
+until [ -S /run/systemd/journal/socket ]; do sleep 1; done
+echo "      journald ready."
+
+# Start otelcol
+echo "[2/3] Starting otelcol..."
+otelcol-contrib --config=/etc/otelcol-contrib/config.yaml &
+OTELCOL_PID=$!
+sleep 2
+
+# Start cloudflared — pipe through systemd-cat so output lands in journal
+# with SYSLOG_IDENTIFIER=cloudflared and PRIORITY=6 (matching real-world behavior)
+echo "[3/3] Starting cloudflared hello-world tunnel..."
+cloudflared tunnel --hello-world 2>&1 | \
+    systemd-cat --identifier=cloudflared --priority=6 &
+CF_PID=$!
+
+echo "All processes running. Waiting..."
+wait $CF_PID
+echo "cloudflared exited — shutting down."
+kill $OTELCOL_PID $JOURNALD_PID 2>/dev/null || true


### PR DESCRIPTION
## Summary

- cloudflared sets `PRIORITY=6` for all journald entries regardless of actual log level — the standard journald severity field is useless for this daemon
- Adds OTel Collector journald receiver config with `regex_parser` + `severity_parser` operators to extract `INF/WRN/ERR/DBG/FTL` tokens from the message body and map them to OTel severity levels
- Includes a Docker Compose test harness (single all-in-one container: journald + cloudflared + otelcol) verified sending logs with correct severity to Last9

## Files

| File | Purpose |
|------|---------|
| `otel-collector-config.yaml` | Production config — journald receiver with severity remap, OTLP export |
| `docker-compose.yml` | Production deployment — mounts host journald dirs |
| `docker-compose.test.yml` | Test harness — all-in-one container |
| `test/Dockerfile.allInOne` | Single image: debian-slim + systemd + cloudflared + otelcol |
| `test/run-all.sh` | Starts journald → otelcol → cloudflared (via systemd-cat) |
| `test/otel-collector-test-config.yaml` | Test config — no `units` filter (systemd-cat sets SYSLOG_IDENTIFIER, not _SYSTEMD_UNIT) |
| `.env.example` | Required env vars |
| `README.md` | Setup guide |

## Test plan

- [x] Build and run `docker compose -f docker-compose.test.yml up --build`
- [x] Confirm `SeverityText: INF` and `SeverityNumber: Info(9)` in debug exporter output
- [x] Confirm OTLP export to Last9 (`cloudflare-tunnel-test` service visible in log explorer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)