### PR TITLE
java-vertx3-rxjava: bump otel autoconfigure to 2.3.5-beta.8, buffer request bodies

### DIFF
--- a/java-vertx3-rxjava/auto-instrumentation/Dockerfile
+++ b/java-vertx3-rxjava/auto-instrumentation/Dockerfile
@@ -9,14 +9,14 @@ RUN mvn install:install-file \
     -Dfile=/tmp/lib/vertx-otel-core.jar \
     -DgroupId=io.last9 \
     -DartifactId=vertx-otel-core \
-    -Dversion=2.1.0-beta.1 \
+    -Dversion=2.3.5-beta.8 \
     -Dpackaging=jar \
     -DgeneratePom=true && \
     mvn install:install-file \
     -Dfile=/tmp/lib/vertx3-rxjava2-otel-autoconfigure.jar \
     -DgroupId=io.last9 \
     -DartifactId=vertx3-rxjava2-otel-autoconfigure \
-    -Dversion=2.1.0-beta.1 \
+    -Dversion=2.3.5-beta.8 \
     -Dpackaging=jar \
     -DgeneratePom=true
 

--- a/java-vertx3-rxjava/auto-instrumentation/docker-compose.local.yaml
+++ b/java-vertx3-rxjava/auto-instrumentation/docker-compose.local.yaml
@@ -1,0 +1,4 @@
+services:
+  otel-collector:
+    volumes:
+      - ./otel-collector-config-local.yaml:/etc/otel-collector-config.yaml:ro

--- a/java-vertx3-rxjava/auto-instrumentation/otel-collector-config-local.yaml
+++ b/java-vertx3-rxjava/auto-instrumentation/otel-collector-config-local.yaml
@@ -1,0 +1,39 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 100
+
+  resource:
+    attributes:
+      - key: deployment.environment
+        value: ${env:DEPLOYMENT_ENV}
+        action: upsert
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch, resource]
+      exporters: [debug]
+
+    logs:
+      receivers: [otlp]
+      processors: [batch, resource]
+      exporters: [debug]
+
+    metrics:
+      receivers: [otlp]
+      processors: [batch, resource]
+      exporters: [debug]

--- a/java-vertx3-rxjava/auto-instrumentation/pom.xml
+++ b/java-vertx3-rxjava/auto-instrumentation/pom.xml
@@ -29,7 +29,7 @@
         <slf4j.version>1.7.36</slf4j.version>
 
         <!-- Auto-instrumentation JAR -->
-        <vertx3.otel.autoconfigure.version>2.1.0-beta.1</vertx3.otel.autoconfigure.version>
+        <vertx3.otel.autoconfigure.version>2.3.5-beta.8</vertx3.otel.autoconfigure.version>
 
         <!-- Main verticle -->
         <main.verticle>com.example.holding.MainVerticle</main.verticle>

--- a/java-vertx3-rxjava/auto-instrumentation/src/main/java/com/example/holding/MainVerticle.java
+++ b/java-vertx3-rxjava/auto-instrumentation/src/main/java/com/example/holding/MainVerticle.java
@@ -21,6 +21,7 @@ import io.vertx.reactivex.ext.jdbc.JDBCClient;
 import io.vertx.reactivex.ext.sql.SQLClient;
 import io.vertx.reactivex.ext.web.Router;
 import io.vertx.reactivex.ext.web.RoutingContext;
+import io.vertx.reactivex.ext.web.handler.BodyHandler;
 import io.vertx.reactivex.ext.web.client.WebClient;
 import io.vertx.reactivex.kafka.client.producer.KafkaProducer;
 import io.vertx.reactivex.kafka.client.producer.KafkaProducerRecord;
@@ -163,6 +164,9 @@ public class MainVerticle extends AbstractVerticle {
 
         // Plain Router — auto-instrumented by RouterImplAdvice
         Router router = Router.router(vertx);
+
+        // Buffer request bodies for POST/PUT routes
+        router.route().handler(BodyHandler.create());
 
         // Health check endpoint
         router.get("/health").handler(this::handleHealth);


### PR DESCRIPTION
Updates the `java-vertx3-rxjava/auto-instrumentation` example.

## Changes
- **Bump** `vertx3-rxjava2-otel-autoconfigure` `2.1.0-beta.1` → `2.3.5-beta.8` (Dockerfile `install:install-file` versions + the `pom.xml` version property).
- **Buffer request bodies** — add `router.route().handler(BodyHandler.create())` in `MainVerticle` so POST/PUT routes can read their bodies.
- **Local run config** — add `docker-compose.local.yaml` + `otel-collector-config-local.yaml` to run the example against a local OTel Collector (OTLP in → debug exporter out).

## Notes
- No secrets or customer references; the collector config uses a `${env:DEPLOYMENT_ENV}` placeholder and the debug exporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)