### PR TITLE
docker-compose: add hostmetrics + Prometheus scrape example

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -83,6 +83,33 @@ The OpenTelemetry Collector is configured to collect various metrics:
 - Block I/O information
 - Container process information
 
+### Active Prometheus scrape (per-app metrics)
+
+`otel-config.yaml` also includes a `prometheus/sample-apps` receiver that
+scrapes the `nginx-prometheus-exporter` sidecar in the `nginx-compose.yaml`
+stack at `nginx-exporter:9113`. This produces metrics like
+`nginx_http_requests_total`, `nginx_connections_active`, etc. in Last9 with
+a `service="nginx"` label.
+
+The collector container is attached to `nginx_network` (and `apache_network`)
+in `otel-compose.yaml` so it can resolve the exporter's hostname over the
+shared Docker network.
+
+To add scraping for your own app:
+
+1. Expose Prometheus metrics from your container (typically on its own
+   port, e.g. `livekit-server:6789/metrics`).
+2. Add the app's network as `external: true` under `networks:` in
+   `otel-compose.yaml`, and list it under the `otel-collector` service.
+3. Add a `scrape_configs` entry under `prometheus/sample-apps` pointing at
+   `<container_name>:<port>`, with a `service` label.
+4. `docker compose -f otel-compose.yaml up -d` to restart the collector.
+
+Unlike `docker_stats` and `logspout` (which read the Docker socket and need
+no network sharing), active-scrape receivers (`prometheus`, `redis`,
+`postgresql`, `httpcheck`, ...) **must** share a Docker network with the
+container they scrape.
+
 ### Log Collection
 
 Container logs are collected using Logspout and sent to OpenTelemetry Collector for processing before being exported to Last9.

--- a/docker-compose/nginx-compose.yaml
+++ b/docker-compose/nginx-compose.yaml
@@ -9,8 +9,24 @@ services:
       - "collect-logs=true"
     volumes:
       - nginx_logs:/var/log/nginx
+      - ./nginx-default.conf:/etc/nginx/conf.d/default.conf:ro
     networks:
       - nginx_network
+
+  # Sidecar exporter that converts nginx's stub_status endpoint into Prometheus
+  # format on :9113. Shares nginx's network namespace so it can scrape
+  # http://localhost/stub_status (which the nginx config restricts to loopback).
+  # The OTel collector scrapes this on nginx-server:9113 via the shared
+  # nginx_network (see otel-compose.yaml + otel-config.yaml).
+  nginx-exporter:
+    image: nginx/nginx-prometheus-exporter:1.4
+    container_name: nginx-exporter
+    command:
+      - "--nginx.scrape-uri=http://localhost/stub_status"
+    network_mode: "service:nginx"
+    depends_on:
+      - nginx
+    restart: unless-stopped
 
 networks:
   nginx_network:

--- a/docker-compose/nginx-default.conf
+++ b/docker-compose/nginx-default.conf
@@ -1,0 +1,17 @@
+server {
+  listen 80;
+
+  location / {
+    root  /usr/share/nginx/html;
+    index index.html;
+  }
+
+  # Exposed to localhost only so the nginx-prometheus-exporter sidecar can
+  # scrape it; not reachable from outside the container.
+  location /stub_status {
+    stub_status;
+    allow 127.0.0.1;
+    allow ::1;
+    deny  all;
+  }
+}

--- a/docker-compose/otel-compose.yaml
+++ b/docker-compose/otel-compose.yaml
@@ -8,18 +8,29 @@ services:
         "--feature-gates=transform.flatten.logs"
       ]
     volumes:
-      - ./otel-config.yaml:/etc/otel-collector-config.yaml
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ./otel-config.yaml:/etc/otel-collector-config.yaml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
       - nginx_logs:/var/log/nginx
