### PR TITLE
feat(otel-collector): add trace timestamp normalization example

### DIFF
--- a/otel-collector/trace-timestamp-normalize/.gitignore
+++ b/otel-collector/trace-timestamp-normalize/.gitignore
@@ -1,0 +1,16 @@
+# Environment/secrets
+.env
+.env.local
+.env.*.local
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log

--- a/otel-collector/trace-timestamp-normalize/README.md
+++ b/otel-collector/trace-timestamp-normalize/README.md
@@ -1,0 +1,95 @@
+# Trace Timestamp Normalization
+
+Demonstrates an OpenTelemetry Collector pipeline that detects spans with bogus start/end timestamps (far past or far future) and rewrites them to the current ingestion time while preserving the span's duration. The original timestamps are stashed as attributes for forensics.
+
+This is useful when client SDKs intermittently emit spans with broken clocks (e.g., timestamps in year 2081), which would otherwise be rejected by downstream storage or land in the wrong time bucket.
+
+## How it works
+
+The `transform/old_traces` processor:
+
+1. Detects spans where `start_time` is more than 900 seconds away from `Now()` (past or future).
+2. Saves the original `start_time` and `end_time` as attributes (`l9.original_start_time`, `l9.original_end_time`).
+3. Rewrites `end_time = Now() + (end_time - start_time)` first to preserve the span's duration.
+4. Rewrites `start_time = Now()`.
+
+Spans within the 900s window pass through untouched.
+
+## Prerequisites
+
+- Docker + Docker Compose
+- `curl`, `openssl`
+
+## Quick Start
+
+1. Start the collector:
+
+   ```bash
+   docker compose up -d
+   ```
+
+2. In another terminal, tail the collector logs:
+
+   ```bash
+   docker compose logs -f otel-collector
+   ```
+
+3. Send a span with timestamps set to year 2081:
+
+   ```bash
+   ./send-bad-span.sh
+   ```
+
+4. In the logs, look for the span. The `Start time` and `End time` should be the current time (not year 2081), and the attributes should include:
+
+   ```
+   -> l9.original_start_time: Int(3502915200)
+   -> l9.original_end_time: Int(3502915201)
+   ```
+
+5. Stop the collector:
+
+   ```bash
+   docker compose down
+   ```
+
+## Configuration
+
+| File | Purpose |
+|------|---------|
+| `otel-collector-config.yaml` | Collector pipeline with `transform/old_traces` and a debug exporter |
+| `docker-compose.yaml` | Runs `otel/opentelemetry-collector-contrib:0.144.0` |
+| `send-bad-span.sh` | Sends a single OTLP/HTTP span with timestamps in year 2081 |
+
+### Tuning the threshold
+
+The 900-second window matches Last9's logs guard. To make it stricter, edit the condition in `otel-collector-config.yaml`:
+
+```yaml
+conditions:
+  - (UnixSeconds(Now()) - UnixSeconds(start_time) > 300 or UnixSeconds(start_time) - UnixSeconds(Now()) > 300)
+```
+
+### Dropping instead of normalizing
+
+If you would rather drop bad spans, replace the `transform/old_traces` processor with a `filter` processor:
+
+```yaml
+filter/bad_span_timestamps:
+  error_mode: ignore
+  traces:
+    span:
+      - UnixSeconds(start_time) - UnixSeconds(Now()) > 86400
+      - UnixSeconds(Now()) - UnixSeconds(start_time) > 86400
+```
+
+## Verification
+
+To confirm a normal-timestamp span is *not* modified, edit `send-bad-span.sh` and replace `START_NS` / `END_NS` with the current time in nanoseconds:
+
+```bash
+START_NS=$(($(date +%s) * 1000000000))
+END_NS=$(( START_NS + 1000000000 ))
+```
+
+The span should appear in the logs without `l9.original_*` attributes.

--- a/otel-collector/trace-timestamp-normalize/docker-compose.yaml
+++ b/otel-collector/trace-timestamp-normalize/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.144.0
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "4317:4317"   # OTLP gRPC
+      - "4318:4318"   # OTLP HTTP

