### PR TITLE
feat(ruby): add Ruby Lambda OpenTelemetry example

### DIFF
--- a/aws/lambda-ruby/.env.example
+++ b/aws/lambda-ruby/.env.example
@@ -1,0 +1,17 @@
+# AWS Configuration
+AWS_DEFAULT_REGION=ap-south-1
+AWS_ACCOUNT_ID=123456789012
+
+# Lambda Configuration
+FUNCTION_NAME=ruby-lambda-otel-example
+LAMBDA_ROLE_NAME=ruby-lambda-otel-role
+
+# Last9 OTLP Configuration
+# Get these from: https://app.last9.io/integrations/opentelemetry
+OTEL_SERVICE_NAME=ruby-lambda-example
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-aps1.last9.io:443
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <your-base64-credentials>
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_TRACES_SAMPLER=always_on
+OTEL_PROPAGATORS=tracecontext,baggage,xray
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production

--- a/aws/lambda-ruby/.gitignore
+++ b/aws/lambda-ruby/.gitignore
@@ -1,0 +1,5 @@
+.env
+vendor/
+.bundle/
+function.zip
+response.json

--- a/aws/lambda-ruby/Gemfile
+++ b/aws/lambda-ruby/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 ruby '>= 3.2'
 
 gem 'aws-sdk-s3', '~> 1'
+gem 'rexml'
 gem 'opentelemetry-exporter-otlp'
 gem 'opentelemetry-instrumentation-aws_lambda'
 gem 'opentelemetry-instrumentation-aws_sdk'

--- a/aws/lambda-ruby/Gemfile
+++ b/aws/lambda-ruby/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+ruby '>= 3.2'
+
+gem 'aws-sdk-s3', '~> 1'
+gem 'opentelemetry-exporter-otlp'
+gem 'opentelemetry-instrumentation-aws_lambda'
+gem 'opentelemetry-instrumentation-aws_sdk'
+gem 'opentelemetry-sdk'