+      # Host filesystem mounts so the hostmetrics receiver can read the VM's
+      # CPU / memory / disk / network / process stats rather than the
+      # collector container's own (containerized) view.
+      - /proc:/hostfs/proc:ro
+      - /sys:/hostfs/sys:ro
+      - /etc/os-release:/hostfs/etc/os-release:ro
+      - /:/hostfs/root:ro,rslave
     ports:
       - "4317:4317" # OTLP gRPC receiver
       - "4318:4318" # OTLP HTTP receiver
     restart: on-failure
-    user: "0" # root user to access docker stats
+    user: "0" # root user to access docker stats + /proc
+    pid: host # required so the process scraper can see host PIDs
     environment:
       - LOGSPOUT=ignore
       - LAST9_OTLP_ENDPOINT=${LAST9_OTLP_ENDPOINT}
       - LAST9_OTLP_AUTH_HEADER=${LAST9_OTLP_AUTH_HEADER}
+      - HOST_PROC=/hostfs/proc
+      - HOST_SYS=/hostfs/sys
+      - HOST_ETC=/hostfs/etc
     networks:
       - otel_network
 

--- a/docker-compose/otel-compose.yaml
+++ b/docker-compose/otel-compose.yaml
@@ -33,6 +33,13 @@ services:
       - HOST_ETC=/hostfs/etc
     networks:
       - otel_network
+      # Attach to each sample app's network so the prometheus receiver can
+      # actively scrape sidecar exporters running inside those containers.
+      # Required only for active-scrape receivers (prometheus, redis,
+      # postgresql, httpcheck, ...) — docker_stats + logspout do not need
+      # this because they read via the Docker socket.
+      - nginx_network
+      - apache_network
 
   logspout:
     image: "gliderlabs/logspout:v3.2.14"

--- a/docker-compose/otel-config.yaml
+++ b/docker-compose/otel-config.yaml
@@ -44,6 +44,25 @@ receivers:
       - type: syslog_parser
         protocol: rfc5424
 
+  # Active-scrape example: pull Prometheus metrics from sidecars / agents
+  # running inside other containers. The collector container must share a
+  # Docker network with each scrape target (see otel-compose.yaml — it
+  # attaches to nginx_network for this reason). Add one job_name per app.
+  # Replace targets with `<container_name>:<port>` for your services.
+  prometheus/sample-apps:
+    config:
+      scrape_configs:
+        - job_name: nginx
+          scrape_interval: 30s
+          static_configs:
+            # nginx-prometheus-exporter shares the nginx-server network
+            # namespace (see nginx-compose.yaml), so it is reachable on
+            # nginx-server:9113 — there is no separate nginx-exporter DNS.
+            - targets:
+                - nginx-server:9113
+              labels:
+                service: nginx
+
   # Host (VM / bare-metal) metrics. When the collector runs inside a docker
   # container, root_path: /hostfs and the HOST_PROC / HOST_SYS / HOST_ETC env
   # vars (set in otel-compose.yaml) point each scraper at the host filesystem
@@ -171,7 +190,7 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers: [docker_stats, hostmetrics]
+      receivers: [docker_stats, hostmetrics, prometheus/sample-apps]
       processors:
         - resourcedetection/system
         - resourcedetection/cloud

--- a/docker-compose/otel-config.yaml
+++ b/docker-compose/otel-config.yaml
@@ -44,6 +44,55 @@ receivers:
       - type: syslog_parser
         protocol: rfc5424
 
