### PR TITLE
feat(python): trace-filtering example — exclude health-check and noisy spans

### DIFF
--- a/python/trace-filtering/.env.example
+++ b/python/trace-filtering/.env.example
@@ -1,0 +1,15 @@
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_SERVICE_NAME=my-python-service
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-aps1.last9.io
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=<your-last9-token>
+OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=https://otlp-aps1.last9.io/v1/metrics
+OTEL_RESOURCE_ATTRIBUTES=service.name=my-python-service,service.version=1.0.0,deployment.environment=production
+OTEL_LOG_LEVEL=error
+
+# Approach 1 (zero-code): exclude URLs via regex patterns — comma-separated
+# Uses re.search(), so "health-check" matches /health-check, /api/health-check, etc.
+OTEL_PYTHON_EXCLUDED_URLS=health-check,ping,ready,live,metrics
+
+# Keep always_on when using env-var exclusion (the exclusion happens in the instrumentation layer)
+OTEL_TRACES_SAMPLER=always_on
+OTEL_TRACES_EXPORTER=otlp

--- a/python/trace-filtering/.gitignore
+++ b/python/trace-filtering/.gitignore
@@ -1,0 +1,16 @@
+.env
+.env.local
+.env.*.local
+.venv/
+venv/
+__pycache__/
+*.pyc
+*.pyo
+.idea/
+.vscode/
+*.swp
+.DS_Store
+*.log
+dist/
+build/
+*.egg-info/