--- a/aws/lambda-ruby/Gemfile.lock
+++ b/aws/lambda-ruby/Gemfile.lock
@@ -1,0 +1,144 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1240.0)
+    aws-sdk-core (3.245.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.123.0)
+      aws-sdk-core (~> 3, >= 3.244.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.220.0)
+      aws-sdk-core (~> 3, >= 3.244.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    google-protobuf (4.34.1)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-aarch64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    googleapis-common-protos-types (1.22.0)
+      google-protobuf (~> 4.26)
+    jmespath (1.6.2)
+    logger (1.7.0)
+    opentelemetry-api (1.9.0)
+      logger
+    opentelemetry-common (0.24.0)
+      opentelemetry-api (~> 1.0)
+    opentelemetry-exporter-otlp (0.33.0)
+      google-protobuf (>= 3.18)
+      googleapis-common-protos-types (~> 1.3)
+      opentelemetry-api (~> 1.1)
+      opentelemetry-common (~> 0.20)
+      opentelemetry-sdk (~> 1.10)
+      opentelemetry-semantic_conventions
+    opentelemetry-instrumentation-aws_lambda (0.7.0)
+      opentelemetry-instrumentation-base (~> 0.25)
+    opentelemetry-instrumentation-aws_sdk (0.12.0)
+      opentelemetry-instrumentation-base (~> 0.25)
+    opentelemetry-instrumentation-base (0.26.0)
+      opentelemetry-api (~> 1.7)
+      opentelemetry-common (~> 0.21)
+      opentelemetry-registry (~> 0.1)
+    opentelemetry-registry (0.5.0)
+      opentelemetry-api (~> 1.1)
+    opentelemetry-sdk (1.11.0)
+      logger
+      opentelemetry-api (~> 1.1)
+      opentelemetry-common (~> 0.20)
+      opentelemetry-registry (~> 0.2)
+      opentelemetry-semantic_conventions
+    opentelemetry-semantic_conventions (1.37.0)
+      opentelemetry-api (~> 1.0)
+    rake (13.4.2)
+    rexml (3.4.4)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm64-darwin
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  aws-sdk-s3 (~> 1)
+  opentelemetry-exporter-otlp
+  opentelemetry-instrumentation-aws_lambda
+  opentelemetry-instrumentation-aws_sdk
+  opentelemetry-sdk
+  rexml
+
+CHECKSUMS
+  aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
+  aws-partitions (1.1240.0) sha256=b885b21712fdad699c56a28434756ed27f1389b07231320796dda9e7551de4a7
+  aws-sdk-core (3.245.0) sha256=94f43b40508c346f1625b3d31f811c5841b667c92de14d5fb3c473b1284cb4ad
+  aws-sdk-kms (1.123.0) sha256=d405f37e82f8fa32045ca8980be266c0b45b37aaf2012afe0254321a1e811f20
+  aws-sdk-s3 (1.220.0) sha256=237fda5e6ac7ecdd9c848e27187bfdc370edad5c5a141aeec389fb450fa28c7c
+  aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  google-protobuf (4.34.1) sha256=347181542b8d659c60f028fa3791c9cccce651a91ad27782dbc5c5e374796cdc
+  google-protobuf (4.34.1-aarch64-linux-gnu) sha256=f9c07607dc139c895f2792a7740fcd01cd94d4d7b0e0a939045b50d7999f0b1d
+  google-protobuf (4.34.1-aarch64-linux-musl) sha256=db58e5a4a492b43c6614486aea31b7fb86955b175d1d48f28ebf388f058d78a9
+  google-protobuf (4.34.1-arm64-darwin) sha256=2745061f973119e6e7f3c81a0c77025d291a3caa6585a2cd24a25bbc7bedb267
+  google-protobuf (4.34.1-x86-linux-gnu) sha256=b6da7891fe96b13038e5435d8ac8b8a84d78a468147a48a377fe8da40aba1c88
+  google-protobuf (4.34.1-x86-linux-musl) sha256=ea0f453e78f4c30d0d9dbaa8cf9b33d2a1ea04ab2cad2c2a07e479411c05f1a9
+  google-protobuf (4.34.1-x86_64-darwin) sha256=4dc498376e218871613589c4d872400d42ad9ae0c700bdb2606fe1c77a593075
+  google-protobuf (4.34.1-x86_64-linux-gnu) sha256=87088c9fd8e47b5b40ca498fc1195add6149e941ff7e81c532a5b0b8876d4cc9
+  google-protobuf (4.34.1-x86_64-linux-musl) sha256=8c0e91436fbe504ffc64f0bd621f2e69adbcce8ed2c58439d7a21117069cfdd7
+  googleapis-common-protos-types (1.22.0) sha256=f97492b77bd6da0018c860d5004f512fe7cd165554d7019a8f4df6a56fbfc4c7
+  jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  opentelemetry-api (1.9.0) sha256=d24065dd26583babd8d498d38ea35f74dfa193fb7102512e6e161649440079fb
+  opentelemetry-common (0.24.0) sha256=f1647b233b8ac667feeb74d66a65b702008d9ab55aae825c220b4fe2c14fa773
+  opentelemetry-exporter-otlp (0.33.0) sha256=6e9ce38e393c7eb9aea3fb57b128174a0066767bf495f4fd9e63d7607e0b2ad3
+  opentelemetry-instrumentation-aws_lambda (0.7.0) sha256=50e5a32c454f2d38ecb53cc94e77dc646b33c47294cc6e6363e7c226097fa132
+  opentelemetry-instrumentation-aws_sdk (0.12.0) sha256=e2f48bf471cefe4d4bd9cfdafabffce65790b73381040e82d337933ac8bfb366
+  opentelemetry-instrumentation-base (0.26.0) sha256=fdec8bff9a8de04d113bd4e8d490b17414c92d6c79dd457dfa079c97ba922be0
+  opentelemetry-registry (0.5.0) sha256=726ca58ada93a23efaa5f7bb81b8ab7a8a1e14602935c9c65dfa2e597a19fb4f
+  opentelemetry-sdk (1.11.0) sha256=427c6708f4732105ffa46c11afecb91807085c59e92538eaa6cf46b97b1850c6
+  opentelemetry-semantic_conventions (1.37.0) sha256=1e2dc5ad649e19ba2fb0fa7c6f9303e5cdd8d3952511415cb07efe28a0f8f4c3
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+
+RUBY VERSION
+  ruby 3.3.3
+
+BUNDLED WITH
+  4.0.2

--- a/aws/lambda-ruby/README.md
+++ b/aws/lambda-ruby/README.md
@@ -1,0 +1,152 @@
+# Ruby Lambda with OpenTelemetry - Last9 Integration
+
+Instrument a Ruby AWS Lambda function with OpenTelemetry and send traces to Last9.
+
+Unlike Python, Node.js, and Java — Ruby has no AWS-managed ADOT language layer. Instead:
+- ✅ Direct OTLP export from the Ruby OTel SDK (no collector sidecar needed)
+- ✅ `opentelemetry-instrumentation-aws_lambda` auto-creates the root invocation span
+- ✅ `opentelemetry-instrumentation-aws_sdk` auto-instruments S3, SES, SQS, DynamoDB calls
+- ✅ `force_flush` in `ensure` block guarantees spans ship before Lambda freezes
+
+## Trace Hierarchy
+
+```
+lambda_handler (auto — AwsLambda instrumentation)
+  └─ process_event (manual span)
+       └─ S3.GetObject (auto — AwsSdk instrumentation)
+```
+
+## Quick Start
+
+### 1. Configure Environment
+
+```bash
+cp .env.example .env
+# Edit .env — fill in OTLP endpoint and credentials from app.last9.io/integrations/opentelemetry
+```
+
+### 2. Install Dependencies
+
+```bash
+bundle install
+```
+
+### 3. Deploy
+
+```bash
+chmod +x deploy.sh
+./deploy.sh
+```
+
+### 4. Test
+
+```bash
+aws lambda invoke \
+  --function-name ruby-lambda-otel-example \
+  --region ap-south-1 \
+  --payload file://test-payload.json \
+  response.json
+
+cat response.json
+```
+
+### 5. View Traces
+
+Open [app.last9.io/traces](https://app.last9.io/traces) and filter by your service name.
+
+## How It Works
+
+### `setup_otel.rb`
+
+Initializes the OTel SDK once. The `return if defined?(OTEL_TRACER)` guard prevents
+double-initialization when tests load their own exporter before this file runs.
+
+```ruby
+require 'opentelemetry/instrumentation/aws_lambda'
+require 'opentelemetry/instrumentation/aws_sdk'
+
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::AwsLambda'  # auto root span
+  c.use 'OpenTelemetry::Instrumentation::AwsSdk'      # auto S3/SES/SQS spans
+  c.add_span_processor(
+    OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
+      OpenTelemetry::Exporter::OTLP::Exporter.new
+    )
+  )
+end
+```
+
+### `lambda_function.rb`
+
+The handler calls `force_flush` in `ensure` — this is critical:
+
+```ruby
+def lambda_handler(event:, context:)
+  # ... your logic ...
+ensure
+  OpenTelemetry.tracer_provider.force_flush
+end
+```
+
+## Environment Variables
+
+| Variable | Required | Example |
+|----------|----------|---------|
+| `OTEL_SERVICE_NAME` | Yes | `ruby-lambda-example` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes | `https://otlp-aps1.last9.io:443` |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Yes | `Authorization=Basic abc123==` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Yes | `http/protobuf` |
+| `OTEL_TRACES_SAMPLER` | Yes | `always_on` |
+| `OTEL_PROPAGATORS` | No | `tracecontext,baggage,xray` |
+| `OTEL_RESOURCE_ATTRIBUTES` | No | `deployment.environment=production` |
+
+## Packaging Gems
+
+Lambda requires gems pre-bundled. The deploy script handles this automatically:
+
+```bash
+bundle config set --local path 'vendor/bundle'
+bundle install
+zip -qr function.zip lambda_function.rb setup_otel.rb Gemfile Gemfile.lock vendor/
+```
+
+## Troubleshooting
+
+### No traces in Last9
+
+1. Check CloudWatch logs: `aws logs tail /aws/lambda/your-function --follow`
+2. Verify `force_flush` is in the `ensure` block
+3. Check `OTEL_EXPORTER_OTLP_HEADERS` format: must be `Authorization=Basic ...` (key=value)
+
+### `Cannot load such file` errors
+
+Gems not bundled into the zip. Run `bundle install` before `deploy.sh`.
+
+### Header format
+
+```
+# Wrong
+OTEL_EXPORTER_OTLP_HEADERS=Basic bGFzdDk6...
+
+# Right
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic bGFzdDk6...
+```
+
+## Files
+
+```
+.
+├── lambda_function.rb   # Lambda handler with manual spans
+├── setup_otel.rb        # OTel SDK initialization (idempotent)
+├── Gemfile              # Dependencies
+├── .env.example         # Environment variable template
+├── deploy.sh            # Automated deployment script
+├── test-payload.json    # Sample test event
+└── README.md
+```
+
+## Additional Resources
+
+- [Last9 OpenTelemetry Documentation](https://last9.io/docs/integrations/cloud-providers/aws-lambda)
+- [opentelemetry-instrumentation-aws_lambda](https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/aws_lambda)
+- [opentelemetry-instrumentation-aws_sdk](https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/aws_sdk)

--- a/aws/lambda-ruby/deploy.sh
+++ b/aws/lambda-ruby/deploy.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Ruby Lambda Deployment Script
+# Deploys a Ruby Lambda function with OpenTelemetry instrumentation to Last9.
+
+set -e
+
+if [ -f .env ]; then
+  export $(grep -v '^#' .env | xargs)
+else
+  echo "Error: .env file not found. Copy .env.example to .env and fill in your values."
+  exit 1
+fi
+
+: "${AWS_DEFAULT_REGION:?AWS_DEFAULT_REGION not set}"
+: "${AWS_ACCOUNT_ID:?AWS_ACCOUNT_ID not set}"
+: "${FUNCTION_NAME:?FUNCTION_NAME not set}"
+: "${LAMBDA_ROLE_NAME:?LAMBDA_ROLE_NAME not set}"
+: "${OTEL_EXPORTER_OTLP_ENDPOINT:?OTEL_EXPORTER_OTLP_ENDPOINT not set}"
+: "${OTEL_EXPORTER_OTLP_HEADERS:?OTEL_EXPORTER_OTLP_HEADERS not set}"
+
+ROLE_ARN="arn:aws:iam::${AWS_ACCOUNT_ID}:role/${LAMBDA_ROLE_NAME}"
+
+echo "📦 Installing gems into vendor/bundle (Lambda-compatible)..."
+bundle config set --local path 'vendor/bundle'
+bundle config set --local without 'development test'
+bundle install
+
+echo "📦 Creating deployment package..."
+zip -qr function.zip lambda_function.rb setup_otel.rb Gemfile Gemfile.lock vendor/
+
+echo "🔐 Ensuring IAM role exists..."
+if ! aws iam get-role --role-name "${LAMBDA_ROLE_NAME}" --region "${AWS_DEFAULT_REGION}" &>/dev/null; then
+  cat > /tmp/trust-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Service": "lambda.amazonaws.com" },
+    "Action": "sts:AssumeRole"
+  }]
+}
+EOF
+  aws iam create-role \
+    --role-name "${LAMBDA_ROLE_NAME}" \
+    --assume-role-policy-document file:///tmp/trust-policy.json
+
+  aws iam attach-role-policy \
+    --role-name "${LAMBDA_ROLE_NAME}" \
+    --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  echo "Waiting for IAM role to propagate..."
+  sleep 10
+fi
+
+ENV_VARS="Variables={\
+OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-ruby-lambda-example},\
+OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT},\
+OTEL_EXPORTER_OTLP_HEADERS=${OTEL_EXPORTER_OTLP_HEADERS},\
+OTEL_EXPORTER_OTLP_PROTOCOL=${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf},\
+OTEL_TRACES_SAMPLER=${OTEL_TRACES_SAMPLER:-always_on},\
+OTEL_PROPAGATORS=${OTEL_PROPAGATORS:-tracecontext,baggage,xray},\
+OTEL_RESOURCE_ATTRIBUTES=${OTEL_RESOURCE_ATTRIBUTES:-deployment.environment=production}\
+}"
+
+if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${AWS_DEFAULT_REGION}" &>/dev/null; then
+  echo "🔄 Updating existing function..."
+  aws lambda update-function-code \
+    --function-name "${FUNCTION_NAME}" \
+    --zip-file fileb://function.zip \
+    --region "${AWS_DEFAULT_REGION}"
+
+  aws lambda update-function-configuration \
+    --function-name "${FUNCTION_NAME}" \
+    --environment "${ENV_VARS}" \
+    --region "${AWS_DEFAULT_REGION}"
+else
+  echo "🚀 Creating Lambda function..."
+  aws lambda create-function \
+    --function-name "${FUNCTION_NAME}" \
+    --runtime ruby3.2 \
+    --role "${ROLE_ARN}" \
+    --handler lambda_function.lambda_handler \
+    --zip-file fileb://function.zip \
+    --timeout 30 \
+    --memory-size 256 \
+    --environment "${ENV_VARS}" \
+    --region "${AWS_DEFAULT_REGION}"
+fi
+
+echo ""
+echo "✅ Deployed ${FUNCTION_NAME} to ${AWS_DEFAULT_REGION}"
+echo ""
+echo "Test with:"
+echo "  aws lambda invoke --function-name ${FUNCTION_NAME} --region ${AWS_DEFAULT_REGION} --payload '{}' response.json && cat response.json"
+echo ""
+echo "View traces at: https://app.last9.io/traces"