+  # Host (VM / bare-metal) metrics. When the collector runs inside a docker
+  # container, root_path: /hostfs and the HOST_PROC / HOST_SYS / HOST_ETC env
+  # vars (set in otel-compose.yaml) point each scraper at the host filesystem
+  # rather than the collector container's own /proc.
+  hostmetrics:
+    collection_interval: 60s
+    root_path: /hostfs
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.logical.count:
+            enabled: true
+          system.cpu.utilization:
+            enabled: true
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+          system.memory.limit:
+            enabled: true
+      load:
+      disk:
+      filesystem:
+        metrics:
+          system.filesystem.utilization:
+            enabled: true
+        exclude_mount_points:
+          mount_points:
+            - /hostfs/sys/*
+            - /hostfs/proc/*
+            - /var/lib/docker/*
+            - /hostfs/root/var/lib/docker/*
+          match_type: regexp
+      network:
+      paging:
+      processes:
+      # mute_process_*_error: true silences the routine "permission denied"
+      # noise for kernel threads and short-lived processes whose
+      # /proc/<pid>/{exe,io,cmdline} entries can't be read.
+      process:
+        mute_process_user_error: true
+        mute_process_io_error: true
+        mute_process_exe_error: true
+        metrics:
+          process.cpu.utilization:
+            enabled: true
+          process.memory.utilization:
+            enabled: true
+
 processors:
   # Set service.name on log records to the container name (set by logspout as
   # the syslog appname field) so logs are filterable by service in Last9.
@@ -71,13 +120,43 @@ processors:
           - set(datapoint.attributes["container.image.tag"], resource.attributes["container.image.tag"])
           - set(datapoint.attributes["container.id"], resource.attributes["container.id"])
 
+  # Promote host + cloud resource attributes onto each host metric datapoint
+  # so they are filterable as labels in Last9. The resourcedetection
+  # processor sets these as resource attributes; without this transform they
+  # would not appear as labels on the metric series.
+  transform/hostmetrics:
+    error_mode: ignore
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(datapoint.attributes["host.name"], resource.attributes["host.name"])
+          - set(datapoint.attributes["host.type"], resource.attributes["host.type"])
+          - set(datapoint.attributes["host.image.id"], resource.attributes["host.image.id"])
+          - set(datapoint.attributes["cloud.provider"], resource.attributes["cloud.provider"])
+          - set(datapoint.attributes["cloud.platform"], resource.attributes["cloud.platform"])
+          - set(datapoint.attributes["cloud.region"], resource.attributes["cloud.region"])
+          - set(datapoint.attributes["cloud.account.id"], resource.attributes["cloud.account.id"])
+          - set(datapoint.attributes["cloud.availability_zone"], resource.attributes["cloud.availability_zone"])
+
   batch:
     send_batch_size: 8192
     send_batch_max_size: 10000
     timeout: 20s
 
-  resourcedetection:
+  resourcedetection/system:
     detectors: [env, system, docker]
+    system:
+      hostname_sources: ["os"]
+    timeout: 5s
+
+  # Cloud-specific VM detectors. Each detector is a no-op on hosts that
+  # aren't on the matching cloud, so it is safe to list all three — only the
+  # one that matches the runtime environment will populate cloud.* labels.
+  # ECS / EKS / AKS detectors are deliberately omitted because they require
+  # runtime context (Kubernetes service env vars / ECS task metadata) that
+  # is not present in a plain docker-on-VM setup.
+  resourcedetection/cloud:
+    detectors: [ec2, gcp, azure]
     timeout: 5s
 
 exporters:
@@ -92,10 +171,19 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers: [docker_stats]
-      processors: [resourcedetection, transform/container_labels, batch]
+      receivers: [docker_stats, hostmetrics]
+      processors:
+        - resourcedetection/system
+        - resourcedetection/cloud
+        - transform/container_labels
+        - transform/hostmetrics
+        - batch
       exporters: [otlp/last9]
     logs:
       receivers: [tcplog/docker]
-      processors: [resourcedetection, transform/docker_logs, batch]
+      processors:
+        - resourcedetection/system
+        - resourcedetection/cloud
+        - transform/docker_logs
+        - batch
       exporters: [otlp/last9]


### PR DESCRIPTION
Follow-up to #190 (merged). Bundles two related improvements to the
`docker-compose/` example so a single customer-facing reference covers both:
host-level VM metrics and active Prometheus scrape of an in-container endpoint.

## Commit 1 — hostmetrics + cloud detection, silence process errors

- **Compose** (`otel-compose.yaml`): mount host `/proc`, `/sys`, `/etc/os-release` into the collector, plus a read-only `rslave` bind of `/` at `/hostfs/root`. Add `pid: host` so the process scraper sees host PIDs. Set `HOST_PROC` / `HOST_SYS` / `HOST_ETC` env vars.
- **Config** (`otel-config.yaml`):
  - Add `hostmetrics` receiver with `root_path: /hostfs` and the full scraper set (cpu, memory, load, disk, filesystem, network, paging, processes, process).
  - `process` scraper enables `mute_process_user_error` / `io_error` / `exe_error` to silence kernel-thread + short-lived-process noise.
  - `filesystem` excludes `/hostfs/sys/*`, `/hostfs/proc/*`, `/var/lib/docker/*`.
  - Split `resourcedetection` into `/system` (`env + system + docker`, `hostname_sources: ["os"]`) and `/cloud` (`ec2 + gcp + azure`). `ecs / eks / aks` omitted (need Kubernetes / ECS runtime context).
  - Add `transform/hostmetrics` processor that promotes `host.name`, `host.type`, `host.image.id`, and `cloud.*` from resource → datapoint.

**Verified:** `system_cpu_utilization_ratio{host_name="..."}` and `system_memory_utilization_ratio{state="used"}` land in Last9; on EC2 hosts the `cloud_provider` / `cloud_region` / `host_type` / `cloud_account_id` labels populate automatically.

## Commit 2 — active Prometheus scrape via nginx-prometheus-exporter

Adds a worked example of scraping a Prometheus endpoint that lives *inside* another container — the case where the OTel collector has to share a Docker network with the target (unlike `docker_stats` / logspout, which read the host's Docker socket and need no network sharing).

- **`nginx-compose.yaml`**: mount a `default.conf` exposing `/stub_status` to loopback only; add an `nginx-prometheus-exporter` sidecar that runs in nginx's network namespace (`network_mode: "service:nginx"`) so it can scrape `http://localhost/stub_status`. The exporter listens on `nginx-server:9113`.
- **`nginx-default.conf`** (new): minimal nginx server block with `stub_status` restricted to `127.0.0.1`.
- **`otel-compose.yaml`**: attach the otel-collector to `nginx_network` (and `apache_network`) so it can reach `nginx-server:9113`. Comment notes this is **only** needed for active-scrape receivers (`prometheus`, `redis`, `postgresql`, `httpcheck`, …), not for socket-based receivers.
- **`otel-config.yaml`**: new `prometheus/sample-apps` receiver with a single `nginx` job pointing at `nginx-server:9113`, labelled `service: nginx`. Wired into the existing metrics pipeline alongside `docker_stats` and `hostmetrics`.
- **`README.md`**: new "Active Prometheus scrape (per-app metrics)" section with a 4-step recipe for adding a customer's own service, plus an explicit note that active-scrape receivers must share a Docker network with the target while socket-based receivers do not.

**Verified end-to-end against `otlp-aps1.last9.io`:**

| Metric | Value | Labels |
|---|---|---|
| `nginx_up` | 1 | `service=nginx, instance=nginx-server:9113, job=nginx` |
| `nginx_http_requests_total` | 37 | same |
| `nginx_connections_active` | 1 | same |

## Test plan

```bash
export LAST9_OTLP_ENDPOINT=otlp-aps1.last9.io:443
export LAST9_OTLP_AUTH_HEADER="Basic <token>"

docker compose -f docker-compose/apache-compose.yaml up -d
docker compose -f docker-compose/nginx-compose.yaml up -d   # now starts nginx + nginx-exporter sidecar
docker compose -f docker-compose/otel-compose.yaml up -d

# Generate traffic
for i in {1..10}; do curl -s http://localhost:8000/ >/dev/null; done

# After ~30s, query Last9:
#   system_cpu_utilization_ratio{host_name="..."}
#   nginx_up{service="nginx"}
#   nginx_http_requests_total{service="nginx"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)