--- a/python/trace-filtering/README.md
+++ b/python/trace-filtering/README.md
@@ -1,0 +1,76 @@
+# Python OTel Trace Filtering
+
+Demonstrates two approaches to exclude noisy, non-actionable spans (e.g. health-check endpoints) from OpenTelemetry traces sent to Last9.
+
+## The Problem
+
+Health-check endpoints polled every 30s generate ~2,880+ spans/day — identical, low-value traces that flood your dashboard and make debugging harder.
+
+## Approach 1: `OTEL_PYTHON_EXCLUDED_URLS` (recommended)
+
+Zero code change. Set the env var before running `opentelemetry-instrument`:
+
+```bash
+export OTEL_PYTHON_EXCLUDED_URLS="health-check,ping,ready,live,metrics"
+```
+
+Patterns are comma-separated regexes matched via `re.search()` on the full URL. Partial matches apply — `health-check` excludes `/health-check`, `/api/health-check`, etc.
+
+Framework-specific variants take precedence if you need different exclusions per service:
+
+```bash
+export OTEL_PYTHON_FASTAPI_EXCLUDED_URLS="health-check,ping"
+export OTEL_PYTHON_FLASK_EXCLUDED_URLS="health,ready"
+```
+
+## Approach 2: Custom Sampler
+
+For cases that need more control (filter by status code, tenant, business logic). See `sampler.py` and `app_with_sampler.py`.
+
+The `ParentBased` wrapper in `sampler.py` is critical — it propagates the `DROP` decision to all child spans of a filtered root span.
+
+## Prerequisites
+
+- Python 3.8+
+- Last9 account with OTLP credentials
+
+## Quick Start
+
+```bash
+# Install dependencies
+uv venv && uv pip install -r requirements.txt
+
+# Copy and fill in credentials
+cp .env.example .env
+
+# Approach 1: env-var exclusion (zero code)
+source .env
+opentelemetry-instrument uvicorn app:app --host 0.0.0.0 --port 8000
+
+# Approach 2: custom sampler
+source .env
+python app_with_sampler.py
+```
+
+## Configuration
+
+| Variable | Description |
+|----------|-------------|
+| `OTEL_PYTHON_EXCLUDED_URLS` | Comma-separated regex patterns for URLs to exclude |
+| `OTEL_PYTHON_FASTAPI_EXCLUDED_URLS` | FastAPI-specific exclusions (overrides generic) |
+| `OTEL_SERVICE_NAME` | Service name in Last9 |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Last9 OTLP endpoint |
+| `OTEL_EXPORTER_OTLP_HEADERS` | `Authorization=<token>` |
+
+## Verification
+
+```bash
+# Generate health-check traffic (should NOT appear in Last9)
+for i in {1..10}; do curl -s http://localhost:8000/health-check; done
+
+# Generate real traffic (SHOULD appear in Last9)
+curl http://localhost:8000/api/orders
+curl http://localhost:8000/api/orders/ord-1
+```
+
+Check [Last9 Traces](https://app.last9.io) — only `/api/*` spans should appear.

--- a/python/trace-filtering/app.py
+++ b/python/trace-filtering/app.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI
+import uvicorn
+import time
+import random
+
+app = FastAPI(title="Trace Filtering Demo")
+
+
+# Health check — high-frequency, non-actionable. Excluded via OTEL_PYTHON_EXCLUDED_URLS.
+@app.get("/health-check")
+async def health_check():
+    return {"status": "ok"}
+
+
+@app.get("/")
+async def root():
+    return {"message": "Trace filtering demo running"}
+
+
+@app.get("/api/orders")
+async def list_orders():
+    time.sleep(random.uniform(0.01, 0.05))
+    return {"orders": [{"id": "ord-1", "amount": 42.0}, {"id": "ord-2", "amount": 99.0}]}
+
+
+@app.get("/api/orders/{order_id}")
+async def get_order(order_id: str):
+    time.sleep(random.uniform(0.005, 0.02))
+    return {"id": order_id, "amount": 42.0, "status": "shipped"}
+
+
+@app.post("/api/orders")
+async def create_order(item: dict):
+    time.sleep(random.uniform(0.02, 0.08))
+    return {"id": "ord-new", "status": "created"}
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/python/trace-filtering/app_with_sampler.py
+++ b/python/trace-filtering/app_with_sampler.py
@@ -1,0 +1,50 @@
+"""
+FastAPI app wired up with the custom sampler.
+Use this when you need more control than OTEL_PYTHON_EXCLUDED_URLS offers.
+"""
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+from sampler import sampler
+
+# Configure TracerProvider with the custom sampler before any instrumentation
+provider = TracerProvider(sampler=sampler)
+provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+trace.set_tracer_provider(provider)
+
+from fastapi import FastAPI
+import uvicorn
+import time
+import random
+
+app = FastAPI(title="Trace Filtering Demo (custom sampler)")
+FastAPIInstrumentor.instrument_app(app)
+
+
+@app.get("/health-check")
+async def health_check():
+    return {"status": "ok"}
+
+
+@app.get("/")
+async def root():
+    return {"message": "Trace filtering demo running"}
+
+
+@app.get("/api/orders")
+async def list_orders():
+    time.sleep(random.uniform(0.01, 0.05))
+    return {"orders": [{"id": "ord-1", "amount": 42.0}]}
+
+
+@app.get("/api/orders/{order_id}")
+async def get_order(order_id: str):
+    return {"id": order_id, "status": "shipped"}
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/python/trace-filtering/requirements.txt
+++ b/python/trace-filtering/requirements.txt
@@ -1,0 +1,8 @@
+fastapi==0.115.5
+uvicorn[standard]==0.32.1
+opentelemetry-api==1.29.0
+opentelemetry-sdk==1.29.0
+opentelemetry-exporter-otlp-proto-http==1.29.0
+opentelemetry-instrumentation-fastapi==0.50b0
+opentelemetry-instrumentation==0.50b0
+opentelemetry-distro==0.50b0

--- a/python/trace-filtering/sampler.py
+++ b/python/trace-filtering/sampler.py
@@ -1,0 +1,65 @@
+"""
+Custom sampler approach for span filtering.
+
+Use this when you need filtering logic beyond URL pattern matching:
+- filter by span attributes (status code, user type, tenant)
+- combine URL exclusion with ratio sampling
+- conditional sampling based on business logic
+
+For simple URL exclusion, prefer OTEL_PYTHON_EXCLUDED_URLS — no code needed.
+"""
+
+from opentelemetry.sdk.trace.sampling import (
+    Sampler,
+    SamplingResult,
+    Decision,
+    ALWAYS_ON,
+    ParentBased,
+)
+from opentelemetry.trace import SpanKind
+from opentelemetry.context import Context
+from opentelemetry.trace.span import TraceState
+from typing import Optional, Sequence
+
+EXCLUDED_URL_PATTERNS = {"/health-check", "/health", "/ping", "/ready", "/live", "/metrics"}
+
+
+class DropNoisySpansSampler(Sampler):
+    """
+    Drops spans for excluded URL paths and error-free 2xx responses.
+    Preserves all error spans regardless of URL.
+    """
+
+    def should_sample(
+        self,
+        parent_context: Optional[Context],
+        trace_id: int,
+        name: str,
+        kind: Optional[SpanKind] = None,
+        attributes=None,
+        links=None,
+        trace_state: Optional[TraceState] = None,
+    ) -> SamplingResult:
+        if attributes:
+            # OTel semconv v1: http.target  |  v2: url.path
+            path = attributes.get("http.target") or attributes.get("url.path") or ""
+            status = attributes.get("http.status_code") or attributes.get("http.response.status_code")
+
+            is_excluded_path = any(path.startswith(p) for p in EXCLUDED_URL_PATTERNS)
+
+            # Always keep error spans — they're actionable even on health endpoints
+            is_error = status is not None and int(status) >= 500
+            if is_excluded_path and not is_error:
+                return SamplingResult(Decision.DROP)
+
+        return ALWAYS_ON.should_sample(
+            parent_context, trace_id, name, kind, attributes, links, trace_state
+        )
+
+    def get_description(self) -> str:
+        return "DropNoisySpansSampler"
+
+
+# ParentBased wrapper: child spans inherit DROP from root span.
+# Without this, a dropped root still creates orphaned child spans.
+sampler = ParentBased(root=DropNoisySpansSampler())


### PR DESCRIPTION
## Summary

- Adds `python/trace-filtering/` example demonstrating two approaches to drop non-actionable spans from Python OTel traces
- **Approach 1**: `OTEL_PYTHON_EXCLUDED_URLS` env var — zero code, comma-separated regex patterns, works with `opentelemetry-instrument` CLI
- **Approach 2**: Custom `ParentBased` sampler — for attribute-based filtering (status code, tenant, business logic), preserves error spans on excluded paths

## Motivation

Health-check endpoints polled every 30s generate ~2,880 identical spans/day per service — flooding the Last9 dashboard and making real traces harder to find.

## Files

| File | Purpose |
|------|---------|
| `app.py` | FastAPI demo with health-check + real API endpoints |
| `sampler.py` | Custom `ParentBased` sampler with error-span preservation |
| `app_with_sampler.py` | FastAPI wired to custom sampler |
| `.env.example` | Shows both env var approaches |
| `README.md` | Setup, verification, decision guide |

## Test plan

- [ ] `OTEL_PYTHON_EXCLUDED_URLS=health-check` + `opentelemetry-instrument` → `/health-check` hits produce no spans in Last9
- [ ] `/api/orders` hits produce spans normally
- [ ] Custom sampler: 500 on `/health-check` → span appears; 200 on `/health-check` → dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)