--- a/aws/lambda-ruby/lambda_function.rb
+++ b/aws/lambda-ruby/lambda_function.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+$stdout.sync = true
+
+require 'aws-sdk-s3'
+require 'json'
+require 'logger'
+require_relative './setup_otel'
+
+LOGGER = Logger.new($stdout)
+
+# rubocop:disable Lint/UnusedMethodArgument
+def lambda_handler(event:, context:)
+  LOGGER.info("Processing event: #{event.inspect}")
+
+  OTEL_TRACER.in_span('process_event', attributes: { 'event.keys' => event.keys.join(',') }) do |span|
+    result = process(event, span)
+    span.set_attribute('result.status', 'ok')
+    result
+  rescue StandardError => e
+    span.record_exception(e)
+    span.status = OpenTelemetry::Trace::Status.error(e.message)
+    raise
+  end
+ensure
+  # Critical: flush buffered spans before Lambda process freezes.
+  OpenTelemetry.tracer_provider.force_flush
+end
+# rubocop:enable Lint/UnusedMethodArgument
+
+def process(event, span)
+  bucket = event['bucket']
+  key    = event['key']
+
+  if bucket && key
+    span.set_attribute('s3.bucket', bucket)
+    span.set_attribute('s3.key', key)
+
+    # AwsSdk instrumentation auto-creates a child span for this call.
+    s3 = Aws::S3::Client.new
+    response = s3.get_object(bucket: bucket, key: key)
+    body = response.body.read
+
+    LOGGER.info("Fetched #{body.bytesize} bytes from s3://#{bucket}/#{key}")
+    { status: 'ok', bytes: body.bytesize }
+  else
+    { status: 'ok', message: 'hello from ruby lambda' }
+  end
+end

