### PR TITLE
docker-compose: add missing otel-config.yaml with gzip + container label transform

### DIFF
--- a/docker-compose/otel-compose.yaml
+++ b/docker-compose/otel-compose.yaml
@@ -18,8 +18,10 @@ services:
     user: "0" # root user to access docker stats
     environment:
       - LOGSPOUT=ignore
+      - LAST9_OTLP_ENDPOINT=${LAST9_OTLP_ENDPOINT}
+      - LAST9_OTLP_AUTH_HEADER=${LAST9_OTLP_AUTH_HEADER}
     networks:
-      - otel_network  
+      - otel_network
 
   logspout:
     image: "gliderlabs/logspout:v3.2.14"

--- a/docker-compose/otel-config.yaml
+++ b/docker-compose/otel-config.yaml
@@ -1,0 +1,101 @@
+receivers:
+  docker_stats:
+    collection_interval: 60s
+    timeout: 30s
+    metrics:
+      container.cpu.usage.total:
+        enabled: true
+      container.cpu.throttling_data.periods:
+        enabled: true
+      container.cpu.throttling_data.throttled_periods:
+        enabled: true
+      container.cpu.utilization:
+        enabled: true
+      container.memory.usage.limit:
+        enabled: true
+      container.memory.usage.total:
+        enabled: true
+      container.memory.percent:
+        enabled: true
+      container.blockio.io_service_bytes_recursive:
+        enabled: true
+      container.network.io.usage.rx_bytes:
+        enabled: true
+      container.network.io.usage.tx_bytes:
+        enabled: true
+      container.network.io.usage.rx_dropped:
+        enabled: true
+      container.network.io.usage.tx_dropped:
+        enabled: true
+      container.network.io.usage.rx_errors:
+        enabled: true
+      container.network.io.usage.tx_errors:
+        enabled: true
+      container.network.io.usage.rx_packets:
+        enabled: true
+      container.network.io.usage.tx_packets:
+        enabled: true
+      container.pids.count:
+        enabled: true
+
+  tcplog/docker:
+    listen_address: "0.0.0.0:2255"
+    operators:
+      - type: syslog_parser
+        protocol: rfc5424
+
+processors:
+  # Set service.name on log records to the container name (set by logspout as
+  # the syslog appname field) so logs are filterable by service in Last9.
+  transform/docker_logs:
+    error_mode: ignore
+    flatten_data: true
+    log_statements:
+      - context: log
+        statements:
+          - set(log.body, log.attributes["message"])
+          - delete_key(log.attributes, "message")
+          - set(resource.attributes["service.name"], log.attributes["appname"])
+
+  # Promote container resource attributes to datapoint attributes so they are
+  # guaranteed to land as filterable labels on metrics in Last9. The
+  # docker_stats receiver emits container.name / container.image.name as
+  # resource attributes; this transform copies them onto each datapoint.
+  transform/container_labels:
+    error_mode: ignore
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(datapoint.attributes["container.name"], resource.attributes["container.name"])
+          - set(datapoint.attributes["container.image.name"], resource.attributes["container.image.name"])
+          - set(datapoint.attributes["container.image.tag"], resource.attributes["container.image.tag"])
+          - set(datapoint.attributes["container.id"], resource.attributes["container.id"])
+
+  batch:
+    send_batch_size: 8192
+    send_batch_max_size: 10000
+    timeout: 20s
+
+  resourcedetection:
+    detectors: [env, system, docker]
+    timeout: 5s
+
+exporters:
+  debug:
+    verbosity: basic
+  otlp/last9:
+    endpoint: ${env:LAST9_OTLP_ENDPOINT}
+    compression: gzip
+    headers:
+      Authorization: ${env:LAST9_OTLP_AUTH_HEADER}
+
+service:
+  pipelines:
+    metrics:
+      receivers: [docker_stats]
+      processors: [resourcedetection, transform/container_labels, batch]
+      exporters: [otlp/last9]
+    logs:
+      receivers: [tcplog/docker]
+      processors: [resourcedetection, transform/docker_logs, batch]
+      exporters: [otlp/last9]


### PR DESCRIPTION
## Summary

The `docker-compose` example was missing its `otel-config.yaml` — `otel-compose.yaml` references it via a volume mount, but the file was never committed. Running the example as-is failed at startup with a config-not-found error.

This PR:

- Adds `docker-compose/otel-config.yaml` based on the same shape used in our integration docs.
- Adds `compression: gzip` on the `otlp/last9` exporter to avoid TCP resets on large batches.
- Adds a `transform/container_labels` processor that promotes container resource attributes (`container.name`, `container.image.name`, `container.image.tag`, `container.id`) onto each metric datapoint so they appear as filterable labels in Last9.
- Uses the explicit `log.body` / `log.attributes[...]` / `datapoint.attributes[...]` OTTL forms to silence context-prefix migration warnings on collector v0.144+.
- Threads `LAST9_OTLP_ENDPOINT` and `LAST9_OTLP_AUTH_HEADER` env vars through `otel-compose.yaml` so the config can reference them via `${env:VAR}`.

## Verification

Ran end-to-end against `otlp-aps1.last9.io:443` with `otel/opentelemetry-collector-contrib:0.144.0`:

| Check | Result |
|---|---|
| Gzip OTLP export | ✅ Zero exporter errors over 5+ min |
| `container_name` label on metrics | ✅ `container_cpu_utilization_ratio{container_name="..."}` returns data |
| `container_image_name` label | ✅ Present |
| `container_id` label | ✅ Present |
| Logs flow | ✅ `service_name` set from logspout appname |
| OTTL warnings | ✅ None after syntax update |

## Test plan

```bash
export LAST9_OTLP_ENDPOINT=otlp-aps1.last9.io:443
export LAST9_OTLP_AUTH_HEADER="Basic <token>"

docker compose -f docker-compose/apache-compose.yaml up -d
docker compose -f docker-compose/nginx-compose.yaml up -d
docker compose -f docker-compose/otel-compose.yaml up -d

docker logs otel-collector -f          # should see Logs / Metrics export lines, no errors
```

Then in Last9 Metrics UI, query: `container_cpu_utilization_ratio{container_name="apache-server"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)