--- a/otel-collector/trace-timestamp-normalize/otel-collector-config.yaml
+++ b/otel-collector/trace-timestamp-normalize/otel-collector-config.yaml
@@ -1,0 +1,41 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch/traces:
+    timeout: 1s
+
+  # Normalize spans with timestamps >900s off from now (past or future).
+  # Stores originals as attributes and rewrites start_time/end_time to Now()
+  # while preserving the span's duration.
+  transform/old_traces:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        conditions:
+          - (UnixSeconds(Now()) - UnixSeconds(start_time) > 900 or UnixSeconds(start_time) - UnixSeconds(Now()) > 900)
+        statements:
+          - set(attributes["l9.original_start_time"], UnixSeconds(start_time))
+          - set(attributes["l9.original_end_time"], UnixSeconds(end_time))
+          # preserve duration: shift end first, then start
+          - set(end_time, Now() + (end_time - start_time))
+          - set(start_time, Now())
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  telemetry:
+    logs:
+      level: info
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch/traces, transform/old_traces]
+      exporters: [debug]

--- a/otel-collector/trace-timestamp-normalize/send-bad-span.sh
+++ b/otel-collector/trace-timestamp-normalize/send-bad-span.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Sends a span with year 2081 start/end timestamps to the local collector.
+# Verifies that transform/old_traces normalizes the times to Now()
+# while preserving the 1-second span duration.
+set -euo pipefail
+
+ENDPOINT="${OTLP_ENDPOINT:-http://localhost:4318/v1/traces}"
+
+# 2081-01-01 00:00:00 UTC = 3502915200 unix seconds
+START_NS=3502915200000000000
+END_NS=3502915201000000000   # +1 second
+
+TRACE_ID=$(openssl rand -hex 16)
+SPAN_ID=$(openssl rand -hex 8)
+
+curl -sS -X POST "$ENDPOINT" \
+  -H 'Content-Type: application/json' \
+  -d @- <<EOF
+{
+  "resourceSpans": [{
+    "resource": {
+      "attributes": [
+        { "key": "service.name", "value": { "stringValue": "bad-timestamp-demo" } }
+      ]
+    },
+    "scopeSpans": [{
+      "scope": { "name": "demo" },
+      "spans": [{
+        "traceId": "$TRACE_ID",
+        "spanId": "$SPAN_ID",
+        "name": "future-span",
+        "kind": 1,
+        "startTimeUnixNano": "$START_NS",
+        "endTimeUnixNano": "$END_NS",
+        "attributes": [
+          { "key": "demo.note", "value": { "stringValue": "timestamp set to year 2081" } }
+        ]
+      }]
+    }]
+  }]
+}
+EOF
+
+echo
+echo "Sent span with start=$START_NS (year 2081)."
+echo "Check collector logs for normalized timestamps and l9.original_* attributes:"
+echo "  docker compose logs -f otel-collector"


### PR DESCRIPTION
## Summary
- Adds `otel-collector/trace-timestamp-normalize/` — runnable Docker Compose example demonstrating an OTTL `transform/old_traces` processor that normalizes spans with bogus start/end timestamps (>900s past or future) to the current ingestion time while preserving span duration. Originals are stashed as `l9.original_start_time` and `l9.original_end_time` attributes.
- Mirrors the existing `transform/old_logs` pattern used for log timestamps.
- Useful when client SDKs intermittently emit spans with broken clocks (e.g. timestamps in the year 2081) that would otherwise be rejected by downstream storage or bucketed into the wrong time window.

## Test plan
- [x] `otelcol-contrib:0.144.0 validate` passes (exit 0)
- [x] e2e: send a span with `startTimeUnixNano = 3502915200000000000` (year 2081) via `send-bad-span.sh`; debug exporter shows `start_time` rewritten to `Now()`, `end_time` to `Now() + 1s` (duration preserved), and `l9.original_start_time` / `l9.original_end_time` attributes stashed
- [ ] Reviewer can reproduce via `docker compose up -d && ./send-bad-span.sh && docker compose logs otel-collector`

🤖 Generated with [Claude Code](https://claude.com/claude-code)