--- a/aws/lambda-ruby/run_local.rb
+++ b/aws/lambda-ruby/run_local.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Local test runner — simulates Lambda invocation without AWS infrastructure.
+$LOAD_PATH.unshift(__dir__)
+require_relative 'lambda_function'
+
+puts "Running lambda_handler with test payload..."
+result = lambda_handler(event: { 'message' => 'hello from local test' }, context: nil)
+puts "Result: #{result.inspect}"
+puts "Done. Traces exported to Last9."

--- a/aws/lambda-ruby/setup_otel.rb
+++ b/aws/lambda-ruby/setup_otel.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Skip if already configured (e.g., test environment sets up its own exporter).
+return if defined?(OTEL_TRACER)
+
+require 'opentelemetry/sdk'
+require 'opentelemetry/exporter/otlp'
+require 'opentelemetry/instrumentation/aws_lambda'
+require 'opentelemetry/instrumentation/aws_sdk'
+
+OpenTelemetry::SDK.configure do |c|
+  c.service_name = ENV.fetch('OTEL_SERVICE_NAME', 'ruby-lambda')
+  c.use 'OpenTelemetry::Instrumentation::AwsLambda'
+  c.use 'OpenTelemetry::Instrumentation::AwsSdk'
+  c.add_span_processor(
+    OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
+      OpenTelemetry::Exporter::OTLP::Exporter.new
+    )
+  )
+end
+
+OTEL_TRACER = OpenTelemetry.tracer_provider.tracer(
+  ENV.fetch('OTEL_SERVICE_NAME', 'ruby-lambda'),
+  '1.0.0'
+)

--- a/aws/lambda-ruby/test-payload.json
+++ b/aws/lambda-ruby/test-payload.json
@@ -1,0 +1,3 @@
+{
+  "message": "hello from test"
+}


### PR DESCRIPTION
## Summary

- Adds `aws/lambda-ruby/` example for instrumenting a Ruby AWS Lambda function with OpenTelemetry
- Uses direct OTLP export to Last9 (no ADOT language layer — Ruby has none)
- `opentelemetry-instrumentation-aws_lambda` auto-creates root invocation span
- `opentelemetry-instrumentation-aws_sdk` auto-instruments S3/SES/SQS/DynamoDB calls
- `setup_otel.rb` uses idempotent guard (`return if defined?(OTEL_TRACER)`) to avoid double-configure in test environments
- `force_flush` in `ensure` block ensures spans ship before Lambda process freezes
- Includes `deploy.sh`, `.env.example`, `README.md`

## Trace hierarchy

```
lambda_handler           ← auto (AwsLambda instrumentation)
  └─ process_event       ← manual span
       └─ S3.GetObject   ← auto (AwsSdk instrumentation)
```

## Test plan

- [ ] `bundle install` succeeds
- [ ] Deploy with `./deploy.sh` — function created/updated in AWS
- [ ] Invoke and verify traces appear in Last9 under configured service name
- [ ] Verify S3 calls produce child spans automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)